### PR TITLE
update kafka docs

### DIFF
--- a/content/en/user-guide/integrations/kafka/docker-compose.yml
+++ b/content/en/user-guide/integrations/kafka/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack
+    image: localstack/localstack-pro
     ports:
       - "4566:4566"
     depends_on:
@@ -62,6 +62,7 @@ services:
       - DEBUG=${DEBUG- }
       - PERSISTENCE=${PERSISTENCE- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"

--- a/content/en/user-guide/integrations/kafka/index.md
+++ b/content/en/user-guide/integrations/kafka/index.md
@@ -1,15 +1,17 @@
 ---
 title: "Self-managed Kafka cluster"
 tags: ["kafka", "self-managed"]
-categories: []
+categories: ["LocalStack Pro"]
 weight: 11
 description: >
-  Using LocalStack lambda with self-managed Kafka cluster
+  Using LocalStack Lambda with a self-managed Kafka cluster
 aliases:
   - /integrations/kafka/
 ---
 
-LocalStack does not currently support AWS MSK out of the box, but you can run your own self-managed Kafka cluster and integrate it with your own applications.
+LocalStack Pro supports [AWS Managed Streaming for Kafka (MSK)]({{< ref "managed-streaming-for-kafka" >}}) and you can create Kafka clusters directly through the MSK API that will run in LocalStack.
+In some cases, you may want to run your own self-managed Kafka cluster and integrate it with your applications, like triggering Lambdas from a Kafka stream running in your own cluster.
+The Lambda integration with self-managed Kafka clusters is also a LocalStack Pro feature.
 
 ## Running self-managed Kafka
 


### PR DESCRIPTION
clarified an outdated part in the docs (self-managed kafka integration with lambda is also in pro)

Should clarify the following questions:
* https://github.com/localstack/localstack/issues/6121
* https://github.com/localstack/localstack/issues/7219