### PR TITLE
DOCS: Add docs to customize default IAM/STS user via config options

### DIFF
--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -127,6 +127,8 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 | `ENFORCE_IAM` | `0` (default)\|`1` | Enable IAM policy evaluation and enforcement. If this is disabled (the default), IAM policies will have no effect to your requests. |
 | `LEGACY_IAM_PROVIDER` | `0` (default)\|`1` | (deprecated) Enable the pre-1.0 legacy IAM provider |
 | `IAM_SOFT_MODE` | `0` (default)\|`1` | Enable IAM soft mode. This leads to policy evaluation without actually denying access. Needs `ENFORCE_IAM` enabled as well. For more information, see [Identity and Access Management]({{< ref "iam" >}}).|
+| `TEST_IAM_USER_ID` | | Customize the default IAM user ID for testing. |
+| `TEST_IAM_USER_NAME` | | Customize the default IAM user name for testing. |
 
 ### Kinesis
 


### PR DESCRIPTION
Adds docs as referenced by @whummer over the LocalStack Community repository: https://github.com/localstack/localstack/pull/5206 