### PR TITLE
Bump current activemq version

### DIFF
--- a/content/en/user-guide/aws/mq/index.md
+++ b/content/en/user-guide/aws/mq/index.md
@@ -55,7 +55,7 @@ $ curl -XPOST -d "body=message" http://admin:admin@localhost:4513/api/message\?d
 
 ## Localstack limitations and differences to AWS
 Only basic functionality is supported right now, main limitations are the following:
-* Only ActiveMQ (version 5.16.5) is supported
+* Only ActiveMQ (version 5.16.6) is supported
 * Users are not actively enforced (but needed to make proper calls)
 * While it is possible to create configurations, they are not actively enforced in a broker
 * Persistence and Cloud Pods are not supported

--- a/content/en/user-guide/aws/mq/index.md
+++ b/content/en/user-guide/aws/mq/index.md
@@ -15,7 +15,7 @@ In the following, we outline basic MQ usage. Please also refer to the sample her
 Assuming you have [`awslocal`]({{< ref "aws-cli" >}}) installed, you can try the following commands:
 
 {{< command >}}
-$ awslocal mq create-broker --broker-name test-broker --deployment-mode SINGLE_INSTANCE --engine-type ACTIVEMQ --engine-version='5.16.5' --host-instance-type 'mq.t2.micro' --auto-minor-version-upgrade --publicly-accessible --users='{"ConsoleAccess": true, "Groups": ["testgroup"],"Password": "QXwV*$iUM9USHnVv&!^7s3c@", "Username": "admin"}'
+$ awslocal mq create-broker --broker-name test-broker --deployment-mode SINGLE_INSTANCE --engine-type ACTIVEMQ --engine-version='5.16.6' --host-instance-type 'mq.t2.micro' --auto-minor-version-upgrade --publicly-accessible --users='{"ConsoleAccess": true, "Groups": ["testgroup"],"Password": "QXwV*$iUM9USHnVv&!^7s3c@", "Username": "admin"}'
 {
     "BrokerArn": "arn:aws:mq:us-east-1:000000000000:broker:test-broker:b-f503abb7-66bc-47fb-b1a9-8d8c51ef6545",
     "BrokerId": "b-f503abb7-66bc-47fb-b1a9-8d8c51ef6545"


### PR DESCRIPTION
We updated the version in LocalStack to 5.16.6[1] but we did not change
the example.

[1]: https://github.com/localstack/localstack-ext/pull/1382
