### PR TITLE
Fix cloudfront dns configuration link

### DIFF
--- a/content/en/aws/cloudfront/index.md
+++ b/content/en/aws/cloudfront/index.md
@@ -20,7 +20,7 @@ $ curl -k https://$domain/hello.txt
 {{< / command >}}
 
 {{< alert >}}
-**Note:** In order for CloudFront to be fully functional, your local DNS setup needs to be properly configured. See the section on [configuring the local DNS server]({{< ref "#configuring-local-dns-server" >}}) for details.
+**Note:** In order for CloudFront to be fully functional, your local DNS setup needs to be properly configured. See the section on [configuring the local DNS server]({{< ref "tools/local-endpoint-injection/dns-server" >}}) for details.
 {{< /alert >}}
 
 {{< alert >}}


### PR DESCRIPTION
The link was taken directly from the old, on-website docs, and was never adapted.

This PR sets the correct link.