### PR TITLE
Improving formatting for the GitHub Actions CI snippet

### DIFF
--- a/content/en/aws/kms/index.md
+++ b/content/en/aws/kms/index.md
@@ -25,9 +25,9 @@ Let's create a simple symmetric encryption key and use it to encrypt / decrypt s
 
 A new key can be created in KMS with
 
-```sh
-awslocal kms create-key
-```
+{{< command >}}
+$ awslocal kms create-key
+{{</ command >}}
 
 By default, this command creates a symmetric encryption key, so we do not even have to supply any additional arguments. In the output we want to pay attention to the ID of the newly created key, `010a4301-4205-4df8-ae52-4c2895d47326` in this case:
 
@@ -56,34 +56,34 @@ By default, this command creates a symmetric encryption key, so we do not even h
 
 If we lose the ID, we can always use
 
-```sh
-awslocal kms list-keys
-```
+{{< command >}}
+$ awslocal kms list-keys
+{{</ command >}}
 
 to list IDs and [Amazon Resource Identifiers](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) (ARNs) of all the available keys. Then, if necessary, we can also check all the details about a key with a given key ID or ARN like this:
 
-```sh
-awslocal kms describe-key --key-id 010a4301-4205-4df8-ae52-4c2895d47326
-```
+{{< command >}}
+$ awslocal kms describe-key --key-id 010a4301-4205-4df8-ae52-4c2895d47326
+{{</ command >}}
 
 We can use the key now to encrypt something. Let's say, `some important stuff`:
 
-```sh
-awslocal kms encrypt \
+{{< command >}}
+$ awslocal kms encrypt \
       --key-id 010a4301-4205-4df8-ae52-4c2895d47326 \
       --plaintext "some important stuff" \
       --output text \
       --query CiphertextBlob \
   | base64 --decode > my_encrypted_data
-```
+{{</ command >}}
 
 Why do we require such a complicated command? The `Encrypt` Operation itself looks like this:
 
-```sh
-awslocal kms encrypt \
+{{< command >}}
+$ awslocal kms encrypt \
       --key-id 010a4301-4205-4df8-ae52-4c2895d47326 \
       --plaintext "some important stuff"
-```
+{{</ command >}}
 
 And its output might be something like
 
@@ -99,13 +99,13 @@ The value of the `CiphertextBlob` field is a Base64-encoded result of encryption
 
 When we want to, we can decrypt our file using the same KMS key:
 
-```sh
-awslocal kms decrypt \
+{{< command >}}
+$ awslocal kms decrypt \
       --ciphertext-blob fileb://my_encrypted_data \
       --output text \
       --query Plaintext
   | base64 --decode
-```
+{{</ command >}}
 
 Here we ask KMS to decrypt contents of the binary file created during our previous `Encrypt` call. We do not have to specify the `key-id` while decrypting our file - when encrypting something with a symmetric key, AWS includes the key ID into the encrypted data, so can figure out itself which key to use for decryption. With asymmetric keys the `key-id` has to be specified, though.
 

