### PR TITLE
add section about testcontainers and RDS

### DIFF
--- a/content/en/user-guide/integrations/testcontainers/index.md
+++ b/content/en/user-guide/integrations/testcontainers/index.md
@@ -194,4 +194,4 @@ int mapped_port = localstack.getMappedPort(localstack_port);
 * https://www.testcontainers.org/modules/localstack (Java)
 * https://golang.testcontainers.org (Go)
 * https://golang.testcontainers.org/modules/localstack (Go)
-* [localstack-pro-samples on testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sampe)
+* [localstack-pro-samples on testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sample)

--- a/content/en/user-guide/integrations/testcontainers/index.md
+++ b/content/en/user-guide/integrations/testcontainers/index.md
@@ -30,13 +30,11 @@ with LocalStack.
 
 ## Covered Topics
 
-- [Overview](#overview)
-- [Covered Topics](#covered-topics)
-  - [Installing the Localstack module](#installing-the-localstack-module)
-  - [Obtaining a LocalStack container](#obtaining-a-localstack-container)
-- [Configuring the AWS client](#configuring-the-aws-client)
-- [Special Setup for using RDS](#special-setup-for-using-rds)
-- [Resources](#resources)
+* [Installing the Localstack module](#installing-the-localstack-module)
+* [Obtaining a LocalStack container](#obtaining-a-localstack-container)
+* [Configuring the AWS client](#configuring-the-aws-client)
+* [Special Setup for using RDS](#special-setup-for-using-rds)
+* [Useful Links](#useful-links)
 
 ### Installing the Localstack module
 
@@ -189,7 +187,7 @@ int mapped_port = localstack.getMappedPort(localstack_port);
 
 
 
-## Resources
+## Useful Links
 
 * https://www.testcontainers.com (Java, .NET, Go, Python, Ruby, Node.js)
 * https://www.testcontainers.org (Java)

--- a/content/en/user-guide/integrations/testcontainers/index.md
+++ b/content/en/user-guide/integrations/testcontainers/index.md
@@ -154,13 +154,11 @@ S3Client s3 = S3Client.builder()
 
 ## Special Setup for using RDS
 
-Some services like RDS require additional setup so that the correct port is exposed and accessible for the tests. 
+Some services like RDS require additional setup so that the correct port is exposed and accessible for the tests. The reserved ports on LocalStack are between `4510-4559`, depending on your use case you might need to expose several ports using `witExposedPorts`.
 
-The reserved ports on LocalStack are between `4510-4559`, depending on your use case you might need to expose several ports using `witExposedPorts`.
+Check the [pro-sample on how to use RDS with Testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sample). 
 
-Please also check the [pro-sample on how to use RDS with Testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sample). 
-
-The testcontainer can be created like this:
+The Testcontainer can be created like this:
 
 ```java
 /**
@@ -185,8 +183,6 @@ int localstack_port = response.dbInstance().endpoint().port();
 int mapped_port = localstack.getMappedPort(localstack_port);
 ```
 
-
-
 ## Useful Links
 
 * https://www.testcontainers.com (Java, .NET, Go, Python, Ruby, Node.js)
@@ -194,4 +190,3 @@ int mapped_port = localstack.getMappedPort(localstack_port);
 * https://www.testcontainers.org/modules/localstack (Java)
 * https://golang.testcontainers.org (Go)
 * https://golang.testcontainers.org/modules/localstack (Go)
-* [localstack-pro-samples on testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sample)

--- a/content/en/user-guide/integrations/testcontainers/index.md
+++ b/content/en/user-guide/integrations/testcontainers/index.md
@@ -30,10 +30,13 @@ with LocalStack.
 
 ## Covered Topics
 
-* [Installing the Localstack module](#installing-the-localstack-module)
-* [Obtaining a LocalStack container](#obtaining-a-localstack-container)
-* [Configuring the AWS client](#configuring-the-aws-client)
-* [Useful Links](#useful-links)
+- [Overview](#overview)
+- [Covered Topics](#covered-topics)
+  - [Installing the Localstack module](#installing-the-localstack-module)
+  - [Obtaining a LocalStack container](#obtaining-a-localstack-container)
+- [Configuring the AWS client](#configuring-the-aws-client)
+- [Special Setup for using RDS](#special-setup-for-using-rds)
+- [Resources](#resources)
 
 ### Installing the Localstack module
 
@@ -151,6 +154,41 @@ S3Client s3 = S3Client.builder()
 {{< /tab >}}
 {{< /tabpane >}}
 
+## Special Setup for using RDS
+
+Some services like RDS require additional setup so that the correct port is exposed and accessible for the tests. 
+
+The reserved ports on LocalStack are between `4510-4559`, depending on your use case you might need to expose several ports using `witExposedPorts`.
+
+Please also check the [pro-sample on how to use RDS with Testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sample). 
+
+The testcontainer can be created like this:
+
+```java
+/**
+  * Start LocalStackContainer with exposed Ports. Those ports are used by services like RDS, where several databases can be started, running on different ports.
+  * In this sample we only map 5 ports, however, depending on your use case you may need to map ports up to 4559
+*/
+@Rule
+public LocalStackContainer localstack = new LocalStackContainer(localstackImage)
+                                                    .withExposedPorts(4510, 4511, 4512, 4513, 4514) // TODO the port can have any value between 4510-4559, but LS starts from 4510
+                                                    .withEnv("LOCALSTACK_API_KEY", api_key) // TODO add your API key here
+                                                    .withServices(LocalStackContainer.EnabledService.named("rds"));
+
+```
+
+To find the exposed port which you can use to connect to the instance:
+
+```java
+// identify the port localstack provides for the instance
+int localstack_port = response.dbInstance().endpoint().port();
+
+// get the port it was mapped to, e.g. the one we can reach from host/the test
+int mapped_port = localstack.getMappedPort(localstack_port);
+```
+
+
+
 ## Resources
 
 * https://www.testcontainers.com (Java, .NET, Go, Python, Ruby, Node.js)
@@ -158,3 +196,4 @@ S3Client s3 = S3Client.builder()
 * https://www.testcontainers.org/modules/localstack (Java)
 * https://golang.testcontainers.org (Go)
 * https://golang.testcontainers.org/modules/localstack (Go)
+* [localstack-pro-samples on testcontainers for Java](https://github.com/localstack/localstack-pro-samples/tree/master/testcontainers-java-sampe)


### PR DESCRIPTION
Add some details about exposed-port configuration required for RDS. 
Added Java example, and link to pro-samples.