### PR TITLE
Remove network_mode: bridge and workarounds

### DIFF
--- a/content/en/aws/elasticsearch/index.md
+++ b/content/en/aws/elasticsearch/index.md
@@ -213,7 +213,6 @@ services:
   elasticsearch:
     container_name: elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
-    network_mode: bridge
     environment:
       - node.name=elasticsearch
       - cluster.name=es-docker-cluster
@@ -232,7 +231,6 @@ services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack
-    network_mode: bridge
     ports:
       - "4566:4566"
     depends_on:
@@ -246,8 +244,6 @@ services:
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
-    links:
-      - elasticsearch
 
 volumes:
   data01:

--- a/content/en/aws/opensearch/index.md
+++ b/content/en/aws/opensearch/index.md
@@ -255,7 +255,6 @@ services:
   opensearch:
     container_name: opensearch
     image: opensearchproject/opensearch:1.1.0
-    network_mode: bridge
     environment:
       - node.name=opensearch
       - cluster.name=opensearch-docker-cluster
@@ -275,7 +274,6 @@ services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack
-    network_mode: bridge
     ports:
       - "4566:4566"
     depends_on:
@@ -288,8 +286,6 @@ services:
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
-    links:
-      - opensearch
 
 volumes:
   data01:

--- a/content/en/integrations/kafka/docker-compose.yml
+++ b/content/en/integrations/kafka/docker-compose.yml
@@ -53,7 +53,6 @@ services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack
-    network_mode: bridge
     ports:
       - "4566:4566"
     depends_on:


### PR DESCRIPTION
This PR removes the `network_mode: bridge` and the workarounds necessary, namely the container links in elasticsearch/opensearch.

This should work out of the box with user-defined docker networks (as per default used by docker)

TODO:

- [ ] test changes