### PR TITLE
add info about failing github runners

### DIFF
--- a/content/en/ci/github-actions/index.md
+++ b/content/en/ci/github-actions/index.md
@@ -76,5 +76,5 @@ Please manually upgrade by running `pip install --upgrade pyopenssl` before inst
 [See here for more information](https://github.com/localstack/localstack/pull/6831#issuecomment-1241974114)
 
 [1]: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#steps "GitHub Action Build Steps"
-[2]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsenv "GitHub Action Steps - Environment variables"
+[2]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsenv "GitHub Action Steps - Environment variables"
 [3]: https://docs.github.com/en/actions/security-guides/encrypted-secrets "GitHub Encrypted Secrets"

--- a/content/en/ci/github-actions/index.md
+++ b/content/en/ci/github-actions/index.md
@@ -66,6 +66,15 @@ There, you create the secret for your API key like in the following image, repla
 
 ![Adding the LocalStack API key as secret in GitHub](github-create-secret.png)
 
+## Troubleshooting / FAQ
+
+### Installations fails with `AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'`
+
+The issue is caused by a conflict of the pre-installed version of `pyOpenSSL` with newer versions of `cryptography`.
+Please manually upgrade by running `pip install --upgrade pyopenssl` before installing localstack to solve this issue.
+
+[See here for more information](https://github.com/localstack/localstack/pull/6831#issuecomment-1241974114)
+
 [1]: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#steps "GitHub Action Build Steps"
 [2]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsenv "GitHub Action Steps - Environment variables"
 [3]: https://docs.github.com/en/actions/security-guides/encrypted-secrets "GitHub Encrypted Secrets"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Hugo theme for technical documentation.",
   "main": "none.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "hugo server --watch=true --disableFastRender -D"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds info about the conflict between the two python libraries `pyopenssl` (when running an older version) and `cryptography`.

See https://github.com/localstack/localstack/pull/6831#issuecomment-1241974114