### PR TITLE
remove deprecated endpoint resolver for go SDK v2 + fix example 

### DIFF
--- a/content/en/user-guide/integrations/sdks/go/index.md
+++ b/content/en/user-guide/integrations/sdks/go/index.md
@@ -63,28 +63,28 @@ import (
 
 func main() {
   awsEndpoint := "http://localhost:4566"
-	awsRegion := "us-east-1"
+  awsRegion := "us-east-1"
+  
+  customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+    if awsEndpoint != "" {
+      return aws.Endpoint{
+        PartitionID:   "aws",
+        URL:           awsEndpoint,
+        SigningRegion: awsRegion,
+        }, nil
+      }
 
-	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		if awsEndpoint != "" {
-			return aws.Endpoint{
-				PartitionID:   "aws",
-				URL:           awsEndpoint,
-				SigningRegion: awsRegion,
-			}, nil
-		}
-
-		// returning EndpointNotFoundError will allow the service to fallback to its default resolution
-		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-	})
-
-	awsCfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithRegion(awsRegion),
-		config.WithEndpointResolverWithOptions(customResolver),
-	)
-	if err != nil {
-		log.Fatalf("Cannot load the AWS configs: %s", err)
-	}
+    // returning EndpointNotFoundError will allow the service to fallback to its default resolution
+    return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+  })
+  
+  awsCfg, err := config.LoadDefaultConfig(context.TODO(),
+    config.WithRegion(awsRegion),
+    config.WithEndpointResolverWithOptions(customResolver),
+  )
+  if err != nil {
+    log.Fatalf("Cannot load the AWS configs: %s", err)
+  }
 
   // Create the resource client
   client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {

--- a/content/en/user-guide/integrations/sdks/go/index.md
+++ b/content/en/user-guide/integrations/sdks/go/index.md
@@ -62,32 +62,32 @@ import (
 )
 
 func main() {
-  awsEndpoint = "http://localhost:4566"
-  awsRegion = "us-east-1"
+  awsEndpoint := "http://localhost:4566"
+	awsRegion := "us-east-1"
 
-  customResolver := aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
-    if awsEndpoint != "" {
-      return aws.Endpoint{
-        PartitionID:   "aws",
-        URL:           awsEndpoint,
-        SigningRegion: awsRegion,
-      }, nil
-    }
+	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		if awsEndpoint != "" {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				URL:           awsEndpoint,
+				SigningRegion: awsRegion,
+			}, nil
+		}
 
-    // returning EndpointNotFoundError will allow the service to fallback to its default resolution
-    return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-  })
+		// returning EndpointNotFoundError will allow the service to fallback to its default resolution
+		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+	})
 
-  awsCfg, err := config.LoadDefaultConfig(context.TODO(),
-    config.WithRegion(awsRegion),
-    config.WithEndpointResolver(customResolver),
-  )
-  if err != nil {
-    log.Fatalf("Cannot load the AWS configs: %s", err)
-  }
+	awsCfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithRegion(awsRegion),
+		config.WithEndpointResolverWithOptions(customResolver),
+	)
+	if err != nil {
+		log.Fatalf("Cannot load the AWS configs: %s", err)
+	}
 
   // Create the resource client
-  client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+  client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
     o.UsePathStyle = true
   })
   // ...

--- a/content/en/user-guide/integrations/sdks/go/index.md
+++ b/content/en/user-guide/integrations/sdks/go/index.md
@@ -71,8 +71,8 @@ func main() {
         PartitionID:   "aws",
         URL:           awsEndpoint,
         SigningRegion: awsRegion,
-        }, nil
-      }
+      }, nil
+    }
 
     // returning EndpointNotFoundError will allow the service to fallback to its default resolution
     return aws.Endpoint{}, &aws.EndpointNotFoundError{}


### PR DESCRIPTION
While working on a support case, I've tried this example and it didn't work, and we made use of a deprecated function. Updated the sample with the new `EndpointResolverWithOptionsFunc`. See https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/