### PR TITLE
Change S3_MOUNT to S3_DIR

### DIFF
--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -181,7 +181,7 @@ While the ElasticSearch API is actively maintained, the configuration variables 
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `S3_MOUNT` | | Configure a global parent directory that contains all buckets as sub-directories (`S3_MOUNT=/path/to/root`) or an individual directory that will get mounted as special bucket names (`S3_MOUNT=/path/to/root/bucket1:bucket1`) |
+| `S3_DIR` | | Configure a global parent directory that contains all buckets as sub-directories (`S3_DIR=/path/to/root`) or an individual directory that will get mounted as special bucket names (`S3_DIR=/path/to/root/bucket1:bucket1`) |
 
 ### StepFunctions
 


### PR DESCRIPTION
## Motivation
The variable is actually named S3_DIR, not S3_MOUNT, so the documentation is wrong.

## Changes
Change occurrences of S3_MOUNT to S3_DIR.