### PR TITLE
Use the latest ubuntu runner

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The 18.04 runner is being deprecated, and they have started adding [brownouts](https://github.com/actions/runner-images/issues/6002) disabling builds.
