### PR TITLE
Add example for Firehose integration with ES, S3 and Kinesis

### DIFF
--- a/content/en/aws/elasticsearch/index.md
+++ b/content/en/aws/elasticsearch/index.md
@@ -148,7 +148,7 @@ This can be used to overwrite the behavior of the endpoint strategies described 
 You can also choose custom domains, however it is important to add the edge port (`80`/`443` or by default `4566`).
 
 {{< command >}}
-awslocal es create-elasticsearch-domain --domain-name my-domain \
+$ awslocal es create-elasticsearch-domain --domain-name my-domain \
     --elasticsearch-version 7.10 \
     --domain-endpoint-options '{ "CustomEndpoint": "http://localhost:4566/my-custom-endpoint", "CustomEndpointEnabled": true }'
 {{< / command >}}
@@ -156,7 +156,7 @@ awslocal es create-elasticsearch-domain --domain-name my-domain \
 Once the domain processing is complete, you can access the cluster:
 
 {{< command >}}
-curl http://localhost:4566/my-custom-endpoint/_cluster/health
+$ curl http://localhost:4566/my-custom-endpoint/_cluster/health
 {{< / command >}}
 
 

--- a/content/en/aws/kinesis-firehose/index.md
+++ b/content/en/aws/kinesis-firehose/index.md
@@ -7,46 +7,140 @@ description: >
 ---
 
 Kinesis Data Firehose is a service to extract, transform and load (ETL service) data to multiple destinations.
-LocalStack supports Firehose with Kinesis as source, and S3, ElasticSearch or HttpEndpoints as targets.
+LocalStack supports Firehose with Kinesis as source, and S3, Elasticsearch or HttpEndpoints as targets.
 
 ## Examples
 
 Firehose is a quite powerful service.
 We will provide some examples to illustrate the possibilities of Firehose in LocalStack.
 
-### Using Firehose to load Kinesis data into ElasticSearch with S3 Backup
+### Using Firehose to load Kinesis data into Elasticsearch with S3 Backup
 
-As example, we want to deliver data sent to a Kinesis stream into ElasticSearch via Firehose, while making a full backup into a S3 bucket.
+As example, we want to deliver data sent to a Kinesis stream into Elasticsearch via Firehose, while making a full backup into a S3 bucket.
 We will assume LocalStack is already [started correctly]({{< ref "get-started" >}}) and we have `awslocal` [installed]({{< ref "aws-cli" >}}).
 
-First we will create our source kinesis stream:
+First we will create our Elasticsearch domain:
 
 {{< command >}}
-$ awslocal kinesis create-stream ...
-{{< / command >}}
-
-And our target S3 bucket and ElasticSearch domain:
-
-{{< command >}}
-$ awslocal s3 mb ...
-{{< / command >}}
-
-
-{{< command >}}
-$ awslocal es create-domain ...
+$ awslocal es create-elasticsearch-domain --domain-name es_local
+{
+  "DomainStatus": {
+    "DomainId": "000000000000/es_local",
+    "DomainName": "es_local",
+    "ARN": "arn:aws:es:us-east-1:000000000000:domain/es_local",
+    "Created": true,
+    "Deleted": false,
+    "Endpoint": "es_local.us-east-1.es.localhost.localstack.cloud:443",
+    "Processing": true,
+    "ElasticsearchVersion": "7.10.0",
+    "ElasticsearchClusterConfig": {
+      "InstanceType": "m3.medium.elasticsearch",
+      "InstanceCount": 1,
+      "DedicatedMasterEnabled": true,
+      "ZoneAwarenessEnabled": false,
+      "DedicatedMasterType": "m3.medium.elasticsearch",
+      "DedicatedMasterCount": 1
+    },
+    "EBSOptions": {
+      "EBSEnabled": true,
+      "VolumeType": "gp2",
+      "VolumeSize": 10,
+      "Iops": 0
+    },
+    "CognitoOptions": {
+      "Enabled": false
+    }
+  }
+}
 {{< / command >}}
 
 We need the Endpoint returned here later for the confirmation of our setup.
 
