### PR TITLE
enable user feedback via GA

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -296,3 +296,7 @@ table {
         }
     }
 }
+
+.feedback--title {
+    margin-top: 20px;
+}

--- a/config.toml
+++ b/config.toml
@@ -158,7 +158,7 @@ sidebar_search_disable = true
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
 [params.ui.feedback]
-enable = false
+enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 yes = 'Glad to hear it! Please <a href="https://github.com/localstack/docs/issues/new">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/localstack/docs/issues/new">tell us how we can improve</a>.'

--- a/content/en/overview/_index.html
+++ b/content/en/overview/_index.html
@@ -9,7 +9,7 @@ menu:
     weight: 20
 cascade:
   type: docs
-hide_readingtime: true
+hide_feedback: true
 ---
 
 <div class="doc-overview-grid container">

--- a/content/en/tutorials/_index.md
+++ b/content/en/tutorials/_index.md
@@ -7,7 +7,7 @@ description: >
 cascade:
   type: docs
 slug: tutorials
-hide_readingtime: true
+hide_feedback: true
 ---
 
 <!-- this div is used as a reference point of where to apply custom style to the list of subcontent -->


### PR DESCRIPTION
adds section to give feedback about articles
![image](https://user-images.githubusercontent.com/39307517/204244070-d2367b3d-e5d4-4304-9ffc-088909fd5535.png)

can be disabled for single pages via `hide_feedback: true` in frontmatter, as demonstrated by `overview` and `tutorials`

more about this here: https://www.docsy.dev/docs/adding-content/feedback/
