### PR TITLE
use new artifacts (pro) for Docs Update Workflow

### DIFF
--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -30,15 +30,25 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Download metrics data from Pro test pipeline (GitHub)
+      - name: Download metrics data from Pro pipeline (GitHub)
         working-directory: docs
         run: ./scripts/get_latest_github_metrics.sh ./target master
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
-          REPOSITORY_NAME: localstack-ext
-          ARTIFACT_ID: parity-metric-ext-raw
-          WORKFLOW: "Integration Tests"
+          REPOSITORY_NAME: lsv2test-ext
+          ARTIFACT_ID: parity-metric-ext-raw # TODO might be renamed
+          WORKFLOW: "Build, Test, Push" # TODO rename
           RENAME_ARTIFACT: pro-integration-test.csv
+      
+      - name: Download coverage (capture-notimplemented) data from Pro pipeline (GitHub)
+        working-directory: docs
+        run: ./scripts/get_latest_github_metrics.sh ./target master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
+          REPOSITORY_NAME: lsv2test-ext
+          ARTIFACT_ID: capture-notimplemented-pro # TODO might be renamed
+          WORKFLOW: "Build, Test, Push" # TODO rename
+          RESOURCE_FOLDER: "metrics-implementation-details"
 
       - name: Download metrics data from latest Community test run (CircleCI)
         working-directory: docs

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Download metrics data from Moto Integration test pipeline (GitHub)
+        working-directory: docs
+        run: ./scripts/get_latest_github_metrics.sh ./target main
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
+          REPOSITORY_NAME: localstack-moto-test-coverage 
+          ARTIFACT_ID: test-metrics
+          WORKFLOW: moto-integration-tests
+          RENAME_ARTIFACT: moto-integration-test.csv
+          FILTER_SUCCESS: 0
+
       - name: Download metrics data from Pro pipeline (GitHub)
         working-directory: docs
         run: ./scripts/get_latest_github_metrics.sh ./target master
@@ -54,16 +65,6 @@ jobs:
         working-directory: docs
         run: ./scripts/get_latest_circleci_metrics.sh ./target
 
-      - name: Download metrics data from Moto Integration test pipeline (GitHub)
-        working-directory: docs
-        run: ./scripts/get_latest_github_metrics.sh ./target main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
-          REPOSITORY_NAME: localstack-moto-test-coverage 
-          ARTIFACT_ID: test-metrics
-          WORKFLOW: moto-integration-tests
-          RENAME_ARTIFACT: moto-integration-test.csv
-          FILTER_SUCCESS: 0
 
       - name: Create Parity Coverage Docs
         working-directory: docs

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -38,7 +38,7 @@ jobs:
           REPOSITORY_NAME: localstack-moto-test-coverage 
           ARTIFACT_ID: test-metrics
           WORKFLOW: moto-integration-tests
-          RENAME_ARTIFACT: moto-integration-test.csv
+          PREFIX_ARTIFACT: moto-integration-test
           FILTER_SUCCESS: 0
 
       - name: Download metrics data from Pro pipeline (GitHub)
@@ -46,19 +46,19 @@ jobs:
         run: ./scripts/get_latest_github_metrics.sh ./target master
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
-          REPOSITORY_NAME: lsv2test-ext
-          ARTIFACT_ID: parity-metric-ext-raw # TODO might be renamed
-          WORKFLOW: "Build, Test, Push" # TODO rename
-          RENAME_ARTIFACT: pro-integration-test.csv
+          REPOSITORY_NAME: localstack-ext
+          ARTIFACT_ID: parity-metric-ext-raw 
+          WORKFLOW: "Build, Test, Push" 
+          PREFIX_ARTIFACT: pro-integration-test
       
       - name: Download coverage (capture-notimplemented) data from Pro pipeline (GitHub)
         working-directory: docs
         run: ./scripts/get_latest_github_metrics.sh ./target master
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
-          REPOSITORY_NAME: lsv2test-ext
-          ARTIFACT_ID: capture-notimplemented-pro # TODO might be renamed
-          WORKFLOW: "Build, Test, Push" # TODO rename
+          REPOSITORY_NAME: localstack-ext
+          ARTIFACT_ID: capture-notimplemented-pro 
+          WORKFLOW: "Build, Test, Push" 
           RESOURCE_FOLDER: "metrics-implementation-details"
 
       - name: Download metrics data from latest Community test run (CircleCI)

--- a/scripts/get_latest_circleci_metrics.sh
+++ b/scripts/get_latest_circleci_metrics.sh
@@ -45,8 +45,6 @@ echo "Moving community metrics implementation details to $METRICS_IMPL..."
 mkdir -p $METRICS_IMPL
 mv community $METRICS_IMPL
 
-# TODO currently the CircleCI master still has the pro details, which would be added to the PR if we do not remove it
-rm -rf pro
 
 echo "Resulting file structure:"
 tree $PARENT_FOLDER

--- a/scripts/get_latest_circleci_metrics.sh
+++ b/scripts/get_latest_circleci_metrics.sh
@@ -10,6 +10,18 @@ PROJECT_SLUG="github/localstack/localstack"
 METRICS_RAW="$PARENT_FOLDER/metrics-raw/"
 METRICS_IMPL="$PARENT_FOLDER/metrics-implementation-details/"
 
