### PR TITLE
Document DISABLE_TERM_HANDLER, update docker run command in getting-started

### DIFF
--- a/content/en/get-started/_index.md
+++ b/content/en/get-started/_index.md
@@ -142,7 +142,7 @@ You can check if `docker` is correctly configured on your machine by executing `
 #### Starting LocalStack with Docker
 You can start the Docker container simply by executing the following `docker run` command:
 {{< command >}}
-$ docker run --rm -it -p 4566:4566 -p 4571:4571 localstack/localstack
+$ docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack
 {{< / command >}}
 
 {{< alert title="Notes" >}}
@@ -155,9 +155,6 @@ $ docker run --rm -it -p 4566:4566 -p 4571:4571 localstack/localstack
   When using Docker to manually start LocalStack, you will have to configure the container on your own.
   This could be seen as the "expert mode" of starting LocalStack.
   If you are looking for a simpler method of starting LocalStack, please use the [LocalStack CLI]({{< ref "#localstack-cli" >}}).
-
-- This command starts all services provided by LocalStack.
-  You can limit the services to a subset by setting the environment variable `SERVICES` (for example with `-e "SERVICES=dynamodb,s3"`).
 
 - To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker. For instance, setting `LOCALSTACK_SERVICES=s3` is equivalent to `SERVICES=s3`.
 {{< /alert >}}

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -192,6 +192,7 @@ Some of the services can be configured to switch to a particular provider:
 | `OUTBOUND_HTTP_PROXY` | `http://10.10.1.3` | HTTP Proxy used for downloads of runtime dependencies and connections outside LocalStack itself
 | `OUTBOUND_HTTPS_PROXY` | `https://10.10.1.3` | HTTPS Proxy used for downloads of runtime dependencies and connections outside LocalStack itself
 | `REQUESTS_CA_BUNDLE` | `/tmp/localstack/ca_bundle.pem` | CA Bundle to be used to verify HTTPS requests made by LocalStack
+| `DISABLE_TERM_HANDLER` | | Whether to disable signal passing to LocalStack when running in docker. Enabling this will prevent an orderly shutdown when running inside LS in docker.
 
 
 ## Debugging


### PR DESCRIPTION
Port 4571 is not used by any default configuration (only legacy elasticsearch), ports 4510-4559 are however used more frequently.

I also removed the hint to the "SERVICES" variable, as we see a lot of misuse in support. Up to discussion!

Main target of this PR is the addition of documentation regarding the environment variable introduced in https://github.com/localstack/localstack/pull/6000 .

This variable disables "orderly" shutdown of LocalStack by preventing passing signals from docker-entrypoint.sh to supervisor.