### PR TITLE
DOCS: Remove multi-region support docs

### DIFF
--- a/content/en/aws/multi-region-support/index.md
+++ b/content/en/aws/multi-region-support/index.md
@@ -1,9 +1,0 @@
----
-title: "Multi-Region Support"
-linkTitle: "Multi-Region Support"
-categories: ["LocalStack Pro", "Stub"]
-description: >
-  Multi-Region Support
----
-
-While the open source version of LocalStack can only be configured to use a single region (e.g., `us-east-1`), the Pro version contains several extensions that allow resources to be addressed across regions, using their unique ARN identifiers.


### PR DESCRIPTION
## Description

This PR removes the multi-region support docs, which is supported across LocalStack now (Community & Pro both). This PR is with respect to https://github.com/localstack/localstack/issues/5147