--- a/content/en/aws/kms/index.md
+++ b/content/en/aws/kms/index.md
@@ -1,0 +1,123 @@
+---
+title: "Key Management Service (KMS)"
+linkTitle: "Key Management Service (KMS)"
+categories: ["LocalStack Community"]
+description: >
+  Key Management Service (KMS)
+---
+
+Key Management Service (KMS) is mainly about
+- creation and management of cryptographic keys
+- use of these keys to encrypt / decrypt data or to sign messages and to verify signatures for signed ones
+
+AWS documentation on KMS amd all its operations can be found [here](https://docs.aws.amazon.com/kms/latest/APIReference/Welcome.html).
+
+Keys in KMS roughly fall into the 3 categories:
+- Asymmetric encryption keys - holding a pair of a private and a public key. Asymmetric keys can be used either for data encryption and decryption with [Encrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html) / [Decrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html) or for creation and verification of digital signatures for messages with [Sign](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html) / [Verify](https://docs.aws.amazon.com/kms/latest/APIReference/API_Verify.html) operations. The same asymmetric key can't be used for both pairs of operations at the same time - when you create such a key, you have to specify in its [KeyUsage](https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html#KMS-CreateKey-request-KeyUsage) parameter, which pair of operations the key will support.
+- Symmetric encryption keys - such keys consist of just one key. Symmetric keys can **not** be used to sign and to verify messages, are only used to encrypt and to decrypt data.
+- Hash-Based Message Authentication Code (HMAC) keys, a special case of symmetric keys that are only used in creation and verification of message authentication codes (MACs) with [GenerateMac](https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateMac.html) / [VerifyMac](https://docs.aws.amazon.com/kms/latest/APIReference/API_VerifyMac.html) operations. You can read more about this type of keys [here](https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html).
+
+You can check [this page](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-compare.html) to see what other operations are supported for each type of keys. When you know what operations you require, this reference can help to figure out what key types are suitable for your goals.
+
+# Tutorial
+
+Let's create a simple symmetric encryption key and use it to encrypt / decrypt something.
+
+A new key can be created in KMS with
+
+```sh
+awslocal kms create-key
+```
+
+By default, this command creates a symmetric encryption key, so we do not even have to supply any additional arguments. In the output we want to pay attention to the ID of the newly created key, `010a4301-4205-4df8-ae52-4c2895d47326` in this case:
+
+```sh
+{
+    "KeyMetadata": {
+        "AWSAccountId": "000000000000",
+        "KeyId": "010a4301-4205-4df8-ae52-4c2895d47326",
+        "Arn": "arn:aws:kms:us-east-1:000000000000:key/010a4301-4205-4df8-ae52-4c2895d47326",
+        "CreationDate": 1665432947.493433,
+        "Enabled": true,
+        "Description": "",
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "KeyState": "Enabled",
+        "Origin": "AWS_KMS",
+        "KeyManager": "CUSTOMER",
+        "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+        "KeySpec": "SYMMETRIC_DEFAULT",
+        "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+        ],
+        "MultiRegion": false
+    }
+}
+```
+
+If we lose the ID, we can always use
+
+```sh
+awslocal kms list-keys
+```
+
+to list IDs and [Amazon Resource Identifiers](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) (ARNs) of all the available keys. Then, if necessary, we can also check all the details about a key with a given key ID or ARN like this:
+
+```sh
+awslocal kms describe-key --key-id 010a4301-4205-4df8-ae52-4c2895d47326
+```
+
+We can use the key now to encrypt something. Let's say, `some important stuff`:
+
+```sh
+awslocal kms encrypt \
+      --key-id 010a4301-4205-4df8-ae52-4c2895d47326 \
+      --plaintext "some important stuff" \
+      --output text \
+      --query CiphertextBlob \
+  | base64 --decode > my_encrypted_data
+```
+
+Why do we require such a complicated command? The `Encrypt` Operation itself looks like this:
+
+```sh
+awslocal kms encrypt \
+      --key-id 010a4301-4205-4df8-ae52-4c2895d47326 \
+      --plaintext "some important stuff"
+```
+
+And its output might be something like
+
+```sh
+{
+    "CiphertextBlob": "MDA4NDk4ZDYtMGU1ZS00NjU3LWEyZTQtMDliYTcwNDgyMmJkxw1eaLVUeUZA7bZzp+k7VAAAAAAAAAAAAAAAAAAAAAAetG9/5Znpw83/4xhwObc6Fc2B73y1ZvIigwahKopT0Q==",
+    "KeyId": "arn:aws:kms:us-east-1:000000000000:key/010a4301-4205-4df8-ae52-4c2895d47326",
+    "EncryptionAlgorithm": "SYMMETRIC_DEFAULT"
+}
+```
+
+The value of the `CiphertextBlob` field is a Base64-encoded result of encryption of our plaintext. In order to use KMS to decrypt this, we have to get rid of this Base64-encoding first. So to our `Encrypt` operation we add the `output` parameter, requesting the output to be in the text form instead of the default JSON. We also supply the `query` parameter, so the output only contains the value of the specified `CiphertextBlob` field. Then we feed the result to `base64` tool, asking it to remove the Base64 encoding, producing a binary output. We save that output to a file for future use. **Note:** Careful with the `CiphertextBlob` value for the `query` parameter - the AWS CLI doesn't check if the requested field is even if the output, so if you have a typo, the command would succeed, but the data sent to `base64` is going to be just a word `None`. Which is going to lead to unexpected results later. 
+
+When we want to, we can decrypt our file using the same KMS key:
+
+```sh
+awslocal kms decrypt \
+      --ciphertext-blob fileb://my_encrypted_data \
+      --output text \
+      --query Plaintext
+  | base64 --decode
+```
+
+Here we ask KMS to decrypt contents of the binary file created during our previous `Encrypt` call. We do not have to specify the `key-id` while decrypting our file - when encrypting something with a symmetric key, AWS includes the key ID into the encrypted data, so can figure out itself which key to use for decryption. With asymmetric keys the `key-id` has to be specified, though.
+
+As with the previous `Encrypt` call, we have to get rid of the Base64-encoding to actually get our data, so we use the `output` and `query` parameters along with the `base64` tool here as well. If everything went fine, the output is going to be
+
+```sh
+some important stuff
+```
+
+# Current differences between LocalStack KMS and AWS KMS
+
+1. LocalStack KMS always performs symmetric key encryption - even if the requested key is an asymmetric one. LocalStack also has a format of encrypted data different from the one used in AWS. This would cause your decryption to fail if you create a key yourself outside LocalStack KMS, import it to KMS with the [ImportKeyMaterial](https://docs.aws.amazon.com/kms/latest/APIReference/API_ImportKeyMaterial.html) operation, encrypt something with LocalStack KMS and then try to decrypt it outside of LocalStack with your copy of the key. Less exotic setups should be fine. 
+2. In AWS KMS, keys have many possible [states](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html). In LocalStack KMS, only `Enabled`, `Disabled` and `PendingDeletion` states exist.
+3. LocalStack KMS supports [multi-region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html), but, unlike in AWS KMS, multi-region key replicas are not synchronized with their primary key. So if you create a replica of a multi-regional key and then update some settings for the primary key, the replica won't get automatically updated.
+4. AWS KMS has [aliases](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html), that are created automatically for KMS keys used by services like, for example, S3. While LocalStack supports those pre-created aliases, they are getting created on the first attempt to access such an alias and are not visible before such an attempt.   

--- a/content/en/ci/github-actions/index.md
+++ b/content/en/ci/github-actions/index.md
@@ -34,15 +34,12 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
-          # install LocalStack cli and awslocal
-          pip install localstack awscli-local[ver1]
-          # Make sure to pull the latest version of the image
-          docker pull localstack/localstack
-          # Start LocalStack in the background
-          localstack start -d
-          # Wait 30 seconds for the LocalStack container to become ready before timing out
-          echo "Waiting for LocalStack startup..."
-          localstack wait -t 30
+          pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
+          docker pull localstack/localstack         # Make sure to pull the latest version of the image
+          localstack start -d                       # Start LocalStack in the background
+          
+          echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container
+          localstack wait -t 30                     # to become ready before timing out 
           echo "Startup complete"
       - name: Run some Tests against LocalStack
         run: |


### PR DESCRIPTION
Currently the syntax highlighting for Markdown paints everything in the `run` section of the YAML with the same color - `|` at the end of the line for `run` tells YAML that the following indented block is a multi-line scalar literal. That making the commands indistinguishable from comments, so not that visible. It seems to be impossible to fix the color in Markdown.

So rewriting the snippet a bit for a better clarity.