### PR TITLE
Add tutorial on ECR EKS integration

### DIFF
--- a/content/en/get-started/_index.md
+++ b/content/en/get-started/_index.md
@@ -46,7 +46,7 @@ In addition you can easily check the status or open a shell in your LocalStack i
 
 #### Prerequisites
 Please make sure to install the following tools on your machine before moving on:
-- [`python`](https://docs.python.org/3/using/index.html) (Python 3.6 up to 3.9 is supported)
+- [`python`](https://docs.python.org/3/using/index.html) (Python 3.6 up to 3.10 is supported)
 - [`pip`](https://pip.pypa.io/en/stable/installation/) (Python package manager)
 - [`docker`](https://docs.docker.com/get-docker/)
 


### PR DESCRIPTION
Due to recent interest, I created a small sample to demonstrate the integration between EKS and ECR and its pitfalls (mainly the possibility of failure to resolve `localhost.localstack.cloud`).

It is a small example, with the necessary explanation at the beginning, with a small sample to demonstrate (nothing special, just creating a pod up to the point where the image is pulled) afterwards, using awscli. With the correct configuration of `EXTERNAL_HOSTNAME`, any IaC tool should work as well though.