### PR TITLE
Update docker port range on pro documentation

### DIFF
--- a/content/en/get-started/pro/index.md
+++ b/content/en/get-started/pro/index.md
@@ -53,7 +53,7 @@ When starting LocalStack using a `docker run` command, you have to specify the A
 $ docker run \
   --rm -it \
   -p 4566:4566 \
-  -p 4571:4571 \
+  -p 4510-4559:4510-4559 \
   -e LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY:- } \
   localstack/localstack
 {{< / command >}}


### PR DESCRIPTION
The docker port range doesn't seem to reflect the latest port ranges. I have updated it.