### PR TITLE
docs: Add nav buttons in footer. Make 'privacy policy' link more readable

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -169,7 +169,6 @@ footer.footer-localstack {
 
     border-top: 1px solid #ced4da;
 
-    padding-top: 3rem;
     padding-bottom: 2rem;
 
     color: $gray-500;
@@ -177,19 +176,25 @@ footer.footer-localstack {
     margin-left: -24px;
     margin-right: -24px;
 
+    & a {
+        color: $gray-500;
+    }
+
+    & a:hover {
+        color: white;
+    }
+
     & .footer-logo {
         max-height: 55px;
         opacity: 0.7;
     }
+    
     & .link-lists li {
         font-size: 1.3rem;
+    }
 
-        & a {
-            color: $gray-500;
-        }
-        & a:hover {
-            color: white;
-        }
+    & .prev-next-nav {
+        height: 3rem;
     }
 
     & hr {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,6 +2,18 @@
 <footer class="footer-localstack d-print-none">
 
   <div class="container-fluid">
+    <div class="row prev-next-nav">
+      <div class="col text-left">
+        {{ with .NextInSection }}
+          <small><a href="{{.Permalink}}">≪ {{.Title}}</a></small>
+        {{ end }}
+      </div>
+      <div class="col text-right">
+        {{ with .PrevInSection }}
+          <small><a href="{{.Permalink}}">{{.Title}} ≫</a></small>
+        {{ end }}
+      </div>
+    </div>
     <div class="row">
       <div class="col">
         <div class="mb-3">


### PR DESCRIPTION
Fixes #69 

* Adds navigation buttons in the footer to move to the previous and next pages in the section.
* Changes "Privacy Policy" link to be visible.
