### PR TITLE
Fixed minor typo in Cloud Pods documentation

### DIFF
--- a/content/en/tools/cloud-pods/_index.md
+++ b/content/en/tools/cloud-pods/_index.md
@@ -36,7 +36,7 @@ $ awslocal kinesis list-streams
 
 {{% alert title="Current Limitations" color="info" %}}
 Currently, Cloud Pods CLI commands require to set a `LOCALSTACK_API_KEY`.
-Additionalky, they require to install `localstack` runtime dependencies. 
+Additionally, they require to install `localstack` runtime dependencies. 
 You can install them with `pip install localstack"[runtime]"`.
 {{% /alert %}}
 


### PR DESCRIPTION
I found a small typo when I was reading the [Cloud Pods documentation](https://docs.localstack.cloud/tools/cloud-pods/).
Note that since this is just a minor documentation change, I didn't setup my local dev environment and I haven't run any tests/linting.