-Next, we will create our firehose delivery stream with ElasticSearch as destination, and S3 as target for our AllDocuments backup.
-We set the ARN of our kinesis stream in the kinesis-stream-source-configuration as well as the role we want to use for accessing the stream.
+Now let us create our target S3 bucket and our source kinesis stream:
+
+{{< command >}}
+$ awslocal s3 mb s3://kinesis-activity-backup-local
+make_bucket: kinesis-activity-backup-local
+{{< / command >}}
+
+{{< command >}}
+$ awslocal kinesis create-stream --stream-name kinesis_es_local_stream --shard-count 2
+{{< / command >}}
+
+
+Next, we will create our firehose delivery stream with Elasticsearch as destination, and S3 as target for our AllDocuments backup.
+We set the ARN of our kinesis stream in the `kinesis-stream-source-configuration` as well as the role we want to use for accessing the stream.
+In the `elasticsearch-destination-configuration` we set (again) the access role, the DomainARN of the Elasticsearch domain we want to publish to, as well as IndexName and TypeName for Elasticsearch.
+Since we want to backup all documents to S3, we also set `S3BackupMode` to `AllDocuments` and provide a `S3Configuration` pointing to our created bucket.
 
 {{< alert >}}
 **Note:** In LocalStack, per default, the IAM roles will not be verified, so you can provide any ARN here. In AWS, you need to check the access rights of the specified role for the task.
 {{< /alert >}}
 
