### PR TITLE
fix last-modified data by fetching repo history in build action

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
+          fetch-depth: 0
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
This commit fixes the "Last modified" footer on the pages. Previously they only showed the last commit, because the GitHub action building the static website only checked out the last commit.
With this PR, the action checks out the whole history and can therefore correctly determine the commit which edited the specific page.
Thanks to @viren-nadkarni for noticing / reporting. :)