### PR TITLE
add docs for CUSTOM_SSL_CERT_PATH

### DIFF
--- a/content/en/localstack/configuration.md
+++ b/content/en/localstack/configuration.md
@@ -275,6 +275,7 @@ python -m localstack.cli.main --profile=dev config show
 | - | - | - |
 | `SKIP_INFRA_DOWNLOADS` | | Whether to skip downloading additional infrastructure components (e.g., specific Elasticsearch versions)
 | `SKIP_SSL_CERT_DOWNLOAD` | | Whether to skip downloading the SSL certificate for localhost.localstack.cloud
+| `CUSTOM_SSL_CERT_PATH` | `/var/lib/localstack/custom/server.test.pem` | Defines the absolute path to a custom SSL certificate for localhost.localstack.cloud
 | `IGNORE_ES_DOWNLOAD_ERRORS` | | Whether to ignore errors (e.g., network/SSL) when downloading Elasticsearch plugins
 | `OVERRIDE_IN_DOCKER` | | Overrides the check whether LocalStack is executed within a docker container. If set to `true`, LocalStack assumes it runs in a docker container. Should not be set unless necessary.
 | `EDGE_FORWARD_URL` | | Optional target URL to forward all edge requests to (e.g., for distributed deployments)


### PR DESCRIPTION
This PR adds a short section on a config variable introduced with https://github.com/localstack/localstack/pull/7102: `CUSTOM_SSL_CERT_PATH`