+{{< command >}}
+$ awslocal firehose create-delivery-stream --delivery-stream-name activity-to-elasticsearch-local --delivery-stream-type KinesisStreamAsSource --kinesis-stream-source-configuration "KinesisStreamARN=arn:aws:kinesis:us-east-1:000000000000:stream/kinesis_es_local_stream,RoleARN=arn:aws:iam::000000000000:role/Firehose-Reader-Role" --elasticsearch-destination-configuration "RoleARN=arn:aws:iam::000000000000:role/Firehose-Reader-Role,DomainARN=arn:aws:es:us-east-1:000000000000:domain/es_local,IndexName=activity,TypeName=activity,S3BackupMode=AllDocuments,S3Configuration={RoleARN=arn:aws:iam::000000000000:role/Firehose-Reader-Role,BucketARN=arn:aws:s3:::kinesis-activity-backup-local}"
+{
+    "DeliveryStreamARN": "arn:aws:firehose:us-east-1:000000000000:deliverystream/activity-to-elasticsearch-local"
+}
+{{< / command >}}
+
+Before testing the integration, we should check whether the Elasticsearch cluster is already started up.
+We can do this using the following command (for more information about this, check out the [docs page about Elasticsearch]({{< ref "elasticsearch" >}}).
 
 
 {{< command >}}
-$ awslocal firehose create-delivery-stream...
+$ awslocal es describe-elasticsearch-domain --domain-name es_local | jq ".DomainStatus.Processing"
+false
 {{< / command >}}
+
+Once this command returns `false`, we are ready to proceed with inputing our data.
+We can input our data into our source kinesis stream, our put it directly into the firehose delivery stream.
+
+To put it into kinesis, run:
+
+{{< command >}}
+$ awslocal kinesis put-record --stream-name kinesis_es_local_stream --data '{ "target": "barry" }' --partition-key partition --cli-binary-format raw-in-base64-out
+{
+    "ShardId": "shardId-000000000001",
+    "SequenceNumber": "49625461294598302663271645332877318906244481566013128722",
+    "EncryptionType": "NONE"
+}
+{{< / command >}}
+
+Or directly into the firehose delivery stream:
+
+{{< command >}}
+$ awslocal firehose put-record --delivery-stream-name activity-to-elasticsearch-local --record '{ "Data": "eyJ0YXJnZXQiOiAiSGVsbG8gd29ybGQifQ==" }' 
+{
+    "RecordId": "00333086-7581-48a2-bc7c-8ac1ed97ed3d"
+}
+{{< / command >}}
+
+If we now check the entries for our index in Elasticsearch (we will use curl for simplicity). Note to replace the url with the "Endpoint" field of our `create-elasticsearch-domain` operation at the beginning.
+
+{{< command >}}
+$ curl -s http://es_local.us-east-1.es.localhost.localstack.cloud:443/activity/_search | jq '.hits.hits'
+[
+  {
+    "_index": "activity",
+    "_type": "activity",
+    "_id": "f38e2c49-d101-46aa-9ce2-0d2ea8fcd133",
+    "_score": 1,
+    "_source": {
+      "target": "Hello world"
+    }
+  },
+  {
+    "_index": "activity",
+    "_type": "activity",
+    "_id": "d2f1c125-b3b0-4c7c-ba90-8acf4075a682",
+    "_score": 1,
+    "_source": {
+      "target": "barry"
+    }
+  }
+]
+{{< / command >}}
+
+If you get a similar output, you have correctly setup a firehose delivery stream!
+Also checkout the specified S3 bucket to check if your backup is working correctly.

--- a/content/en/aws/kinesis-firehose/index.md
+++ b/content/en/aws/kinesis-firehose/index.md
@@ -1,0 +1,19 @@
+---
+title: "Kinesis Data Firehose"
+linkTitle: "Kinesis Data Firehose"
+categories: ["LocalStack Community"]
+description: >
+  Kinesis Data Firehose
+---
+
+Kinesis Data Firehose is a service to extract, transform and load (ETL service) data to multiple destinations.
+LocalStack supports Firehose with Kinesis as source, and S3, ElasticSearch or HttpEndpoints as targets.
+
+## Examples
+
+Firehose is a quite powerful service.
+We will provide some examples to illustrate the possibilities of Firehose in LocalStack.
+
+### Using Firehose to load Kinesis data into ElasticSearch with S3 Backup
+
+As example, we want to deliver data sent to a Kinesis stream into ElasticSearch via Firehose, while making a full backup into a S3 bucket.

--- a/content/en/aws/kinesis-firehose/index.md
+++ b/content/en/aws/kinesis-firehose/index.md
@@ -17,3 +17,36 @@ We will provide some examples to illustrate the possibilities of Firehose in Loc
 ### Using Firehose to load Kinesis data into ElasticSearch with S3 Backup
 
 As example, we want to deliver data sent to a Kinesis stream into ElasticSearch via Firehose, while making a full backup into a S3 bucket.
+We will assume LocalStack is already [started correctly]({{< ref "get-started" >}}) and we have `awslocal` [installed]({{< ref "aws-cli" >}}).
+
+First we will create our source kinesis stream:
+
+{{< command >}}
+$ awslocal kinesis create-stream ...
+{{< / command >}}
+
+And our target S3 bucket and ElasticSearch domain:
+
+{{< command >}}
+$ awslocal s3 mb ...
+{{< / command >}}
+
+
+{{< command >}}
+$ awslocal es create-domain ...
+{{< / command >}}
+
+We need the Endpoint returned here later for the confirmation of our setup.
+
+Next, we will create our firehose delivery stream with ElasticSearch as destination, and S3 as target for our AllDocuments backup.
+We set the ARN of our kinesis stream in the kinesis-stream-source-configuration as well as the role we want to use for accessing the stream.
+
+{{< alert >}}
+**Note:** In LocalStack, per default, the IAM roles will not be verified, so you can provide any ARN here. In AWS, you need to check the access rights of the specified role for the task.
+{{< /alert >}}
+
+
+
+{{< command >}}
+$ awslocal firehose create-delivery-stream...
+{{< / command >}}

--- a/content/en/aws/kinesis-firehose/index.md
+++ b/content/en/aws/kinesis-firehose/index.md
@@ -11,7 +11,6 @@ LocalStack supports Firehose with Kinesis as source, and S3, Elasticsearch or Ht
 
 ## Examples
 
-Firehose is a quite powerful service.
 We will provide some examples to illustrate the possibilities of Firehose in LocalStack.
 
 ### Using Firehose to load Kinesis data into Elasticsearch with S3 Backup
@@ -116,7 +115,7 @@ $ awslocal firehose put-record --delivery-stream-name activity-to-elasticsearch-
 }
 {{< / command >}}
 
