### PR TITLE
Rds docs update

### DIFF
--- a/content/en/user-guide/aws/rds/index.md
+++ b/content/en/user-guide/aws/rds/index.md
@@ -19,9 +19,17 @@ In order to use MSSQL databases, you need to explicitly accept the [Microsoft SQ
 ### Postgres versions
 
 When creating an RDS DB cluster or instance with `postgres`/`aurora-postgresql` DB engine and a specific `EngineVersion`, LocalStack will install and provision the respective Postgres version on demand.
-Currently, versions 11/12/13 can be installed - when selecting a major version outside of this range, the default version 11 is used as fallback.
+
+Currently, versions 11, 12, and 13 can be chosen - when selecting a major version outside of this range, the default version 11 is used as fallback.
+
+Please be aware that the minor version cannot be freely selected - the latest available version will be installed in the docker environment.
 
 In order to disable installation of custom versions, you may configure the environment variable `RDS_PG_CUSTOM_VERSIONS=0`, in which case always the default Postgres version 11 will be used.
+
+
+{{< alert title="Note" >}}
+The `describe-db-cluster` and `describe-db-instances` calls will still return the `engine-version` as it was defined for the creation, but the actual installed postgres engine could be different. This is important, e.g., when using a terraform configuration, as it should not detect changes in that case.
+{{< /alert >}}
 
 ## End-to-end example (Postgres)
 


### PR DESCRIPTION
add one sentence about RDS minor versions, and a note on the `engine_version` that is returned for db-cluster and db-instances 