### PR TITLE
Hide readingtime and feedback on some pages

### DIFF
--- a/content/en/overview/_index.html
+++ b/content/en/overview/_index.html
@@ -10,6 +10,7 @@ menu:
 cascade:
   type: docs
 hide_feedback: true
+hide_readingtime: true
 ---
 
 <div class="doc-overview-grid container">

--- a/content/en/tutorials/_index.md
+++ b/content/en/tutorials/_index.md
@@ -8,6 +8,7 @@ cascade:
   type: docs
 slug: tutorials
 hide_feedback: true
+hide_readingtime: true
 ---
 
 <!-- this div is used as a reference point of where to apply custom style to the list of subcontent -->

--- a/content/en/user-guide/_index.md
+++ b/content/en/user-guide/_index.md
@@ -8,4 +8,5 @@ cascade:
   type: docs
 slug: user-guide
 hide_readingtime: true
+hide_feedback: true
 ---


### PR DESCRIPTION
Due to some to me unknown reason the fields `hide_readingtime` and `hide_feedback` were removed on a few pages I would have disabled them.