### PR TITLE
add sample to demostrate how to use hugo data templates

### DIFF
--- a/content/en/samples/_index.md
+++ b/content/en/samples/_index.md
@@ -1,0 +1,12 @@
+---
+title: Samples
+linkTitle: Samples
+main_menu: true
+weight: 1
+menu:
+  main:
+    name: "Documentation"
+    weight: 20
+hide_feedback: true
+hide_readingtime: true
+---

--- a/data/developerhub/applications.json
+++ b/data/developerhub/applications.json
@@ -1,0 +1,24 @@
+{
+  "applications": [
+    {
+      "title": "Shipment List Demo",
+      "description": "Shipment List Demo Application - AWS in PROD and LocalStack on DEV environment",
+      "url": "https://github.com/tinyg210/shipment-list-demo",
+      "teaser": "https://raw.githubusercontent.com/tinyg210/shipment-list-demo/master/app_diagram.png",
+      "services": ["s3", "dynamodb", "lambda"],
+      "deployment":  ["terraform"],
+      "platform": ["java", "spring-boot"],
+      "tags": ["some-tag"]
+    },
+    {
+      "title": "Serverless Image Resizer",
+      "description": "A serverless application that demos several AWS functionalities on LocalStack. The sample also includes a GitHub actions workflow to demonstrate how to run end-to-end tests of your AWS apps using LocalStack in CI.",
+      "url": "https://github.com/thrau/serverless-image-resizer",
+      "teaser": "https://user-images.githubusercontent.com/3996682/203586505-e54ccb3e-5101-4ee8-917d-d6372ee965ef.png",
+      "services": ["s3", "ssm", "lambda", "sns", "ses"],
+      "deployment":  ["awscli", "github-actions"],
+      "platform": ["python"],
+      "tags": ["s3-website", "lambda-function-urls"]
+    }
+  ]
+}

--- a/layouts/samples/list.html
+++ b/layouts/samples/list.html
@@ -1,0 +1,28 @@
+{{ define "main" }}
+<!-- {{ .Content }} -->
+
+<main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+
+    <div class="td-content">
+        <h1>Samples</h1>
+        <p>Just an ugly page to demonstrate how to use Hugo data templates</p>
+
+        <div>
+            <ul>
+            {{ range $.Site.Data.developerhub.applications.applications }}
+                <li>
+                    <a href="{{.url}}">{{ .title }}</a>
+                    <div>
+                    {{ range .tags }}<span class="badge badge-secondary">{{ . }}</span>{{ end}}
+                    </div>
+                    <p>{{ .description }}</p>
+                    <img src="{{ .teaser }}" style="max-width: 100px">
+                </li>
+            {{ end }}
+            </ul>
+        </div>
+    </div>
+
+</main>
+
+{{ end }}


### PR DESCRIPTION
This PR demonstrates how to use [hugo data templates](https://gohugo.io/templates/data-templates/), which will be useful to populate the developer hub sample application page from data we scrape from github.