### PR TITLE
Add docs for EKS LB ports config and host-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ PS.: Feel free to add more best practices here.
 
 ## Troubleshooting
 This section covers common issues when working with LocalStack Docs:
+
 ### Missing shortcodes
 Example error:
 ```


### PR DESCRIPTION
* add docs for EKS load balancer ports config (via `_lb_ports_` cluster tags)
* add section and sample for host-based routing
* rename `__k3d_volume_mount__` to `_volume_mount_` and add deprecation notice