### PR TITLE
Update docs around RDS_PG_CUSTOM_VERSIONS

### DIFF
--- a/content/en/aws/rds/index.md
+++ b/content/en/aws/rds/index.md
@@ -18,9 +18,10 @@ In order to use MSSQL databases, you need to explicitly accept the [Microsoft SQ
 
 ### Postgres versions
 
-When creating an RDS DB cluster or instance with `postgres`/`aurora-postgresql` DB engine, by default Postgres version 11 is used. 
-In order to use custom versions, make sure to configure the environment variable `RDS_PG_CUSTOM_VERSIONS=1`, which then causes LocalStack to install and start up the respective Postgres version on demand.
+When creating an RDS DB cluster or instance with `postgres`/`aurora-postgresql` DB engine and a specific `EngineVersion`, LocalStack will install and provision the respective Postgres version on demand.
 Currently, versions 11/12/13 can be installed - when selecting a major version outside of this range, the default version 11 is used as fallback.
+
+In order to disable installation of custom versions, you may configure the environment variable `RDS_PG_CUSTOM_VERSIONS=0`, in which case always the default Postgres version 11 will be used.
 
 ## End-to-end example (Postgres)
 

--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -176,7 +176,7 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `RDS_PG_CUSTOM_VERSIONS` | `1` / `0` (default) | Whether to install and use custom Postgres versions for RDS (or alternatively, use default version 11). |
+| `RDS_PG_CUSTOM_VERSIONS` | `0` / `1` (default) | Whether to install and use custom Postgres versions for RDS (or alternatively, use default version 11). |
 
 ### StepFunctions
 


### PR DESCRIPTION
Update docs around `RDS_PG_CUSTOM_VERSIONS` - the default value is changing from `false` to `true` in the upcoming minor release `1.1.0`.