### PR TITLE
Document SES configuration options

### DIFF
--- a/content/en/aws/cognito/index.md
+++ b/content/en/aws/cognito/index.md
@@ -9,9 +9,9 @@ description: >
 
 LocalStack Pro contains basic support for authentication via Cognito. You can create Cognito user pools, sign up and confirm users, set up Lambda triggers, and use the `COGNITO_USER_POOLS` authorizer integration with API Gateway.
 
-{{< alert title="SMTP settings" >}}
-By default, Cognito does not send actual email messages. To enable this feature, you will require an e-mail address and the corresponding SMTP settings ([see below](#smtp-integration)).
-{{< /alert >}}
+By default, Cognito does not send actual email messages.
+To enable this feature, you will require an email address and the corresponding SMTP settings.
+Please refer to the [Configuration]({{< ref "configuration#emails" >}}) guide for instructions on how to configure the connection parameters of your SMTP server.
 
 ## Creating a User Pool
 
@@ -164,18 +164,6 @@ Note that the value of the `redirect_uri` parameter must match the value provide
   'http://localhost:4566/oauth2/token'
 {"access_token": "eyJ0eXAi…lKaHx44Q", "expires_in": 86400, "token_type": "Bearer", "refresh_token": "e3f08304", "id_token": "eyJ0eXAi…ADTXv5mA"}
 ```
-
-## SMTP Integration
-
-In order to enable sending activation emails, configure the following SMTP settings as environment variables:
-```env
-SMTP_HOST=<smtp-host-address>
-SMTP_USER=<email-user-name>
-SMTP_PASS=<email-password>
-SMTP_EMAIL=<email-address>
-```
-
-Please check with your email provider for details regarding the SMTP settings above.
 
 ## Serverless and Cognito
 

--- a/content/en/aws/elastic-compute-cloud/index.md
+++ b/content/en/aws/elastic-compute-cloud/index.md
@@ -52,6 +52,8 @@ If the LocalStack daemon is not running, the instance will be only accessible ov
 
 LocalStack daemon is supported on Linux and MacOS.
 
+Ports other than 22 (SSH) are currently not exposed from the Dockerised instances.
+
 
 ### Operations
 
@@ -61,7 +63,7 @@ The Docker backend supports following operations:
 |:----------|:------|
 | CreateImage | Uses Docker commit to take a snapshot of a running instance into a new AMI |
 | DescribeImages | Retrieve a list of Docker images available for use within LocalStack |
-| DescribeInstances | Describe 'mock' instances as well as Docker-backed instances |
+| DescribeInstances | Describe 'mock' instances as well as Docker-backed instances. Docker-backed instances have the resource tag `ec2_vm_manager:docker` |
 | RunInstances | Launch an instance. Supports `ImageId`, `MaxCount`, `KeyPair` and `UserData` parameters |
 | StopInstances | Corresponds to pausing a container |
 | StartInstances | Corresponds to unpausing a container |

--- a/content/en/aws/ses/index.md
+++ b/content/en/aws/ses/index.md
@@ -19,7 +19,7 @@ The files are saved as JSON in the `ses/` subdirectory and organised by message 
 
 LocalStack Pro ships with extended support including a simple user interface to inspect email accounts and sent messages, as well as support for sending SES messages through an actual SMTP email server.
 
-Please refer to the [Configuration]({{< ref "configuration#configuration" >}}) guide for instructions on how to configure the connection parameters of your SMTP server (`SMTP_HOST`/`SMTP_USER`/`SMTP_PASS`).
+Please refer to the [Configuration]({{< ref "configuration#simple-email-service" >}}) guide for instructions on how to configure the connection parameters of your SMTP server (`SMTP_HOST`/`SMTP_USER`/`SMTP_PASS`).
 
 Once the SMTP server has been configured, the SES user interface in the Web app can be used to create a new email account (e.g., `user1@yourdomain.com`).
 Emails can be sent via the command line (or SES client SDK):

--- a/content/en/aws/ses/index.md
+++ b/content/en/aws/ses/index.md
@@ -19,7 +19,7 @@ The files are saved as JSON in the `ses/` subdirectory and organised by message 
 
 LocalStack Pro ships with extended support including a simple user interface to inspect email accounts and sent messages, as well as support for sending SES messages through an actual SMTP email server.
 
-Please refer to the [Configuration]({{< ref "configuration#simple-email-service" >}}) guide for instructions on how to configure the connection parameters of your SMTP server (`SMTP_HOST`/`SMTP_USER`/`SMTP_PASS`).
+Please refer to the [Configuration]({{< ref "configuration#emails" >}}) guide for instructions on how to configure the connection parameters of your SMTP server (`SMTP_HOST`/`SMTP_USER`/`SMTP_PASS`).
 
 Once the SMTP server has been configured, the SES user interface in the Web app can be used to create a new email account (e.g., `user1@yourdomain.com`).
 Emails can be sent via the command line (or SES client SDK):

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -145,14 +145,6 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 | `OPENSEARCH_MULTI_CLUSTER` | `0`\|`1` | When activated, LocalStack will spawn one OpenSearch cluster per domain. Otherwise all domains will share a single cluster instance. This is ignored if `OPENSEARCH_CUSTOM_BACKEND` is set. |
 | `OPENSEARCH_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` | Governs how domain endpoints are created to access a cluster (see [OpenSearch#endpoints]({{< ref "opensearch#endpoints" >}})). |
 
-### Simple Email Service
-
-| Variable | Example Values | Description |
-| - | - | - |
-| `SMTP_HOST` | `localhost` | Hostname of the SMTP server. The port defaults to 25. |
-| `SMTP_USER` |  | Login username for the SMTP server if required. |
-| `SMTP_PASS` |  | Login password for the SMTP server if required. |
-
 ### StepFunctions
 
 | Variable | Example Values | Description |
@@ -173,6 +165,18 @@ Please be aware that the following configurations may have severe security impli
 | `EXTRA_CORS_ALLOWED_ORIGINS` | | Comma-separated list of origins that are allowed to communicate with localstack. |
 | `EXTRA_CORS_ALLOWED_HEADERS` | | Comma-separated list of header names to be be added to Access-Control-Allow-Headers CORS header. |
 | `EXTRA_CORS_EXPOSE_HEADERS` | | Comma-separated list of header names to be be added to Access-Control-Expose-Headers CORS header. |
+
+
+## Emails
+
+Please check with your SMTP email service provider for the following settings.
+
+| Variable | Example Values | Description |
+| - | - | - |
+| `SMTP_HOST` | `localhost` | Hostname of the SMTP server. The port defaults to 25. |
+| `SMTP_USER` |  | Login username for the SMTP server if required. |
+| `SMTP_PASS` |  | Login password for the SMTP server if required. |
+| `SMTP_EMAIL` | `sender@example.com` | Origin email address. Required for Cognito only. |
 
 
 ## Provider

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -145,6 +145,14 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 | `OPENSEARCH_MULTI_CLUSTER` | `0`\|`1` | When activated, LocalStack will spawn one OpenSearch cluster per domain. Otherwise all domains will share a single cluster instance. This is ignored if `OPENSEARCH_CUSTOM_BACKEND` is set. |
 | `OPENSEARCH_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` | Governs how domain endpoints are created to access a cluster (see [OpenSearch#endpoints]({{< ref "opensearch#endpoints" >}})). |
 
+### Simple Email Service
+
+| Variable | Example Values | Description |
+| - | - | - |
+| `SMTP_HOST` | `localhost` | Hostname of the SMTP server. The port defaults to 25. |
+| `SMTP_USER` |  | Login username for the SMTP server if required. |
+| `SMTP_PASS` |  | Login password for the SMTP server if required. |
+
 ### StepFunctions
 
 | Variable | Example Values | Description |


### PR DESCRIPTION
This PR adds missing environment config options for Simple Email Service.