### PR TITLE
Fix `INIT_SCRIPTS_PATH` default location

### DIFF
--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -33,7 +33,7 @@ $ SERVICES=kinesis,lambda,sqs,dynamodb DEBUG=1 localstack start
 | `LEGACY_PERSISTENCE` | `true` (default) | Whether to enable legacy persistence mechanism based on API calls record&replay (deprecated). Only relevant for Community version, not relevant for advanced persistence mechanism in Pro. |
 | `<SERVICE>_BACKEND` | | Custom endpoint URL to use for a specific service, where <SERVICE> is the uppercase service name. See (TODO) for supported services and (TODO) for examples for third-party integration |
 | `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
-| `INIT_SCRIPTS_PATH` | `/some/path` | Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d.` |
+| `INIT_SCRIPTS_PATH` | `/some/path` | Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`. |
 | `LS_LOG` | `trace`, `trace-internal`, `debug`, `info`, `warn`, `error`, `warning`| Specify the log level. Currently overrides the `DEBUG` configuration. `trace` for detailed request/response, `trace-internal` for internal calls, too. |
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/#available-services


### PR DESCRIPTION
The default location for `INIT_SCRIPTS_PATH` incorrectly contains a trailing dot.