### PR TITLE
Remove multi-accounts feature flag

### DIFF
--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -24,7 +24,6 @@ $ DEBUG=1 localstack start
 | `IMAGE_NAME`| `localstack/localstack` (default), `localstack/localstack:0.11.0` | Specific name and tag of LocalStack Docker image to use.|
 | `USE_LIGHT_IMAGE` | `1` (default) | Whether to use the light-weight Docker image. Overwritten by `IMAGE_NAME`.|
 | `LEGACY_DIRECTORIES` | `0` (default) | Use legacy method of managing internal filesystem layout. See [filesystem layout]({{< ref "filesystem" >}}). |
-| `MULTI_ACCOUNTS` | `0` (default) | Enable multi-accounts (preview) |
 | `PERSISTENCE` | `0` (default) | Enable persistence. See [persistence mechanism]({{< ref "persistence-mechanism" >}}) and [filesystem layout]({{< ref "filesystem" >}}). |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, or Cognito users). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
 | `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |

--- a/content/en/tools/multi-account-setups/index.md
+++ b/content/en/tools/multi-account-setups/index.md
@@ -10,14 +10,8 @@ description: >
   Using LocalStack in multi-tenant setups
 ---
 
-{{< alert title="Warning" color="warning">}}
-Multi-account is a preview feature and has limited compatibility with cloud pods and persistence.
-To enable multi-accounts, refer to [configuration]({{< ref "configuration#core" >}}).
-{{< /alert >}}
-
-
-LocalStack Community only supports a single AWS Account ID, `000000000000` by default.
-By contrast, LocalStack Pro ships with multi-account support which adds namespacing based on AWS Account ID
+LocalStack Pro ships with multi-account support which allows namespacing based on AWS Account ID.
+By contrast, LocalStack Community only supports a single AWS Account ID: `000000000000`.
 
 Namespaced AWS resources can be accessed by using the `AWS_ACCESS_KEY_ID` variable when making requests.
 No additional server-side configuration is required.
@@ -62,40 +56,3 @@ $ awslocal ec2 describe-key-pairs
 LocalStack uses the `AWS_ACCESS_KEY_ID` client-side variable for Account ID.
 In future LocalStack may support proper access key IDs issued by the local IAM service, which will then internally be translated to corresponding account IDs.
 {{< /alert >}}
-
-### Limitations
-
-Multi-accounts is a preview feature and has limited compatibility with cloud pods and persistence.
-The services are listed below:
-
-- API Gateway
-- Athena
-- Backup
-- CloudFormation
-- CloudFront
-- CloudTrail
-- CloudWatch
-- CodeCommit
-- DynamoDB
-- EventBridge
-- Firehose
-- Glacier
-- Glue
-- IoT Analytics
-- IoT Wireless
-- Kafka
-- LakeFormation
-- Lambda
-- MediaStore
-- MWAA
-- OpenSearch
-- QLDB
-- Route53
-- SageMaker
-- SecretsManager
-- ServerlessRepo
-- Service Discovery
-- SNS
-- SQS
-- Timestream
-- Transfer


### PR DESCRIPTION
Multi-account will be baked-into the core system from v1.2 and cannot be disabled. This PR removes the defunct flag from the docs.