### PR TITLE
fix opensearch custom cluster sample

### DIFF
--- a/content/en/aws/opensearch/index.md
+++ b/content/en/aws/opensearch/index.md
@@ -303,7 +303,7 @@ $ docker-compose up -d
 
 2. Create the OpenSearch domain:
 {{< command >}}
-$ awslocal opensearch create-domain --domain-name my-cluster
+$ awslocal opensearch create-domain --domain-name my-domain
 {
     "DomainStatus": {
         "DomainId": "000000000000/my-domain",
@@ -405,7 +405,7 @@ $ curl my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/_cluster/h
 
 5. Create an example index:
 {{< command >}}
-$ curl -X PUT my-domain.us-east-1.es.localhost.localstack.cloud:4566/my-index
+$ curl -X PUT my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/my-index
 {"acknowledged":true,"shards_acknowledged":true,"index":"my-index"}
 {{< /command >}}
 


### PR DESCRIPTION
While testing for PR #192 , I noticed some inconsistencies in the sample, which are fixed by this PR:
* Domain name in command did not match output or subsequent operations
* Opensearch domain contained `.es.` instead of `.opensearch.`, leading to it being routed to S3.