### PR TITLE
New filesystem layout

### DIFF
--- a/content/en/aws/elasticsearch/index.md
+++ b/content/en/aws/elasticsearch/index.md
@@ -59,12 +59,12 @@ $ awslocal es create-elasticsearch-domain --domain-name my-domain
 In the LocalStack log you will see something like the following, where you can see the cluster starting up in the background.
 
 ```
-2021-11-08T16:29:28:INFO:localstack.services.es.cluster: starting elasticsearch: /opt/code/localstack/localstack/localstack/infra/elasticsearch/bin/elasticsearch -E http.port=57705 -E http.publish_port=57705 -E transport.port=0 -E network.host=127.0.0.1 -E http.compression=false -E path.data="/tmp/localstack/elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/data" -E path.repo="/tmp/localstack/elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/backup" -E xpack.ml.enabled=false with env {'ES_JAVA_OPTS': '-Xms200m -Xmx600m', 'ES_TMPDIR': '/tmp/localstack/elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp'}
+2021-11-08T16:29:28:INFO:localstack.services.es.cluster: starting elasticsearch: /opt/code/localstack/localstack/localstack/infra/elasticsearch/bin/elasticsearch -E http.port=57705 -E http.publish_port=57705 -E transport.port=0 -E network.host=127.0.0.1 -E http.compression=false -E path.data="/var/lib/localstack/lib//elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/data" -E path.repo="/var/lib/localstack/lib//elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/backup" -E xpack.ml.enabled=false with env {'ES_JAVA_OPTS': '-Xms200m -Xmx600m', 'ES_TMPDIR': '/var/lib/localstack/lib//elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp'}
 2021-11-08T16:29:28:INFO:localstack.services.es.cluster: registering an endpoint proxy for http://my-domain.us-east-1.es.localhost.localstack.cloud:4566 => http://127.0.0.1:57705
 2021-11-08T16:29:30:INFO:localstack.services.es.cluster: OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
 2021-11-08T16:29:32:INFO:localstack.services.es.cluster: [2021-11-08T16:29:32,502][INFO ][o.e.n.Node               ] [noctua] version[7.10.0], pid[22403], build[default/tar/51e9d6f22758d0374a0f3f5c6e8f3a7997850f96/2020-11-09T21:30:33.964949Z], OS[Linux/5.4.0-89-generic/amd64], JVM[Ubuntu/OpenJDK 64-Bit Server VM/11.0.11/11.0.11+9-Ubuntu-0ubuntu2.20.04]
 2021-11-08T16:29:32:INFO:localstack.services.es.cluster: [2021-11-08T16:29:32,510][INFO ][o.e.n.Node               ] [noctua] JVM home [/usr/lib/jvm/java-11-openjdk-amd64], using bundled JDK [false]
-2021-11-08T16:29:32:INFO:localstack.services.es.cluster: [2021-11-08T16:29:32,511][INFO ][o.e.n.Node               ] [noctua] JVM arguments [-Xshare:auto, -Des.networkaddress.cache.ttl=60, -Des.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.locale.providers=SPI,COMPAT, -XX:+UseConcMarkSweepGC, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -Djava.io.tmpdir=/tmp/localstack/elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=data, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Xms200m, -Xmx600m, -XX:MaxDirectMemorySize=314572800, -Des.path.home=/opt/code/localstack/localstack/localstack/infra/elasticsearch, -Des.path.conf=/opt/code/localstack/localstack/localstack/infra/elasticsearch/config, -Des.distribution.flavor=default, -Des.distribution.type=tar, -Des.bundled_jdk=true]
+2021-11-08T16:29:32:INFO:localstack.services.es.cluster: [2021-11-08T16:29:32,511][INFO ][o.e.n.Node               ] [noctua] JVM arguments [-Xshare:auto, -Des.networkaddress.cache.ttl=60, -Des.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.locale.providers=SPI,COMPAT, -XX:+UseConcMarkSweepGC, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -Djava.io.tmpdir=/var/lib/localstack/lib//elasticsearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=data, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Xms200m, -Xmx600m, -XX:MaxDirectMemorySize=314572800, -Des.path.home=/opt/code/localstack/localstack/localstack/infra/elasticsearch, -Des.path.conf=/opt/code/localstack/localstack/localstack/infra/elasticsearch/config, -Des.distribution.flavor=default, -Des.distribution.type=tar, -Des.bundled_jdk=true]
 2021-11-08T16:29:36:INFO:localstack.services.es.cluster: [2021-11-08T16:29:36,258][INFO ][o.e.p.PluginsService     ] [noctua] loaded module [aggs-matrix-stats]
 2021-11-08T16:29:36:INFO:localstack.services.es.cluster: [2021-11-08T16:29:36,259][INFO ][o.e.p.PluginsService     ] [noctua] loaded module [analysis-common]
 2021-11-08T16:29:36:INFO:localstack.services.es.cluster: [2021-11-08T16:29:36,260][INFO ][o.e.p.PluginsService     ] [noctua] loaded module [constant-keyword]
@@ -179,7 +179,7 @@ This can however lead to unexpected behavior when persisting data into Elasticse
 Elasticsearch will be organized in your state directory as follows:
 
 ```
