### PR TITLE
Update Multi-accounts docs

### DIFF
--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -31,6 +31,7 @@ $ SERVICES=kinesis,lambda,sqs,dynamodb DEBUG=1 localstack start
 | `PERSISTENCE_SINGLE_FILE` | `true` (default)| Specify if persistence files should be combined (deprecated - only relevant for legacy persistence in Community version, not relevant for advanced persistence in Pro version). |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, Cognito users, etc). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
 | `LEGACY_PERSISTENCE` | `true` (default) | Whether to enable legacy persistence mechanism based on API calls record&replay (deprecated). Only relevant for Community version, not relevant for advanced persistence mechanism in Pro. |
+| `MULTI_ACCOUNTS` | `0` (default) | Enable multi-accounts (preview) |
 | `<SERVICE>_BACKEND` | | Custom endpoint URL to use for a specific service, where <SERVICE> is the uppercase service name. See (TODO) for supported services and (TODO) for examples for third-party integration |
 | `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
 | `INIT_SCRIPTS_PATH` | `/some/path` | Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`. |

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -2,39 +2,76 @@
 title: "Multi-Account Setups"
 linkTitle: "Multi-Account Setups"
 categories: ["LocalStack Pro"]
-tags: ["multi-tenant", "multi-account", "account-id"]
+tags: ["multi-tenant", "multi-account", "account-id", "namespaces"]
 aliases:
   - /aws/multi-account-setups/
 weight: 5
 description: >
-  Using multiple tenants on LocalStack
+  Using LocalStack in multi-tenant setups
 ---
 
-Unlike the open source LocalStack, which uses a single hardcoded account ID (`000000000000`), the Pro version allows to use multiple instances for different AWS account IDs in parallel.
+LocalStack Pro supports multiple AWS accounts on a single running instance.
+In contrast, LocalStack Community has a non-configurable AWS Account ID (`000000000000`).
 
-In order to set up a multi-account environment, simply configure the `TEST_AWS_ACCOUNT_ID` to include a comma-separated list of account IDs. For example, use the following to start up LocalStack with two account IDs:
+AWS resources can be addressed by accounts using the `AWS_ACCESS_KEY_ID` variable.
+As can be seen in the example below, all created resources are namespaced by account ID.
+
 {{< command >}}
-$ TEST_AWS_ACCOUNT_ID=000000000001,000000000002 SERVICES=s3 localstack start
+$ AWS_ACCESS_KEY_ID=001 awslocal ec2 create-key-pair --key-name green-hospital
+
+$ AWS_ACCESS_KEY_ID=002 awslocal ec2 create-key-pair --key-name red-medicine
+
+$ AWS_ACCESS_KEY_ID=001 awslocal ec2 describe-key-pairs
+{
+    "KeyPairs": [
+        {
+            "KeyFingerprint": "6b:e3:a3:41:4b:60:f3:6d:7b:84:3e:17:e3:ad:d0:15",
+            "KeyName": "green-hospital"
+        }
+    ]
+}
+
+$ AWS_ACCESS_KEY_ID=002 awslocal ec2 describe-key-pairs
+{
+    "KeyPairs": [
+        {
+            "KeyFingerprint": "16:4c:64:13:36:41:7c:75:d0:51:f0:db:ed:d7:c8:95",
+            "KeyName": "red-medicine"
+        }
+    ]
+}
 {{< / command >}}
 
-You can then use `AWS_ACCESS_KEY_ID` to address resources in the two separate account instances:
-{{< command >}}
-$ AWS_ACCESS_KEY_ID=000000000001 aws --endpoint-url=http://localhost:4566 s3 mb s3://bucket-account-one
-make_bucket: bucket-account-one
-$ AWS_ACCESS_KEY_ID=000000000002 aws --endpoint-url=http://localhost:4566 s3 mb s3://bucket-account-two
-make_bucket: bucket-account-two
-$ AWS_ACCESS_KEY_ID=000000000001 aws --endpoint-url=http://localhost:4566 s3 ls
-2020-05-24 17:09:41 bucket-account-one
-$ AWS_ACCESS_KEY_ID=000000000002 aws --endpoint-url=http://localhost:4566 s3 ls
-2020-05-24 17:09:53 bucket-account-two
-{{< / command >}}
+In absence of an explicit value for Account ID, LocalStack reverts to the default value of `000000000000`.
+Thus, in this example, not setting an explicit Account ID will return no resources.
 
-Note that using an invalid account ID should result in a 404 (not found) error response from the API:
 {{< command >}}
-$ AWS_ACCESS_KEY_ID=123000000123 aws --endpoint-url=http://localhost:4566 s3 ls
-An error occurred (404) when calling the ListBuckets operation: Not Found
-{{< / command >}}
+$ awslocal ec2 describe-key-pairs
+{
+    "KeyPairs": []
+}
+{{< /command >}}
 
 {{< alert >}}
