### PR TITLE
Remove mention of SERVICES except configuration.md

### DIFF
--- a/content/en/aws/s3/index.md
+++ b/content/en/aws/s3/index.md
@@ -41,8 +41,6 @@ $ awslocal s3api put-object --bucket sample-bucket --key index.html --body index
 }
 {{< / command >}}
 
- When working with the `SERVICES` environment variable, please make sure to include `s3` in the list of services.
-For instance, to load the S3, SQS, and Kinesis service you'd pass the variable as `SERVICES=s3,sqs,kinesis`.
 
 {{% alert title="Path-Style Requests versus Virtual Hosted-Style Requests " color="info" %}}
 Just like AWS, LocalStack differentiates between [Path-Style and Virtual Hosted-Style Requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) depending on your `Host` header for a request.

--- a/content/en/get-started/_index.md
+++ b/content/en/get-started/_index.md
@@ -116,8 +116,7 @@ $ localstack start
 {{< / command >}}
 
 {{< alert title="Notes" >}}
-- This command starts all services provided by LocalStack.
-  You can limit the services to a subset by setting the environment variable `SERVICES` (for example with `SERVICES="dynamodb,s3" localstack start`).
+- This command loads all services provided by LocalStack, they will however be started on the first request reaching this service.
 
 - By default, LocalStack uses the image tagged `latest` that is cached on your machine, and will **not** pull the latest image automatically from Docker Hub (i.e., the image needs to be pulled manually if needed).
 
@@ -156,7 +155,7 @@ $ docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack
   This could be seen as the "expert mode" of starting LocalStack.
   If you are looking for a simpler method of starting LocalStack, please use the [LocalStack CLI]({{< ref "#localstack-cli" >}}).
 
-- To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker. For instance, setting `LOCALSTACK_SERVICES=s3` is equivalent to `SERVICES=s3`.
+- To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker. For instance, setting `LOCALSTACK_PERSISTENCE=1` is equivalent to `PERSISTENCE=1`.
 {{< /alert >}}
 
 ### Docker-Compose
@@ -181,7 +180,7 @@ $ docker-compose up
 
 - On MacOS you may have to run `TMPDIR=/private$TMPDIR docker-compose up` if `$TMPDIR` contains a symbolic link that cannot be mounted by Docker.
 
-- To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker. For instance, setting `LOCALSTACK_SERVICES=s3` is equivalent to `SERVICES=s3`.
+- To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker. For instance, setting `LOCALSTACK_PERSISTENCE=1` is equivalent to `PERSISTENCE=1`.
 
 - Before 0.13: If you do not connect your LocalStack container to the default bridge network with `network_mode: bridge` as in the example, you need to set `LAMBDA_DOCKER_NETWORK=<docker-compose-network>`. 
 

--- a/content/en/get-started/pro/index.md
+++ b/content/en/get-started/pro/index.md
@@ -86,9 +86,6 @@ $ curl localhost:4566/health | jq
 
 If a Pro-only [service]({{< ref "aws" >}}) -- like [XRay]({{< ref "XRay-Tracing" >}}) -- is running, LocalStack Pro or Enterprise has started successfully.
 
-**Note**: This only works if your `SERVICES` config variable contains LocalStack Pro services.
-If in doubt, try starting LocalStack without this variable set, so all services can start.
-
 Otherwise, please check our collected most [common activation issues](#common-activation-issues).
 
 ## Common activation issues

--- a/content/en/integrations/architect/index.md
+++ b/content/en/integrations/architect/index.md
@@ -38,12 +38,7 @@ $ arclocal init
 
 ### Deployment
 
-Now you need to start LocalStack. For Architect to work properly, you need to start the following services in LocalStack (using the `SERVICES` [configuration option]({{< ref "configuration.md" >}})):
- - s3 
- - ssm
- - cloudformation
-
-After LocalStack has started you can deploy your Architect setup via:
+Now you need to start LocalStack. After LocalStack has started you can deploy your Architect setup via:
 {{< command >}}
 $ arclocal deploy
 {{< / command >}}

--- a/content/en/integrations/kafka/docker-compose.yml
+++ b/content/en/integrations/kafka/docker-compose.yml
@@ -59,7 +59,6 @@ services:
       - kafka
       - kowl
     environment:
-      - SERVICES=lambda,secretsmanager
       - DEBUG=${DEBUG- }
       - PERSISTENCE=${PERSISTENCE- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -9,14 +9,14 @@ LocalStack allows for many different configuration options.
 You can pass these via environment variables, e.g., like the following:
 
 {{< command >}}
-$ SERVICES=kinesis,lambda,sqs,dynamodb DEBUG=1 localstack start
+$ DEBUG=1 localstack start
 {{< / command >}}
 
 ## Core
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `SERVICES` | `kinesis,lambda,sqs`,`serverless`| Comma-separated list of [AWS CLI service names][1] or shorthands to start up. |
+| `SERVICES` | `kinesis,lambda,sqs`,`serverless`| Only works with `EAGER_SERVICE_LOADING=1`. Comma-separated list of [AWS CLI service names][1] or shorthands to start. Per default, all services are loaded and started on the first request for that service. |
 | `EDGE_BIND_HOST` | `127.0.0.1` (default), `0.0.0.0` (docker)| Address the edge service binds to.|
 | `EDGE_PORT` | `4566` (default)| Port number for the edge service, the main entry point for all API invocations. |
 | `HOSTNAME`| `localhost` (default) | Name of the host to expose the services internally. For framework-internal communication, e.g., services are started in different containers using docker-compose.|


### PR DESCRIPTION
The `SERVICES` variable is often misused and should not be actively promoted in the documentation, especially in regards with localstack/localstack#6438 .

This removes a bunch of references to the variable, and specifies its newly-introduced limitations in LocalStack.