### PR TITLE
Add section on ECS task code mounting

### DIFF
--- a/content/en/references/usage-tracking.md
+++ b/content/en/references/usage-tracking.md
@@ -13,7 +13,7 @@ For API Key activations, we track the timestamp and the API key. We need to do t
 
 ## LocalStack usage statistics
 
-For pro users, most of the information is collected to populate the "stack insights" dashboard. Collecting basic anonymized usage of AWS services helps us better direct engineering efforts to services that are used the most or cause the most issues.
+For Pro users, most of the information is collected to populate the [Stack Insights](https://docs.localstack.cloud/user-guide/web-application/stack-insights) dashboard. Collecting basic anonymized usage of AWS services helps us better direct engineering efforts to services that are used the most or cause the most issues.
 
 ### Session information
 
@@ -115,3 +115,7 @@ We collect the usage of particular features in an anonymized and aggregated way.
 - Content or file names of files being uploaded to S3
 - More generally, we don't collect any parameters of AWS API Calls. We do not track S3 bucket names, Lambda function names, EC2 configurations, or anything similar
 - Any sensitive information about the request (like credentials and URL parameters)
+
+## Configuration
+
+You can disable event reporting in your LocalStack instance by setting the environment variable `DISABLE_EVENTS=1`.

--- a/content/en/user-guide/aws/elastic-container-service/index.md
+++ b/content/en/user-guide/aws/elastic-container-service/index.md
@@ -33,7 +33,8 @@ In some cases, it can be useful to mount code from the host filesystem into the 
 In order to leverage code mounting, we can use the ECS bind mounts feature, which is covered in the [AWS docs here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html).
 
 For example, the Python sample code below registers a task definition, mounting a host path `/host/path` into the container under `/container/path`:
-```
+
+```bash
 ecs_client = boto3.client("ecs", endpoint_url="http://localhost:4566")
 ...
 ecs_client.register_task_definition(

--- a/content/en/user-guide/aws/elastic-container-service/index.md
+++ b/content/en/user-guide/aws/elastic-container-service/index.md
@@ -16,6 +16,8 @@ By default, the **ECS Fargate** launch type is assumed, i.e., the local Docker e
 More complex features like integration of application load balancers (ALBs) are currently not available. Nonetheless, they are being developed and will be available in the near future.
 {{< /alert >}}
 
+## Executing ECS tasks in Docker
+
 Task instances are started in a local Docker engine, which needs to be accessible to the LocalStack container. The name pattern for task containers is `localstack_<family>_<revision>`, where `<family>` refers to the task family and `<revision>` refers to a task revision (for example, `localstack_nginx_1`).
 
 You can use the configuration option `LAMBDA_DOCKER_NETWORK` to specify the network the ECS containers are started in.
@@ -23,3 +25,29 @@ If your ECS containers depend on LocalStack services, this should be the network
 For more information regarding the configuration of LocalStack, please check the [LocalStack configuration]({{< ref "configuration" >}}) section.
 
 If you are running LocalStack through a `docker run` command, do not forget to enable the communication from the container to the Docker Engine API. You can provide the access by adding the following option `-v /var/run/docker.sock:/var/run/docker.sock`.
+
+## Mounting local directories for ECS tasks
+
+In some cases, it can be useful to mount code from the host filesystem into the ECS container. For example, to enable a quick debugging loop where you can test changes without having to build and redeploy the task's Docker image each time - similar to the [Lambda hot swapping](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-swapping) feature in LocalStack.
+
+In order to leverage code mounting, we can use the ECS bind mounts feature, which is covered in the [AWS docs here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html).
+
+For example, the Python sample code below registers a task definition, mounting a host path `/host/path` into the container under `/container/path`:
+```
+ecs_client = boto3.client("ecs", endpoint_url="http://localhost:4566")
+...
+ecs_client.register_task_definition(
+    family="...",
+    containerDefinitions=[
+        {
+            "name": "...",
+            "image": "alpine",
+            "command": ["..."],
+            "mountPoints": [
+                {"containerPath": "/container/path", "sourceVolume": "test-volume"}
+            ],
+        }
+    ],
+    volumes=[{"host": {"sourcePath": "/host/path"}, "name": "test-volume"}],
+)
+```

--- a/content/en/user-guide/aws/elastic-container-service/index.md
+++ b/content/en/user-guide/aws/elastic-container-service/index.md
@@ -30,7 +30,7 @@ If you are running LocalStack through a `docker run` command, do not forget to e
 
 In some cases, it can be useful to mount code from the host filesystem into the ECS container. For example, to enable a quick debugging loop where you can test changes without having to build and redeploy the task's Docker image each time - similar to the [Lambda hot swapping](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-swapping) feature in LocalStack.
 
-In order to leverage code mounting, we can use the ECS bind mounts feature, which is covered in the [AWS docs here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html).
+In order to leverage code mounting, we can use the ECS bind mounts feature, which is covered in the [AWS Bind mounts documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html).
 
 For example, the Python sample code below registers a task definition, mounting a host path `/host/path` into the container under `/container/path`:
 


### PR DESCRIPTION
Add section on ECS task code mounting. Follow-up from https://github.com/localstack/localstack/issues/5941

Also sneaking in a small change with links to Stack Insights, and a note on how to `DISABLE_EVENTS=1` /cc @HarshCasper 