### PR TITLE
switch from Lunr to Algolia DocSearch

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -250,3 +250,12 @@ table {
 .coverage-report table .collapsing {
     transition: none !important;
   }
+
+
+#td-sidebar-menu {
+    padding-top: 0.5rem
+}
+
+.td-sidebar-nav {
+    padding-top: 0.5rem
+}

--- a/config.toml
+++ b/config.toml
@@ -126,10 +126,10 @@ github_branch= "main"
 # gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Algolia DocSearch
-algolia_docsearch = false
+algolia_docsearch = true
 
 # Enable Lunr.js offline search
-offlineSearch = true
+offlineSearch = false
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false
@@ -151,7 +151,7 @@ navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+sidebar_search_disable = true
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,7 @@
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+<script type="text/javascript">docsearch({
+  container: '#docsearch',
+  appId: 'XBW1JU7CW5',
+  apiKey: '6b0341e2f50196d328d088dbb5cd6166',
+  indexName: 'localstack',
+  });</script>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />


### PR DESCRIPTION
`docs.localstack.cloud` was accepted for Algolia's DocSearch program!

This PR is in direct competition to #218.
It integrates Algolia search instead of the current "offline" Lunr search.
The search does not have any Ads, has better results, and imho looks way better than the Google Custom Search:
![image](https://user-images.githubusercontent.com/2796604/182796492-4a892e00-ec90-403c-b301-5974510acd6e.png)

You can play around with it in the preview deployment :)
Let me know what you think!