### PR TITLE
migrate SES and Cognito IDP login endpoints

### DIFF
--- a/content/en/tutorials/java-notification-app/index.md
+++ b/content/en/tutorials/java-notification-app/index.md
@@ -592,7 +592,7 @@ $ curl -s localhost:8080/process
 To check whether the email has been sent, you can query the LocalStack internal SES endpoint using the following command:
 
 {{< command >}}
-$ curl -s localhost:4566/_localstack/ses | jq .
+$ curl -s localhost:4566/_aws/ses | jq .
 {{< / command >}}
 
 You will see an output similar to the following:

--- a/content/en/user-guide/aws/cognito/index.md
+++ b/content/en/user-guide/aws/cognito/index.md
@@ -178,7 +178,7 @@ More details on Cognito Lambda triggers can be found in the [AWS documentation](
 
 You can also access the local [Cognito login form](https://docs.aws.amazon.com/cognito/latest/developerguide/login-endpoint.html) by entering the following URL in your browser:
 ```plaintext
-https://localhost.localstack.cloud/login?response_type=code&client_id=<client_id>&redirect_uri=<redirect_uri>
+https://localhost.localstack.cloud/_aws/cognito-idp/login?response_type=code&client_id=<client_id>&redirect_uri=<redirect_uri>
 ```
 Please replace `<client_id>` with the ID of an existing user pool client ID (in this case, `example_user`), and `<redirect_uri>` with the redirect URI of your application (e.g., `http://example.com`).
 
@@ -195,7 +195,7 @@ Note that the value of the `redirect_uri` parameter must match the value provide
   --data-urlencode 'redirect_uri=http://example.com' \
   --data-urlencode "client_id=${client_id}" \
   --data-urlencode 'code=test123' \
-  'http://localhost:4566/oauth2/token'
+  'http://localhost:4566/_aws/cognito-idp/oauth2/token'
 {"access_token": "eyJ0eXAi…lKaHx44Q", "expires_in": 86400, "token_type": "Bearer", "refresh_token": "e3f08304", "id_token": "eyJ0eXAi…ADTXv5mA"}
 ```
 

--- a/content/en/user-guide/aws/ses/index.md
+++ b/content/en/user-guide/aws/ses/index.md
@@ -11,7 +11,7 @@ aliases:
 
 LocalStack keeps track of all sent emails for retrospection.
 
-The sent messages can be retrieved via a service API endpoint (GET `/_localstack/ses`) or from the filesystem.
+The sent messages can be retrieved via a service API endpoint (GET `/_aws/ses`) or from the filesystem.
 
 Messages are also saved to the state directory (see [filesystem layout]({{< ref "filesystem" >}})).
 The files are saved as JSON in the `ses/` subdirectory and organised by message ID.


### PR DESCRIPTION
This PR updates the docs after some internal endpoints have been adjusted:
- SES Internal API to retrieve emails: https://github.com/localstack/localstack/pull/7630
- Cognito IDP Login / OAuth URLs

The old URLs are still working, but will log a deprecation warning.