### PR TITLE
Improving formatting in the GitHub Actions CI snippet.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Broken link checker
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
+          # The following config contains this workaround: https://github.com/tcort/markdown-link-check/issues/201#issuecomment-1110242146
+          # as otherwise links to docs.github.com are considered dead.
+          # When the issue gets resolved, it might be fine to remove the workaround.
           config-file: '.github/workflows/markdown.links.config.json'
           folder-path: 'content/en/'
           check-modified-files-only: 'yes'

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -28,4 +28,12 @@
             "pattern": "http://localstack:4566"
         }
     ]
+    "httpHeaders": [
+        {
+            "urls": ["https://docs.github.com/"],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
+    ]
 }

--- a/content/en/ci/github-actions/index.md
+++ b/content/en/ci/github-actions/index.md
@@ -34,15 +34,12 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
-          # install LocalStack cli and awslocal
-          pip install localstack awscli-local[ver1]
-          # Make sure to pull the latest version of the image
-          docker pull localstack/localstack
-          # Start LocalStack in the background
-          localstack start -d
-          # Wait 30 seconds for the LocalStack container to become ready before timing out
-          echo "Waiting for LocalStack startup..."
-          localstack wait -t 30
+          pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
+          docker pull localstack/localstack         # Make sure to pull the latest version of the image
+          localstack start -d                       # Start LocalStack in the background
+          
+          echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container
+          localstack wait -t 30                     # to become ready before timing out 
           echo "Startup complete"
       - name: Run some Tests against LocalStack
         run: |


### PR DESCRIPTION
Currently the syntax highlighting for Markdown paints everything in the `run` section of the YAML with the same color - `|` at the end of the line for `run` tells YAML that the following indented block is a multi-line scalar literal. That making the commands indistinguishable from comments, so not that visible. It seems to be impossible to fix the color in Markdown.

So rewriting the snippet a bit for a better clarity.

Also fixing the config for markdown-link-check, as currently the tool fails for links to docs.github.com. See https://github.com/tcort/markdown-link-check/issues/201#issuecomment-1110242146 for details.