-**Note:** For now, the account ID is encoded directly in the `AWS_ACCESS_KEY_ID` client-side variable, for simplicity. In a future version, we will support proper access key IDs issued by the local IAM service, which will then internally be translated to corresponding account IDs.
+**Note:**
+LocalStack uses the `AWS_ACCESS_KEY_ID` client-side variable for Account ID.
+In future LocalStack may support proper access key IDs issued by the local IAM service, which will then internally be translated to corresponding account IDs.
 {{< /alert >}}
+
+Multi-accounts is currently supported by following services:
+- ACM
+- Batch
+- CloudWatch
+- EC2 (partial)
+- ECS
+- ELB
+- IAM
+- KMS
+- CloudWatch
+- Organisations
+- Resource Groups
+- Secrets Manager
+- SES
+- SSM (partial)
+- SWF
+- Xray

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -13,11 +13,12 @@ description: >
 LocalStack Community uses a fixed AWS Account ID (`000000000000`).
 In contrast, LocalStack Pro supports namespacing based on AWS Account ID on the single running instance.
 
-Namespaced AWS resources can be accessed by using the `AWS_ACCESS_KEY_ID` variable as illustrated below.
+Namespaced AWS resources can be accessed by using the `AWS_ACCESS_KEY_ID` variable when making requests.
+No additional configuration is required on LocalStack side.
 
 {{< alert >}}
 **Important:**