-If we now check the entries for our index in Elasticsearch (we will use curl for simplicity). Note to replace the url with the "Endpoint" field of our `create-elasticsearch-domain` operation at the beginning.
+If we now check the entries we made in Elasticsearch (we will use curl for simplicity). Note to replace the url with the "Endpoint" field of our `create-elasticsearch-domain` operation at the beginning.
 
 {{< command >}}
 $ curl -s http://es_local.us-east-1.es.localhost.localstack.cloud:443/activity/_search | jq '.hits.hits'

--- a/content/en/aws/kinesis-firehose/index.md
+++ b/content/en/aws/kinesis-firehose/index.md
@@ -53,9 +53,9 @@ $ awslocal es create-elasticsearch-domain --domain-name es_local
 }
 {{< / command >}}
 
-We need the Endpoint returned here later for the confirmation of our setup.
+We need the `Endpoint` returned here later for the confirmation of our setup.
 
-Now let us create our target S3 bucket and our source kinesis stream:
+Now let us create our target S3 bucket and our source Kinesis stream:
 
 {{< command >}}
 $ awslocal s3 mb s3://kinesis-activity-backup-local
@@ -67,9 +67,9 @@ $ awslocal kinesis create-stream --stream-name kinesis_es_local_stream --shard-c
 {{< / command >}}
 
 
-Next, we will create our firehose delivery stream with Elasticsearch as destination, and S3 as target for our AllDocuments backup.
-We set the ARN of our kinesis stream in the `kinesis-stream-source-configuration` as well as the role we want to use for accessing the stream.
-In the `elasticsearch-destination-configuration` we set (again) the access role, the DomainARN of the Elasticsearch domain we want to publish to, as well as IndexName and TypeName for Elasticsearch.
+Next, we will create our Firehose delivery stream with Elasticsearch as destination, and S3 as target for our AllDocuments backup.
+We set the ARN of our Kinesis stream in the `kinesis-stream-source-configuration` as well as the role we want to use for accessing the stream.
+In the `elasticsearch-destination-configuration` we set (again) the access role, the `DomainARN` of the Elasticsearch domain we want to publish to, as well as `IndexName` and `TypeName` for Elasticsearch.
 Since we want to backup all documents to S3, we also set `S3BackupMode` to `AllDocuments` and provide a `S3Configuration` pointing to our created bucket.
 
 {{< alert >}}
@@ -92,10 +92,10 @@ $ awslocal es describe-elasticsearch-domain --domain-name es_local | jq ".Domain
 false
 {{< / command >}}
 
-Once this command returns `false`, we are ready to proceed with inputing our data.
-We can input our data into our source kinesis stream, our put it directly into the firehose delivery stream.
+Once this command returns `false`, we are ready to proceed with ingesting our data.
+We can input our data into our source Kinesis stream, our put it directly into the Firehose delivery stream.
 
-To put it into kinesis, run:
+To put it into Kinesis, run:
 
 {{< command >}}
 $ awslocal kinesis put-record --stream-name kinesis_es_local_stream --data '{ "target": "barry" }' --partition-key partition --cli-binary-format raw-in-base64-out
@@ -106,7 +106,7 @@ $ awslocal kinesis put-record --stream-name kinesis_es_local_stream --data '{ "t
 }
 {{< / command >}}
 
-Or directly into the firehose delivery stream:
+Or directly into the Firehose delivery stream:
 
 {{< command >}}
 $ awslocal firehose put-record --delivery-stream-name activity-to-elasticsearch-local --record '{ "Data": "eyJ0YXJnZXQiOiAiSGVsbG8gd29ybGQifQ==" }' 
@@ -141,5 +141,5 @@ $ curl -s http://es_local.us-east-1.es.localhost.localstack.cloud:443/activity/_
 ]
 {{< / command >}}
 
-If you get a similar output, you have correctly setup a firehose delivery stream!
+If you get a similar output, you have correctly set up a Firehose delivery stream!
 Also checkout the specified S3 bucket to check if your backup is working correctly.


### PR DESCRIPTION
This PR adds a sample how to manually (using aws CLI) create an integration using AWS Firehose to deliver Kinesis stream data to ElasticSearch and S3 as full backup.

Example was created on request for a customer, so the little additional work turning it into a docs article seemed worth it.