### PR TITLE
removing: Pulumi mobileanalytics endpoint from docs

### DIFF
--- a/content/en/integrations/pulumi/index.md
+++ b/content/en/integrations/pulumi/index.md
@@ -273,7 +273,6 @@ config:
       migrationhub: http://localhost:4566
       migrationhubconfig: http://localhost:4566
       mobile: http://localhost:4566
-      mobileanalytics: http://localhost:4566
       mq: http://localhost:4566
       mturk: http://localhost:4566
       mwaa: http://localhost:4566


### PR DESCRIPTION
Updating the docs to remove the `mobileanalytics` endpoint for pulumi which no longer exists