-Region must be configured not to be `us-east-1`.
+Any region other than `us-east-1` must be used.
 See [limitation note](#limitations).
 {{< /alert >}}
 
@@ -71,25 +72,3 @@ In order to use multi-accounts, the region must be configured to something other
 Note that `us-east-1` is the default region and must be explicitly overridden.
 This can be done using the `AWS_DEFAULT_REGION` or the `--region` argument in AWS CLI.
 More information can be found on [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
-
-Multi-accounts is currently supported by following services:
-<!--
-Services that use the Moto backend.
-In phase 2 of multi-accounts, this list will be expanded to LocalStack RegionBackend.
--->
-- ACM
-- Batch
-- CloudWatch
-- EC2
-- ECS
-- ELB
-- IAM
-- KMS
-- CloudWatch
-- Organisations
-- Resource Groups
-- Secrets Manager
-- SES
-- SSM
-- SWF
-- Xray

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -10,14 +10,19 @@ description: >
   Using LocalStack in multi-tenant setups
 ---
 
+{{< alert title="Warning" color="warning">}}
+Multi-account is a preview feature and is not compatible with cloud pods and persistence.
+To enable multi-accounts, refer to [configuration]({{< ref "configuration#core" >}}).
+{{< /alert >}}
+
+
 LocalStack Community only supports a single AWS Account ID, `000000000000` by default.
 By contrast, LocalStack Pro ships with multi-account support which adds namespacing based on AWS Account ID
 
 Namespaced AWS resources can be accessed by using the `AWS_ACCESS_KEY_ID` variable when making requests.
 No additional server-side configuration is required.
 
-{{< alert >}}
-**Important:**
+{{< alert title="Note" color="primary">}}
 Multi-account is not supported for the `us-east-1` region.
 See [limitation note](#limitations).
 {{< /alert >}}
@@ -60,15 +65,17 @@ $ awslocal ec2 describe-key-pairs
 }
 {{< /command >}}
 
-{{< alert >}}
-**Note:**
+{{< alert title="Note" color="primary">}}
 LocalStack uses the `AWS_ACCESS_KEY_ID` client-side variable for Account ID.
 In future LocalStack may support proper access key IDs issued by the local IAM service, which will then internally be translated to corresponding account IDs.
 {{< /alert >}}
 
 ### Limitations
 
+Multi-accounts is a preview feature and is not compatible with cloud pods and persistence.
+
 In order to use multi-accounts, the region must be configured to something other than `us-east-1`.
 Note that `us-east-1` is the default region and must be explicitly overridden.
 For the AWS CLI, this can be done using the `AWS_DEFAULT_REGION` or the `--region` argument.
 More information can be found on [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -10,15 +10,15 @@ description: >
   Using LocalStack in multi-tenant setups
 ---
 
-LocalStack Community uses a fixed AWS Account ID (`000000000000`).
-In contrast, LocalStack Pro supports namespacing based on AWS Account ID on the single running instance.
+LocalStack Community only supports a single AWS Account ID, `000000000000` by default.
+By contrast, LocalStack Pro ships with multi-account support which adds namespacing based on AWS Account ID
 
 Namespaced AWS resources can be accessed by using the `AWS_ACCESS_KEY_ID` variable when making requests.
-No additional configuration is required on LocalStack side.
+No additional server-side configuration is required.
 
 {{< alert >}}
 **Important:**
-Any region other than `us-east-1` must be used.
+Multi-account is not supported for the `us-east-1` region.
 See [limitation note](#limitations).
 {{< /alert >}}
 
@@ -70,5 +70,5 @@ In future LocalStack may support proper access key IDs issued by the local IAM s
 
 In order to use multi-accounts, the region must be configured to something other than `us-east-1`.
 Note that `us-east-1` is the default region and must be explicitly overridden.
-This can be done using the `AWS_DEFAULT_REGION` or the `--region` argument in AWS CLI.
+For the AWS CLI, this can be done using the `AWS_DEFAULT_REGION` or the `--region` argument.
 More information can be found on [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -10,18 +10,25 @@ description: >
   Using LocalStack in multi-tenant setups
 ---
 
-LocalStack Pro supports multiple AWS accounts on a single running instance.
-In contrast, LocalStack Community has a non-configurable AWS Account ID (`000000000000`).
+LocalStack Community uses a fixed AWS Account ID (`000000000000`).
+In contrast, LocalStack Pro supports namespacing based on AWS Account ID on the single running instance.
 
-AWS resources can be addressed by accounts using the `AWS_ACCESS_KEY_ID` variable.
-As can be seen in the example below, all created resources are namespaced by account ID.
+Namespaced AWS resources can be accessed by using the `AWS_ACCESS_KEY_ID` variable as illustrated below.
+
+{{< alert >}}
+**Important:**
+Region must be configured not to be `us-east-1`.
+See [limitation note](#limitations).
+{{< /alert >}}
 
 {{< command >}}
-$ AWS_ACCESS_KEY_ID=001 awslocal ec2 create-key-pair --key-name green-hospital
+$ export AWS_DEFAULT_REGION=eu-central-1
 
-$ AWS_ACCESS_KEY_ID=002 awslocal ec2 create-key-pair --key-name red-medicine
+$ AWS_ACCESS_KEY_ID=000000000001 awslocal ec2 create-key-pair --key-name green-hospital
 
-$ AWS_ACCESS_KEY_ID=001 awslocal ec2 describe-key-pairs
+$ AWS_ACCESS_KEY_ID=000000000002 awslocal ec2 create-key-pair --key-name red-medicine
+
+$ AWS_ACCESS_KEY_ID=000000000001 awslocal ec2 describe-key-pairs
 {
     "KeyPairs": [
         {
@@ -31,7 +38,7 @@ $ AWS_ACCESS_KEY_ID=001 awslocal ec2 describe-key-pairs
     ]
 }
 
-$ AWS_ACCESS_KEY_ID=002 awslocal ec2 describe-key-pairs
+$ AWS_ACCESS_KEY_ID=000000000002 awslocal ec2 describe-key-pairs
 {
     "KeyPairs": [
         {
@@ -43,7 +50,7 @@ $ AWS_ACCESS_KEY_ID=002 awslocal ec2 describe-key-pairs
 {{< / command >}}
 
 In absence of an explicit value for Account ID, LocalStack reverts to the default value of `000000000000`.
-Thus, in this example, not setting an explicit Account ID will return no resources.
+In the current example, not setting an explicit Account ID will return no resources.
 
 {{< command >}}
 $ awslocal ec2 describe-key-pairs
@@ -58,11 +65,22 @@ LocalStack uses the `AWS_ACCESS_KEY_ID` client-side variable for Account ID.
 In future LocalStack may support proper access key IDs issued by the local IAM service, which will then internally be translated to corresponding account IDs.
 {{< /alert >}}
 
+### Limitations
+
+In order to use multi-accounts, the region must be configured to something other than `us-east-1`.
+Note that `us-east-1` is the default region and must be explicitly overridden.
+This can be done using the `AWS_DEFAULT_REGION` or the `--region` argument in AWS CLI.
+More information can be found on [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+
 Multi-accounts is currently supported by following services:
+<!--
+Services that use the Moto backend.
+In phase 2 of multi-accounts, this list will be expanded to LocalStack RegionBackend.
+-->
 - ACM
 - Batch
 - CloudWatch
-- EC2 (partial)
+- EC2
 - ECS
 - ELB
 - IAM
@@ -72,6 +90,6 @@ Multi-accounts is currently supported by following services:
 - Resource Groups
 - Secrets Manager
 - SES
-- SSM (partial)
+- SSM
 - SWF
 - Xray

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -2,8 +2,12 @@
 title: "Multi-Account Setups"
 linkTitle: "Multi-Account Setups"
 categories: ["LocalStack Pro"]
+tags: ["multi-tenant", "multi-account", "account-id"]
+aliases:
+  - /aws/multi-account-setups/
+weight: 5
 description: >
-  Multi-Account Setups
+  Using multiple tenants on LocalStack
 ---
 
 Unlike the open source LocalStack, which uses a single hardcoded account ID (`000000000000`), the Pro version allows to use multiple instances for different AWS account IDs in parallel.


### PR DESCRIPTION
This change moves the Multi-accounts documentation from AWS Services section to Tools section.
There is an alias added so the old link will work too.
The documentation contents have been updated to reflect the changes done as part of Multi-accounts revamp.