### PR TITLE
Add notes around custom Postgres versions and RDS_PG_CUSTOM_VERSIONS

### DIFF
--- a/content/en/aws/rds/index.md
+++ b/content/en/aws/rds/index.md
@@ -6,11 +6,23 @@ description: >
   Relational Database Service (RDS)
 ---
 
-LocalStack supports a basic version of [RDS](https://aws.amazon.com/rds/) for testing. Currently, it is possible to spin up PostgreSQL, MySQL, and MSSQL (SQL Server) databases on the local machine.
+LocalStack supports a basic version of the [Relational Database Service (RDS)](https://aws.amazon.com/rds/) for testing.
+
+## Supported DB engines
+
+Currently, it is possible to spin up PostgreSQL, MySQL, and MSSQL (SQL Server) databases on the local machine.
 
 {{< alert title="Note" >}}
 In order to use MSSQL databases, you need to explicitly accept the [Microsoft SQL Server End-User Licensing Agreement (EULA)](https://hub.docker.com/_/microsoft-mssql-server) by setting `MSSQL_ACCEPT_EULA=Y` in the LocalStack container environment.
 {{< /alert >}}
+
+### Postgres versions
+
+When creating an RDS DB cluster or instance with `postgres`/`aurora-postgresql` DB engine, by default Postgres version 11 is used. 
+In order to use custom versions, make sure to configure the environment variable `RDS_PG_CUSTOM_VERSIONS=1`, which then causes LocalStack to install and start up the respective Postgres version on demand.
+Currently, versions 11/12/13 can be installed - when selecting a major version outside of this range, the default version 11 is used as fallback.
+
+## End-to-end example (Postgres)
 
 The local RDS service also supports the [RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html), which allows executing data queries against RDS clusters over a JSON/REST interface. Below is a simple example that illustrates (1) creation of an RDS cluster, (2) creation of a SecretsManager secret with the DB password, and (3) running a simple `SELECT 123` query via the RDS Data API.
 {{< command >}}
@@ -72,9 +84,10 @@ $ psql -d test -U test -p 4513 -h localhost -W
 Password: <enter "test">
 {{< / command >}}
 
-{{< alert title="Notes" >}}
+## Default usernames and passwords
+
+Please consider the following notes regarding default usernames/passwords and database names:
 - The default for `master-username` and `db-name` is "test". The default `master-user-password` is "test" - except for MSSQL DBs, which uses "Test123!" as the default master password.
 - You can use any `master-username`, except "postgres", for creating a new RDS instance. The user will automatically be created.
 - The user "postgres" is special, and it is not possible to create a new RDS instance with this user name.
 - Do not use `db-name` "postgres" as it is already in use by LocalStack.
-{{< /alert >}}

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -170,12 +170,17 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 | `OPENSEARCH_MULTI_CLUSTER` | `0`\|`1` | When activated, LocalStack will spawn one OpenSearch cluster per domain. Otherwise all domains will share a single cluster instance. This is ignored if `OPENSEARCH_CUSTOM_BACKEND` is set. |
 | `OPENSEARCH_ENDPOINT_STRATEGY` | `path`\|`domain`\|`port` | Governs how domain endpoints are created to access a cluster (see [Opensearch Endpoints]({{< ref "opensearch#endpoints" >}})). |
 
+### RDS
+
+| Variable | Example Values | Description |
+| - | - | - |
+| `RDS_PG_CUSTOM_VERSIONS` | `1` / `0` (default) | Whether to install and use custom Postgres versions for RDS (or alternatively, use default version 11). |
+
 ### StepFunctions
 
 | Variable | Example Values | Description |
 | - | - | - |
 | `STEPFUNCTIONS_LAMBDA_ENDPOINT` | `default` | URL to use as the Lambda service endpoint in Step Functions. By default this is the LocalStack Lambda endpoint. Use default to select the original AWS Lambda endpoint. |
-
 
 ### SQS
 


### PR DESCRIPTION
Add notes around custom Postgres versions and `RDS_PG_CUSTOM_VERSIONS`. Also added a few section titles, to introduce a bit more structure to the page.