### PR TITLE
Increase the limit for child pages to display in sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -152,6 +152,8 @@ navbar_translucent_over_cover_disable = false
 sidebar_menu_compact = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = true
+# Limit for number of children pages (This is an undocumented option)
+sidebar_menu_truncate = 128
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.


### PR DESCRIPTION
### Summary

Docsy limited the number of pages to 50 causing several child pages to be hidden. 

This PR increases the limit making sure they appear in the sidebar and search index.

#### Before
![image](https://user-images.githubusercontent.com/5170829/207528058-2a6b044b-0b0a-406d-a6a1-72a833763f7c.png)


#### After
![image](https://user-images.githubusercontent.com/5170829/207527989-8c6ba283-4cfd-4f98-b438-b2c209925c70.png)

