### PR TITLE
Add docs for AWS C++ SDK

### DIFF
--- a/content/en/user-guide/integrations/sdks/cpp/index.md
+++ b/content/en/user-guide/integrations/sdks/cpp/index.md
@@ -4,8 +4,6 @@ categories: []
 tags: ["sdk"]
 description: >
   How to use the C++ AWS SDK with LocalStack.
-aliases:
-  - /integrations/sdks/cpp/
 ---
 
 ## Overview
@@ -16,7 +14,8 @@ which is the preferred way of integrating the C++ SDK with LocalStack.
 ## Example
 
 Consider the following example, which creates an SQS queue, sends a message to it, then receives the same message via the SDK:
-```
+
+```cpp
 #include <iostream>
 #include <aws/core/Aws.h>
 #include <aws/core/utils/logging/LogLevel.h>
@@ -74,7 +73,8 @@ int main()
 ```
 
 Once compiled, we'll see the following output when running the application:
-```
+
+```sh
 Creating queue ...
 Sending message ...
 Receiving message ...

--- a/content/en/user-guide/integrations/sdks/cpp/index.md
+++ b/content/en/user-guide/integrations/sdks/cpp/index.md
@@ -1,0 +1,91 @@
+---
+title: "C++"
+categories: []
+tags: ["sdk"]
+description: >
+  How to use the C++ AWS SDK with LocalStack.
+aliases:
+  - /integrations/sdks/cpp/
+---
+
+## Overview
+
+The [AWS SDK for C++](https://docs.aws.amazon.com/sdk-for-cpp), like other AWS SDKs, lets you set the endpoint when creating resource clients,
+which is the preferred way of integrating the C++ SDK with LocalStack.
+
+## Example
+
+Consider the following example, which creates an SQS queue, sends a message to it, then receives the same message via the SDK:
+```
+#include <iostream>
+#include <aws/core/Aws.h>
+#include <aws/core/utils/logging/LogLevel.h>
+#include <aws/sqs/SQSClient.h>
+#include <aws/sqs/model/CreateQueueRequest.h>
+#include <aws/sqs/model/SendMessageRequest.h>
+#include <aws/sqs/model/ReceiveMessageRequest.h>
+
+using namespace Aws;
+
+int main()
+{
+    // initialize AWS SDK
+    SDKOptions options;
+    options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    InitAPI(options);
+
+    // create SQS client with local endpoint configuration
+    Aws::Client::ClientConfiguration clientConfig;
+    clientConfig.endpointOverride = "http://localhost:4566";
+    SQS::SQSClient client = SQS::SQSClient(clientConfig);
+
+    // create queue
+    Aws::SQS::Model::CreateQueueRequest cqReq;
+    cqReq.SetQueueName("test-queue");
+    auto cqRes = client.CreateQueue(cqReq);
+    auto queueUrl = cqRes.GetResult().GetQueueUrl();
+
+    // send message
+    std::cout << "Sending message ..." << std::endl;
+    Aws::SQS::Model::SendMessageRequest smReq;
+    smReq.SetQueueUrl(queueUrl);
+    smReq.SetMessageBody("test message 123");
+    client.SendMessage(smReq);
+
+    // receive message
+    std::cout << "Receiving message ..." << std::endl;
+    Aws::SQS::Model::ReceiveMessageRequest rmReq;
+    rmReq.SetQueueUrl(queueUrl);
+    auto rmRes = client.ReceiveMessage(rmReq);
+    const auto& messages = rmRes.GetResult().GetMessages();
+    std::cout << "Received " << messages.size() << " messages from queue " << queueUrl << std::endl;
+
+    // print message
+    const auto& message = messages[0];
+    std::cout << "Received message:" << std::endl;
+    std::cout << "  MessageId: " << message.GetMessageId() << std::endl;
+    std::cout << "  ReceiptHandle: " << message.GetReceiptHandle() << std::endl;
+    std::cout << "  Body: " << message.GetBody() << std::endl << std::endl;
+
+    // shut down the SDK
+    ShutdownAPI(options);
+    return 0;
+}
+```
+
+Once compiled, we'll see the following output when running the application:
+```
+Creating queue ...
+Sending message ...
+Receiving message ...
+Received 1 messages from queue http://localhost:4566/000000000000/test-queue
+Received message:
+  MessageId: 4731b327-49b2-4410-a8da-2c479e7bde04
+  ReceiptHandle: ZTQ1M2Q1ZjYtMjBkZS00ODQxLTlkYzQtMjBlMGQ4MDNkODVkIGFybjphd3M6c3FzOnVzLWVhc3QtMTowMDAwMDAwMDAwMDA6dGVzdC1xdWV1ZSA0NzMxYjMyNy00OWIyLTQ0MTAtYThkYS0yYzQ3OWU3YmRlMDQgMTY3ODIxMjExMS42ODk1NTE=
+  Body: test message 123
+```
+
+## Resources
+
+* [AWS SDK for C++](https://docs.aws.amazon.com/sdk-for-cpp)
+* [Getting Started Guide](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/getting-started.html)


### PR DESCRIPTION
Add docs for AWS C++ SDK - analogous to the other SDKs already covered in our docs.