+# Resulting directory structure required for the create_data_coverage.py
+# - resources/metrics-raw
+#   - community-integration-test.csv (Community) -> this is downloaded from CircleCI (using this script)
+#   - pro-integration-test.csv (Pro)
+#   - moto-integration-test.csv (Moto)
+#   - ...
+# - resources/metrics-implementation-details
+#   - community
+#     - implementation_coverage_full.csv -> this is downloaded from CircleCI (using this script)
+#   - pro
+#     - implementation_coverage_full.csv
+
 echo "Project: $PROJECT_SLUG."
 
 WORKFLOW_ID=$(curl -X 'GET' "https://circleci.com/api/v2/insights/${PROJECT_SLUG}/workflows/main?branch=${METRICS_ARTIFACTS_BRANCH}" -H 'accept: application/json' | jq -r '[.items[] | select(.status == "success")][0].id')
@@ -25,16 +37,6 @@ echo "$ARTIFACT_URLS"
 echo "Downloading metrics data..."
 wget -m --cut-dirs 5 --no-host-directories $ARTIFACT_URLS
 
-# Create the following directory structure for the coverage_docs_utility.py
-# - resources/metrics-raw
-#   - metric-report-raw-data-2022-08-16__11_37_31-d1e519d6.csv (Pro)
-#   - metric-report-raw-data-2022-08-16__11_37_31-d1e51as6.csv (Community)
-# - resources/metrics-implementation-details
-#   - pro
-#     - implementation_coverage_full.csv
-#   - community
-#     - implementation_coverage_full.csv
-
 echo "Moving raw community metrics data to $METRICS_RAW"
 mkdir -p $METRICS_RAW
 mv parity_metrics/metric-report-*.csv $METRICS_RAW/community-integration-test.csv
@@ -43,8 +45,6 @@ echo "Moving community metrics implementation details to $METRICS_IMPL..."
 mkdir -p $METRICS_IMPL
 mv community $METRICS_IMPL
 
-echo "Moving pro metrics implementation details to $METRICS_IMPL..."
-mv pro $METRICS_IMPL
 
 echo "Resulting file structure:"
 tree $PARENT_FOLDER

--- a/scripts/get_latest_circleci_metrics.sh
+++ b/scripts/get_latest_circleci_metrics.sh
@@ -45,6 +45,8 @@ echo "Moving community metrics implementation details to $METRICS_IMPL..."
 mkdir -p $METRICS_IMPL
 mv community $METRICS_IMPL
 
+# TODO currently the CircleCI master still has the pro details, which would be added to the PR if we do not remove it
+rm -rf pro
 
 echo "Resulting file structure:"
 tree $PARENT_FOLDER

--- a/scripts/get_latest_github_metrics.sh
+++ b/scripts/get_latest_github_metrics.sh
@@ -9,7 +9,7 @@ METRICS_ARTIFACTS_BRANCH=${2:-master}
 REPOSITORY_NAME=${REPOSITORY_NAME:-localstack-ext}
 ARTIFACT_ID=${ARTIFACT_ID:-parity-metric-ext-raw}
 WORKFLOW=${WORKFLOW:-"Integration Tests"}
-RENAME_ARTIFACT=${RENAME_ARTIFACT:-}
+PREFIX_ARTIFACT=${PREFIX_ARTIFACT:-}
 FILTER_SUCCESS=${FILTER_SUCCESS:-1}
 
 RESOURCE_FOLDER=${RESOURCE_FOLDER:-metrics-raw}
@@ -89,12 +89,15 @@ fi
 
 echo "Moving artifact to $TARGET_FOLDER"
 mkdir -p $TARGET_FOLDER
-if [[ -z "${RENAME_ARTIFACT}" ]]; then
+if [[ -z "${PREFIX_ARTIFACT}" ]]; then
     # pro implementation_coverage artifact download has a subfolder "pro"
     cp -R $TMP_FOLDER/* $TARGET_FOLDER
 else
     # metrics-raw-data artifacts -> we are only want to keept the csv and rename it
-    mv $TMP_FOLDER/*.csv $TARGET_FOLDER/$RENAME_ARTIFACT
+    for file in $TMP_FOLDER/*.csv; do
+      org_file_name=$(echo $file | sed "s/.*\///")
+      mv -- "$file" "$TARGET_FOLDER/$PREFIX_ARTIFACT-$org_file_name"
+    done
 fi
 
 # cleanup


### PR DESCRIPTION
When moving to the new pro pipeline, some of the artifacts required for updating the docs need to be retrieved from different locations:

**Coverage information for pro (capture not-implemented)**
* previously run in CircleCI, with the move only community details are available in CircleCI
* added new job in the workflow to retrieve the artifact

**Metrics Raw Data for pro (test details)**
* previously already retrieved from GitHub, nothing should change here

In this PR:
* updated the workflow
* updated the scripts to retrieve the resources from CircleCI + Github

Open TODOs:

- [x] adapt workflow + artifact names + repository name
- [x] remove the TODO (`rm -rf pro`) from `get_latest_circleci_metrics.sh` (currently the pro-artifacts are still available)

/cc @alexrashed