-localstack@machine /tmp/localstack/data % tree -L 4
+localstack@machine % tree -L 4 volume/state
 .
 ├── elasticsearch
 │   └── arn:aws:es:us-east-1:000000000000:domain
@@ -242,10 +242,9 @@ services:
       - DEBUG=${DEBUG- }
       - PERSISTENCE=${PERSISTENCE- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
-      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     links:
       - elasticsearch

--- a/content/en/aws/elasticsearch/index.md
+++ b/content/en/aws/elasticsearch/index.md
@@ -176,7 +176,7 @@ This can however lead to unexpected behavior when persisting data into Elasticse
 
 ### Storage Layout
 
-Elasticsearch will be organized in your `DATA_DIR`, or the temporary directory (e.g., `/tmp/localstack/data`), as follows:
+Elasticsearch will be organized in your state directory as follows:
 
 ```
 localstack@machine /tmp/localstack/data % tree -L 4
@@ -240,13 +240,12 @@ services:
     environment:
       - ES_CUSTOM_BACKEND=http://elasticsearch:9200
       - DEBUG=${DEBUG- }
-      - DATA_DIR=${DATA_DIR- }
+      - PERSISTENCE=${PERSISTENCE- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     links:
       - elasticsearch

--- a/content/en/aws/opensearch/index.md
+++ b/content/en/aws/opensearch/index.md
@@ -218,7 +218,7 @@ This can however lead to unexpected behavior when persisting data into OpenSearc
 
 ### Storage Layout
 
-OpenSearch will be organized in your `DATA_DIR`, or the temporary directory (e.g., `/tmp/localstack/data`), as follows:
+OpenSearch will be organized in your state directory as follows:
 
 ```
 localstack@machine /tmp/localstack/data % tree -L 4
@@ -283,11 +283,10 @@ services:
     environment:
       - OPENSEARCH_CUSTOM_BACKEND=http://opensearch:9200
       - DEBUG=${DEBUG- }
-      - DATA_DIR=${DATA_DIR- }
+      - PERSISTENCE=${PERSISTENCE- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     links:
       - opensearch

--- a/content/en/aws/opensearch/index.md
+++ b/content/en/aws/opensearch/index.md
@@ -101,11 +101,11 @@ $ awslocal opensearch create-domain --domain-name my-domain
 In the LocalStack log you will see something like, where you can see the cluster starting up in the background.
 
 ```
-2022-01-13T10:36:29.436:INFO:localstack.services.opensearch.cluster: starting opensearch: /tmp/localstack/var_libs/opensearch/1.1.0/bin/opensearch -E http.port=35403 -E http.publish_port=35403 -E transport.port=0 -E network.host=127.0.0.1 -E http.compression=false -E path.data="/tmp/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/data" -E path.repo="/tmp/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/backup" -E plugins.security.disabled=true with env {'OPENSEARCH_JAVA_OPTS': '-Xms200m -Xmx600m', 'OPENSEARCH_TMPDIR': '/tmp/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp'}
+2022-01-13T10:36:29.436:INFO:localstack.services.opensearch.cluster: starting opensearch: /var/lib/localstack/libs/opensearch/1.1.0/bin/opensearch -E http.port=35403 -E http.publish_port=35403 -E transport.port=0 -E network.host=127.0.0.1 -E http.compression=false -E path.data="/var/lib/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/data" -E path.repo="/var/lib/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/backup" -E plugins.security.disabled=true with env {'OPENSEARCH_JAVA_OPTS': '-Xms200m -Xmx600m', 'OPENSEARCH_TMPDIR': '/var/lib/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp'}
 2022-01-13T10:36:29.437:INFO:localstack.services.opensearch.cluster: registering an endpoint proxy for http://my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566 => http://127.0.0.1:35403
 2022-01-13T10:36:32.803:INFO:localstack.services.opensearch.cluster: [2022-01-13T10:36:32,800][INFO ][o.o.n.Node               ] [host-pc] version[1.1.0], pid[231895], build[tar/15e9f137622d878b79103df8f82d78d782b686a1/2021-10-04T21:29:03.079792Z], OS[Linux/5.11.0-46-generic/amd64], JVM[AdoptOpenJDK/OpenJDK 64-Bit Server VM/15.0.1/15.0.1+9]
-2022-01-13T10:36:32.805:INFO:localstack.services.opensearch.cluster: [2022-01-13T10:36:32,805][INFO ][o.o.n.Node               ] [host-pc] JVM home [/tmp/localstack/var_libs/opensearch/1.1.0/jdk], using bundled JDK [true]
-2022-01-13T10:36:32.806:INFO:localstack.services.opensearch.cluster: [2022-01-13T10:36:32,805][INFO ][o.o.n.Node               ] [host-pc] JVM arguments [-Xshare:auto, -Dopensearch.networkaddress.cache.ttl=60, -Dopensearch.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -XX:+ShowCodeDetailsInExceptionMessages, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.locale.providers=SPI,COMPAT, -XX:+UseG1GC, -XX:G1ReservePercent=25, -XX:InitiatingHeapOccupancyPercent=30, -Djava.io.tmpdir=/tmp/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=data, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Xms200m, -Xmx600m, -XX:MaxDirectMemorySize=314572800, -Dopensearch.path.home=/tmp/localstack/var_libs/opensearch/1.1.0, -Dopensearch.path.conf=/tmp/localstack/var_libs/opensearch/1.1.0/config, -Dopensearch.distribution.type=tar, -Dopensearch.bundled_jdk=true]
+2022-01-13T10:36:32.805:INFO:localstack.services.opensearch.cluster: [2022-01-13T10:36:32,805][INFO ][o.o.n.Node               ] [host-pc] JVM home [/var/lib/localstack/libs/opensearch/1.1.0/jdk], using bundled JDK [true]
+2022-01-13T10:36:32.806:INFO:localstack.services.opensearch.cluster: [2022-01-13T10:36:32,805][INFO ][o.o.n.Node               ] [host-pc] JVM arguments [-Xshare:auto, -Dopensearch.networkaddress.cache.ttl=60, -Dopensearch.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -XX:+ShowCodeDetailsInExceptionMessages, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.locale.providers=SPI,COMPAT, -XX:+UseG1GC, -XX:G1ReservePercent=25, -XX:InitiatingHeapOccupancyPercent=30, -Djava.io.tmpdir=/var/lib/localstack/opensearch/arn:aws:es:us-east-1:000000000000:domain/my-domain/tmp, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=data, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Xms200m, -Xmx600m, -XX:MaxDirectMemorySize=314572800, -Dopensearch.path.home=/var/lib/localstack/libs/opensearch/1.1.0, -Dopensearch.path.conf=/var/lib/localstack/libs/opensearch/1.1.0/config, -Dopensearch.distribution.type=tar, -Dopensearch.bundled_jdk=true]
 ...
 ```
 
@@ -221,8 +221,8 @@ This can however lead to unexpected behavior when persisting data into OpenSearc
 OpenSearch will be organized in your state directory as follows:
 
 ```
-localstack@machine /tmp/localstack/data % tree -L 4
-.
+localstack@machine % tree -L 4 ./volume/state
+./volume/state
 ├── opensearch
 │   └── arn:aws:es:us-east-1:000000000000:domain
 │       ├── my-cluster-1
@@ -286,7 +286,7 @@ services:
       - PERSISTENCE=${PERSISTENCE- }
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     links:
       - opensearch

--- a/content/en/aws/ses/index.md
+++ b/content/en/aws/ses/index.md
@@ -11,8 +11,7 @@ LocalStack keeps track of all sent emails for retrospection.
 
 The sent messages can be retrieved via a service API endpoint (GET `/_localstack/ses`) or from the filesystem.
 
-Messages are also saved to the data directory (`DATA_DIR`, see [Configuration]({{< ref "configuration#configuration" >}})).
-If data directory is not available, the temporary directory (`TMPDIR`) is used.
+Messages are also saved to the state directory (see [filesystem layout]({{< ref "filesystem" >}})).
 The files are saved as JSON in the `ses/` subdirectory and organised by message ID.
 
 ## Pro

--- a/content/en/integrations/kafka/docker-compose.yml
+++ b/content/en/integrations/kafka/docker-compose.yml
@@ -64,8 +64,7 @@ services:
       - DEBUG=${DEBUG- }
       - PERSISTENCE=${PERSISTENCE- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
-      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/content/en/integrations/kafka/docker-compose.yml
+++ b/content/en/integrations/kafka/docker-compose.yml
@@ -62,11 +62,10 @@ services:
     environment:
       - SERVICES=lambda,secretsmanager
       - DEBUG=${DEBUG- }
-      - DATA_DIR=${DATA_DIR- }
+      - PERSISTENCE=${PERSISTENCE- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -28,10 +28,10 @@ $ SERVICES=kinesis,lambda,sqs,dynamodb DEBUG=1 localstack start
 | `TMPDIR`| `/tmp` (default)| Temporary folder on the host running the CLI and inside the LocalStack container .|
 | `HOST_TMP_FOLDER` | `/some/path` | Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false.` |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, Cognito users, etc). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
-| `LEGACY_FILESYSTEM` | `0` (default) | TODO |
+| `LEGACY_DIRECTORIES` | `0` (default) | Use legacy method of managing internal filesystem layout. See [filesystem layout]({{< ref "filesystem" >}}). |
 | `MULTI_ACCOUNTS` | `0` (default) | Enable multi-accounts (preview) |
 | `PERSISTENCE` | `0` (default) | Enable persistence. See [persistence mechanism]({{< ref "persistence-mechanism" >}}) and [filesystem layout]({{< ref "filesystem" >}}). |
-| `<SERVICE>_BACKEND` | | Custom endpoint URL to use for a specific service, where <SERVICE> is the uppercase service name. <!--See (TODO) for supported services and (TODO) for examples for third-party integration--> |
+| `<SERVICE>_BACKEND` | | Custom endpoint URL to use for a specific service, where <SERVICE> is the uppercase service name.
 | `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
 | `INIT_SCRIPTS_PATH` | `/some/path` | Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`. |
 | `LS_LOG` | `trace`, `trace-internal`, `debug`, `info`, `warn`, `error`, `warning`| Specify the log level. Currently overrides the `DEBUG` configuration. `trace` for detailed request/response, `trace-internal` for internal calls, too. |

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -27,12 +27,11 @@ $ SERVICES=kinesis,lambda,sqs,dynamodb DEBUG=1 localstack start
 | `USE_LIGHT_IMAGE` | `1` (default) | Whether to use the light-weight Docker image. Overwritten by `IMAGE_NAME`.|
 | `TMPDIR`| `/tmp` (default)| Temporary folder on the host running the CLI and inside the LocalStack container .|
 | `HOST_TMP_FOLDER` | `/some/path` | Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false.` |
-| `DATA_DIR`| blank (disabled/default), `/tmp/localstack/data` | Local directory for saving persistent data (see: TODO)|
-| `PERSISTENCE_SINGLE_FILE` | `true` (default)| Specify if persistence files should be combined (deprecated - only relevant for legacy persistence in Community version, not relevant for advanced persistence in Pro version). |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, Cognito users, etc). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
-| `LEGACY_PERSISTENCE` | `true` (default) | Whether to enable legacy persistence mechanism based on API calls record&replay (deprecated). Only relevant for Community version, not relevant for advanced persistence mechanism in Pro. |
+| `LEGACY_FILESYSTEM` | `0` (default) | TODO |
 | `MULTI_ACCOUNTS` | `0` (default) | Enable multi-accounts (preview) |
-| `<SERVICE>_BACKEND` | | Custom endpoint URL to use for a specific service, where <SERVICE> is the uppercase service name. See (TODO) for supported services and (TODO) for examples for third-party integration |
+| `PERSISTENCE` | `0` (default) | Enable persistence. See [persistence mechanism]({{< ref "persistence-mechanism" >}}) and [filesystem layout]({{< ref "filesystem" >}}). |
+| `<SERVICE>_BACKEND` | | Custom endpoint URL to use for a specific service, where <SERVICE> is the uppercase service name. <!--See (TODO) for supported services and (TODO) for examples for third-party integration--> |
 | `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
 | `INIT_SCRIPTS_PATH` | `/some/path` | Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`. |
 | `LS_LOG` | `trace`, `trace-internal`, `debug`, `info`, `warn`, `error`, `warning`| Specify the log level. Currently overrides the `DEBUG` configuration. `trace` for detailed request/response, `trace-internal` for internal calls, too. |
@@ -73,7 +72,7 @@ This section covers configuration values that are specific to certain AWS servic
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `GRAPHQL_ENDPOINT_STRATEGY` | `legacy`\|`domain`\|`path` |  Governs how AppSync endpoints are created to access a GraphQL API (see [AppSync#endpoints]({{< ref "appsync#endpoints" >}})) |
+| `GRAPHQL_ENDPOINT_STRATEGY` | `legacy`\|`domain`\|`path` |  Governs how AppSync endpoints are created to access a GraphQL API (see [AppSync Endpoints]({{< ref "appsync#endpoints" >}})) |
 
 ### Batch
 
@@ -113,9 +112,9 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `ES_CUSTOM_BACKEND` | `http://elasticsearch:9200` | *Deprecated*. Use [`OPENSEARCH_CUSTOM_BACKEND`](#opensearch) instead. URL to a custom elasticsearch backend cluster. If this is set to a valid URL, then localstack will not create elasticsearch cluster instances, but instead forward all domains to the given backend (see [Elasticsearch#custom-elasticsearch-backends]({{< ref "elasticsearch#custom-elasticsearch-backends" >}})). |
+| `ES_CUSTOM_BACKEND` | `http://elasticsearch:9200` | *Deprecated*. Use [`OPENSEARCH_CUSTOM_BACKEND`](#opensearch) instead. URL to a custom elasticsearch backend cluster. If this is set to a valid URL, then localstack will not create elasticsearch cluster instances, but instead forward all domains to the given backend (see [Custom Elasticsearch Backends]({{< ref "elasticsearch#custom-elasticsearch-backends" >}})). |
 | `ES_MULTI_CLUSTER` | `0`\|`1` | *Deprecated*. Use [`OPENSEARCH_MULTI_CLUSTER`](#opensearch) instead. When activated, LocalStack will spawn one Elasticsearch cluster per domain. Otherwise all domains will share a single cluster instance. This is ignored if `ES_CUSTOM_BACKEND` is set. |
-| `ES_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` (formerly `off`) | *Deprecated*. Use [`OPENSEARCH_ENDPOINT_STRATEGY`](#opensearch) instead. Governs how domain endpoints are created to access a cluster (see [Elasticsearch#endpoints]({{< ref "elasticsearch#endpoints" >}})) |
+| `ES_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` (formerly `off`) | *Deprecated*. Use [`OPENSEARCH_ENDPOINT_STRATEGY`](#opensearch) instead. Governs how domain endpoints are created to access a cluster (see [Elasticsearch Endpoints]({{< ref "elasticsearch#endpoints" >}})) |
 
 ### Kinesis
 
@@ -156,9 +155,9 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `OPENSEARCH_CUSTOM_BACKEND` | `http://opensearch:9200` | URL to a custom OpenSearch backend cluster. If this is set to a valid URL, then LocalStack will not create OpenSearch cluster instances, but instead forward all domains to the given backend (see [OpenSearch#custom-opensearch-backends]({{< ref "opensearch#custom-opensearch-backends" >}})). |
+| `OPENSEARCH_CUSTOM_BACKEND` | `http://opensearch:9200` | URL to a custom OpenSearch backend cluster. If this is set to a valid URL, then LocalStack will not create OpenSearch cluster instances, but instead forward all domains to the given backend (see [Custom Opensearch Backends]({{< ref "opensearch#custom-opensearch-backends" >}})). |
 | `OPENSEARCH_MULTI_CLUSTER` | `0`\|`1` | When activated, LocalStack will spawn one OpenSearch cluster per domain. Otherwise all domains will share a single cluster instance. This is ignored if `OPENSEARCH_CUSTOM_BACKEND` is set. |
-| `OPENSEARCH_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` | Governs how domain endpoints are created to access a cluster (see [OpenSearch#endpoints]({{< ref "opensearch#endpoints" >}})). |
+| `OPENSEARCH_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` | Governs how domain endpoints are created to access a cluster (see [Opensearch Endpoints]({{< ref "opensearch#endpoints" >}})). |
 
 ### StepFunctions
 
@@ -307,6 +306,9 @@ More information [here]({{< ref "pro" >}}).
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `USE_SSL` | `false` (default) | Whether to use https://... URLs with SSL encryption. *Deprecated as of version 0.11.3* - each service endpoint now supports multiplexing HTTP/HTTPS traffic over the same port.
-| `DEFAULT_REGION` | | AWS region to use when talking to the API (needs to be activated via `USE_SINGLE_REGION=1`). *Deprecated and inactive as of version 0.12.17* - LocalStack now has full multi-region support.
-| `USE_SINGLE_REGION` | | Whether to use the legacy single-region mode, defined via `DEFAULT_REGION`.
+| `USE_SSL` | `false` (default) | Whether to use https://... URLs with SSL encryption. Deprecated as of version 0.11.3. Each service endpoint now supports multiplexing HTTP/HTTPS traffic over the same port. |
+| `DEFAULT_REGION` | | AWS region to use when talking to the API (needs to be activated via `USE_SINGLE_REGION=1`). Deprecated and inactive as of version 0.12.17. LocalStack now has full multi-region support. |
+| `USE_SINGLE_REGION` | | Whether to use the legacy single-region mode, defined via `DEFAULT_REGION`. |
+| `LEGACY_PERSISTENCE` | `true` (default) | Whether to enable legacy persistence mechanism based on API calls record & replay. Only relevant for Community version, not relevant for advanced persistence mechanism in Pro. |
+| `PERSISTENCE_SINGLE_FILE` | `true` (default)| Specify if persistence files should be combined (only relevant for legacy persistence in Community version, not relevant for advanced persistence in Pro version). |
+| `DATA_DIR`| blank (disabled/default), `/tmp/localstack/data` | Local directory for saving persistent data. This option is deprecated since LocalStack v1. Please use `PERSISTENCE`. Using this option will set `PERSISTENCE=1` as a deprecation path. |

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -26,7 +26,6 @@ $ SERVICES=kinesis,lambda,sqs,dynamodb DEBUG=1 localstack start
 | `IMAGE_NAME`| `localstack/localstack` (default), `localstack/localstack:0.11.0` | Specific name and tag of LocalStack Docker image to use.|
 | `USE_LIGHT_IMAGE` | `1` (default) | Whether to use the light-weight Docker image. Overwritten by `IMAGE_NAME`.|
 | `TMPDIR`| `/tmp` (default)| Temporary folder on the host running the CLI and inside the LocalStack container .|
-| `HOST_TMP_FOLDER` | `/some/path` | Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false.` |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, Cognito users, etc). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
 | `LEGACY_DIRECTORIES` | `0` (default) | Use legacy method of managing internal filesystem layout. See [filesystem layout]({{< ref "filesystem" >}}). |
 | `MULTI_ACCOUNTS` | `0` (default) | Enable multi-accounts (preview) |
@@ -136,7 +135,7 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 | `LAMBDA_STAY_OPEN_MODE` | `1` (default) | Usage of the [stay-open mode]({{< ref "lambda-executors#stay-open-mode" >}}) of Lambda containers. Only applicable if `LAMBDA_EXECUTOR=docker-reuse`. Set to `0` if you want to use [Hot Swapping]({{< ref "hot-swapping" >}}).|
 | `LAMBDA_REMOTE_DOCKER` | | determines whether Lambda code is copied or mounted into containers |
 | | `true` (default) | your Lambda function definitions will be passed to the container by copying the zip file (potentially slower). It allows for remote execution, where the host and the client are not on the same machine.|
-| | `false` | your Lambda function definitions will be passed to the container by mounting a volume (potentially faster). This requires to have the Docker client and the Docker host on the same machine. Also, `HOST_TMP_FOLDER` must be set properly, and a volume mount like `${HOST_TMP_FOLDER}:/tmp/localstack` needs to be configured if you're using docker-compose. |
+| | `false` | your Lambda function definitions will be passed to the container by mounting a volume (potentially faster). This requires to have the Docker client and the Docker host on the same machine. |
 | `LAMBDA_TRUNCATE_STDOUT` | `2000` | Allows increasing the default char value for truncation of lambda logs.|
 | `BUCKET_MARKER_LOCAL` | | Optional bucket name for running lambdas locally.|
 | `LAMBDA_CODE_EXTRACT_TIME` | `25` | Time in seconds to wait at max while extracting Lambda code. By default it is 25 seconds for limiting the execution time to avoid client/network timeout issues.| 
@@ -312,3 +311,4 @@ More information [here]({{< ref "pro" >}}).
 | `LEGACY_PERSISTENCE` | `true` (default) | Whether to enable legacy persistence mechanism based on API calls record & replay. Only relevant for Community version, not relevant for advanced persistence mechanism in Pro. |
 | `PERSISTENCE_SINGLE_FILE` | `true` (default)| Specify if persistence files should be combined (only relevant for legacy persistence in Community version, not relevant for advanced persistence in Pro version). |
 | `DATA_DIR`| blank (disabled/default), `/tmp/localstack/data` | Local directory for saving persistent data. This option is deprecated since LocalStack v1. Please use `PERSISTENCE`. Using this option will set `PERSISTENCE=1` as a deprecation path. |
+| `HOST_TMP_FOLDER` | `/some/path` | Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false.` |

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -258,7 +258,7 @@ python -m localstack.cli.main --profile=dev config show
 | `DISABLE_EVENTS` | `1` | Whether to disable publishing LocalStack events
 | `OUTBOUND_HTTP_PROXY` | `http://10.10.1.3` | HTTP Proxy used for downloads of runtime dependencies and connections outside LocalStack itself
 | `OUTBOUND_HTTPS_PROXY` | `https://10.10.1.3` | HTTPS Proxy used for downloads of runtime dependencies and connections outside LocalStack itself
-| `REQUESTS_CA_BUNDLE` | `/tmp/localstack/ca_bundle.pem` | CA Bundle to be used to verify HTTPS requests made by LocalStack
+| `REQUESTS_CA_BUNDLE` | `/var/lib/localstack/lib/ca_bundle.pem` | CA Bundle to be used to verify HTTPS requests made by LocalStack
 | `DISABLE_TERM_HANDLER` | | Whether to disable signal passing to LocalStack when running in docker. Enabling this will prevent an orderly shutdown when running inside LS in docker.
 
 
@@ -310,5 +310,5 @@ More information [here]({{< ref "pro" >}}).
 | `USE_SINGLE_REGION` | | Whether to use the legacy single-region mode, defined via `DEFAULT_REGION`. |
 | `LEGACY_PERSISTENCE` | `true` (default) | Whether to enable legacy persistence mechanism based on API calls record & replay. Only relevant for Community version, not relevant for advanced persistence mechanism in Pro. |
 | `PERSISTENCE_SINGLE_FILE` | `true` (default)| Specify if persistence files should be combined (only relevant for legacy persistence in Community version, not relevant for advanced persistence in Pro version). |
-| `DATA_DIR`| blank (disabled/default), `/tmp/localstack/data` | Local directory for saving persistent data. This option is deprecated since LocalStack v1. Please use `PERSISTENCE`. Using this option will set `PERSISTENCE=1` as a deprecation path. |
+| `DATA_DIR`| blank (disabled/default), `/tmp/localstack/data` | Local directory for saving persistent data. This option is deprecated since LocalStack v1 and will be ignored. Please use `PERSISTENCE`. Using this option will set `PERSISTENCE=1` as a deprecation path. The state will be stored in your LocalStack volume in the `state/` directory |
 | `HOST_TMP_FOLDER` | `/some/path` | Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false.` |

--- a/content/en/localstack/filesystem.md
+++ b/content/en/localstack/filesystem.md
@@ -1,0 +1,6 @@
+---
+title: "Filesystem Layout"
+weight: 5
+description: >
+  Overview of runtime directory structure
+---

--- a/content/en/localstack/filesystem.md
+++ b/content/en/localstack/filesystem.md
@@ -4,3 +4,70 @@ weight: 5
 description: >
   Overview of runtime directory structure
 ---
+
+This page describes the filesystem directory layout used internally by LocalStack.
+
+LocalStack uses following directories when running within a container.
+
+- `/var/lib/localstack`: the root directory
+- `/var/lib/localstack/lib`: variable packages (like lazy-loaded third-party dependencies)
+- `/var/lib/localstack/logs`: logs for recent LocalStack runs
+- `/var/lib/localstack/state`: persistence state of third-party services (or what is sometimes called 'data' or 'assets', e.g., Opensearch cluster data)
+- `/var/lib/localstack/tmp`: temporary data that is not expected to survive LocalStack runs (may be cleared when LocalStack starts)
+- `/var/lib/localstack/cache`: temporary data that is expected to survive LocalStack runs (is not cleared when LocalStack starts)
+- `/usr/lib/localstack`: static third-party packages installed into the container images
+<!-- For future use, not currently in use
+- `/etc/localstack`: configuration directory
+- `/etc/localstack/conf.d`: configuration overrides
+- `/etc/localstack/init`: initialisation hooks
+-->
+
+In order to persist data across runs, these directories must be mounted from the host into the container.
+For Docker Compose, this can be achieved using following:
+
+```yaml
+volumes:
+  - "${TMPDIR}/localstack:/var/lib/localstack"
+```
+
+`${TMPDIR}` could be an arbitrary location on the host e.g. `/some/path/`.
+In this case the effective layout would be something like:
+
+```
+$ tree -L 4 /some/path/localstack
+.
+└── localstack
+    ├── cache
+    │   ├── machine.json
+    │   ├── server.test.pem
+    │   ├── server.test.pem.crt
+    │   └── server.test.pem.key
+    ├── lib
+    │   └── opensearch
+    │       └── 1.1.0
+    ├── logs
+    │   ├── localstack_infra.err
+    │   └── localstack_infra.log
+    ├── state
+    │   ├── recorded_api_calls.json
+    │   └── startup_info.json
+    └── tmp
+        └── zipfile.4986fb95
+```
+
+
+{{< alert title="Warning" color="warning">}}
+`DATA_DIR` and `HOST_TMP_DIR` are deprecated since LocalStack v1.
+
+`DATA_DIR` implicitly points to `/var/lib/localstack/state`.
+Use `PERSISTENCE=1` to enable persistence.
+If `DATA_DIR` is set, its value is ignored, a warning is logged and `PERSISTENCE` is set to `1`.
+
+`HOST_TMP_FOLDER` is determined by inspecting the volume mounts and using the source of the bind mount to `/var/lib/localstack`.
+{{< /alert >}}
+
+
+When LocalStack is running in host mode, the system `/usr/lib/localstack` or `/var/lib/localstack` are not used.
+Instead, the root directory is changed to `FILESYSTEM_ROOT` which defaults to `./.filesystem`, i.e. the LocalStack project root.
+
+<!-- For further details, see https://github.com/localstack/localstack/pull/6302, https://github.com/localstack/localstack/pull/5011 -->

--- a/content/en/localstack/filesystem.md
+++ b/content/en/localstack/filesystem.md
@@ -16,7 +16,7 @@ LocalStack uses following directories when running within a container.
 - `/var/lib/localstack`: the root directory
 - `/var/lib/localstack/lib`: variable packages (like lazy-loaded third-party dependencies)
 - `/var/lib/localstack/logs`: logs for recent LocalStack runs
-- `/var/lib/localstack/state`: persistence state of third-party services (or what is sometimes called 'data' or 'assets', e.g., Opensearch cluster data)
+- `/var/lib/localstack/state`: persistence state of services (or what is sometimes called 'data' or 'assets', e.g., Opensearch cluster data)
 - `/var/lib/localstack/tmp`: temporary data that is not expected to survive LocalStack runs (may be cleared when LocalStack starts)
 - `/var/lib/localstack/cache`: temporary data that is expected to survive LocalStack runs (is not cleared when LocalStack starts)
 - `/usr/lib/localstack`: static third-party packages installed into the container images
@@ -35,7 +35,7 @@ volumes:
 ```
 
 `${TMPDIR}` could be an arbitrary location on the host e.g. `/some/path/`.
-In this case the effective layout would be something like:
+In such case the effective layout would be something like:
 
 ```
 $ tree -L 4 /some/path/localstack

--- a/content/en/localstack/filesystem.md
+++ b/content/en/localstack/filesystem.md
@@ -7,6 +7,10 @@ description: >
 
 This page describes the filesystem directory layout used internally by LocalStack.
 
+{{< alert title="Information" color="primary">}}
+This filesystem hierarchy was introduced in LocalStack v1 and can be disabled by setting `LEGACY_DIRECTORIES` to `1`.
+{{< /alert >}}
+
 LocalStack uses following directories when running within a container.
 
 - `/var/lib/localstack`: the root directory

--- a/content/en/localstack/persistence-mechanism/index.md
+++ b/content/en/localstack/persistence-mechanism/index.md
@@ -68,7 +68,7 @@ While this approach is generic enough to cover a sizable amount of services, the
 ### Persistence Mechanism - Pro Version
 
 The persistence mechanism of the Pro version is much more sophisticated and is based on *serialized state*.
-Starting the Pro version of LocalStack will traverse the persist storage directory recursively and directly deserialize the file into the application state.
+Starting the Pro version of LocalStack will traverse the state directory recursively and directly deserialize the file into the application state.
 Typically, each service has one state file for each region.
 
 Each serialization mechanism has its own root folder.

--- a/content/en/localstack/persistence-mechanism/index.md
+++ b/content/en/localstack/persistence-mechanism/index.md
@@ -21,7 +21,7 @@ To enable the persistence mechanism simply set the `PERSISTENCE` environment var
       - LOCALSTACK_API_KEY=...
       - PERSISTENCE=1
     volumes:
-      - ${TMPDIR:-/tmp/localstack}:/var/lib/localstack
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
 ```
 
 Once the application has been set and configured properly, the `/health` endpoint of LocalStack will indicate whether the persistence mechanism has been initialized successfully.
@@ -75,7 +75,7 @@ Each serialization mechanism has its own root folder.
 As of now, all supported services are serialized as pickle files, except for Kinesis (which is serialized as JSON) and DynamoDB (which is serialized as an SQLite database).
 This is illustrated with the diagram below.
 
-![Structure of the DATA_DIR](datadir_structure.png)
+![Structure of the state directory](datadir_structure.png)
 
 This approach does not suffer from the same limitations as *record-and-replay*.
 Restoring the state -- even for large projects -- usually only takes a few milliseconds.

--- a/content/en/localstack/persistence-mechanism/index.md
+++ b/content/en/localstack/persistence-mechanism/index.md
@@ -15,18 +15,13 @@ Please note that the coverage is only guaranteed for the Pro version, while the 
 
 To enable the persistence mechanism simply set the `PERSISTENCE` environment variable to `1`.
 
-When working with Docker you may want to specify a different location for temporary folders using the `HOST_TMP_FOLDER` flag.
-In this case, it is advisable to use a `$TMPDIR` variable, which you can re-use for both flags.
-For instance, you'll set `$TMPDIR=/tmp/my-tmp` then your environment configuration in your `docker-compose` file could look as follows: 
-
 ```yaml
     ...
     environment:
       - LOCALSTACK_API_KEY=...
       - PERSISTENCE=1
-      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
-      - ${TMPDIR}:/tmp/localstack
+      - ${TMPDIR:-/tmp/localstack}:/var/lib/localstack
 ```
 
 Once the application has been set and configured properly, the `/health` endpoint of LocalStack will indicate whether the persistence mechanism has been initialized successfully.

--- a/content/en/localstack/persistence-mechanism/index.md
+++ b/content/en/localstack/persistence-mechanism/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Persistence Mechanism Configuration"
+title: "Persistence Mechanism"
 weight: 5
 description: >
   How the LocalStack persistence mechanism works and how you can configure it.
@@ -11,11 +11,9 @@ Commonly, you may simply have a local development server that relies on a non-ep
 
 While the persistence mechanism covers most services, not all of them are supported yet.
 Please make sure to check the [feature coverage page]({{< ref "feature-coverage" >}}) to see whether your desired services are covered.
-Please note that the coverage is only guaranteed for the _Pro_ version, while the _Community_ version attempts to restore the state on a best-effort basis using a *record-and-replay* approach (more on that in the [Technical Details]({{< ref "#technical-details" >}}) section).
+Please note that the coverage is only guaranteed for the Pro version, while the Community version attempts to restore the state on a best-effort basis using a *record-and-replay* approach (more on that in the [Technical Details]({{< ref "#technical-details" >}}) section).
 
-To enable the persistence mechanism simply set the `DATA_DIR` environment variable.
-For instance, `DATA_DIR=/tmp/localstack/data` will store all relevant files to the `/tmp/localstack/data` directory.
-Please note that the path is created recursively, that is you do not have to make sure that the set path exists.
+To enable the persistence mechanism simply set the `PERSISTENCE` environment variable to `1`.
 
 When working with Docker you may want to specify a different location for temporary folders using the `HOST_TMP_FOLDER` flag.
 In this case, it is advisable to use a `$TMPDIR` variable, which you can re-use for both flags.
@@ -25,7 +23,7 @@ For instance, you'll set `$TMPDIR=/tmp/my-tmp` then your environment configurati
     ...
     environment:
       - LOCALSTACK_API_KEY=...
-      - DATA_DIR=${TMPDIR}/localstack/data
+      - PERSISTENCE=1
       - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
       - ${TMPDIR}:/tmp/localstack
@@ -75,7 +73,7 @@ While this approach is generic enough to cover a sizable amount of services, the
 ### Persistence Mechanism - Pro Version
 
 The persistence mechanism of the Pro version is much more sophisticated and is based on *serialized state*.
-Starting the Pro version of LocalStack will traverse the `DATA_DIR` root folder recursively and directly deserialize the file into the application state.
+Starting the Pro version of LocalStack will traverse the persist storage directory recursively and directly deserialize the file into the application state.
 Typically, each service has one state file for each region.
 
 Each serialization mechanism has its own root folder.


### PR DESCRIPTION
- Adds new page describing the new filesystem hierarchy
- Updates references to deprecated vars `DATA_DIR` and `HOST_TMP_DIR` everywhere

Followup to https://github.com/localstack/localstack/pull/6302/