### PR TITLE
Documentation updates across LocalStack

### DIFF
--- a/content/en/aws/cloudformation/index.md
+++ b/content/en/aws/cloudformation/index.md
@@ -236,6 +236,7 @@ When running the Community Edition, any unsupported resources in the stack are i
 - `AWS::Lambda::Alias`
 - `AWS::Lambda::LayerVersion`
 - `AWS::Lambda::LayerVersionPermission`
+- `AWS::QLDB::Ledger`
 - `AWS::RDS::DBCluster`
 - `AWS::RDS::DBInstance`
 - `AWS::RDS::DBParameterGroup`

--- a/content/en/aws/elasticache/index.md
+++ b/content/en/aws/elasticache/index.md
@@ -31,3 +31,9 @@ OK
 $ redis-cli -p 4530 get foo
 "bar"
 {{< / command >}}
+
+We also support the `create-replication-group` API which supports the replication groups in ElastiCache clusters. With the API, you can now have a Redis cluster, a Redis replication group with cluster mode disabled, and a Redis replication group with cluster mode enabled.
+
+{{< alert >}}**Note**:
+Redis requires at least 3+ nodes to form a Redis replication group with cluster mode enabled. Hence, if the user requests only 2 node groups, we transparently upgrade to 3 nodes behind the scenes, to avoid raising an error.
+{{< /alert >}}

--- a/content/en/localstack/podman/index.md
+++ b/content/en/localstack/podman/index.md
@@ -9,7 +9,7 @@ tags: ["podman", "docker"]
 ## Overview
 
 By default, the LocalStack CLI starts the LocalStack runtime inside a Docker container.
-Docker may not be awailable on your system, and a popular alternative is [Podman](https://podman.io/getting-started/) which you can use to run LocalStack.
+Docker may not be available on your system, and a popular alternative is [Podman](https://podman.io/getting-started/) which you can use to run LocalStack.
 Podman support is still experimental, and the following docs give you an overview of the current state.
 
 From the Podman docs:
@@ -21,7 +21,7 @@ To run `localstack`, simply aliasing `alias docker=podman` is not enough, for th
 - `localstack` is using [docker-py](https://pypi.org/project/docker/) which requires a connection to `/var/run/docker.sock`
 - `LAMBDA_EXECUTOR=docker` requires mounting `/var/run/docker.sock` into the container
 
-Here are several options how to run LocalStack using podman:
+Here are several options on running LocalStack using podman:
 
 ### podman-docker
 The package `podman-docker` emulates the Docker CLI using podman. It creates the following links:


### PR DESCRIPTION
## Description

This PR:

- Documents `create-replication-group` API for ElastiCache
- Reverts the Authorizers Pro status
- Fixes typos across Podman-specific docs
- Documenta support for `AWS::QLDB::Ledger`