### PR TITLE
add information about arm support + iam authentication for RDS

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -197,6 +197,9 @@ The OpenSearch configuration variables are used to manage both, OpenSearch and E
 | Variable | Example Values | Description |
 | - | - | - |
 | `RDS_PG_CUSTOM_VERSIONS` | `0` / `1` (default) | Whether to install and use custom Postgres versions for RDS (or alternatively, use default version 11). |
+| `RDS_MYSQL_DOCKER`       | `0` (default) / `1` | Whether to enable MySQL engines (instead of MariaDB). Will run the MySQL cluster/instances in a new docker container. |
+| `MYSQL_IMAGE`            | `mysql:mytag`       | Defines a specific MySQL image that should be used when spinning up the MySQL engine. Only available if `RDS_MYSQL_DOCKER` is enabled. |
+| `MSSQL_IMAGE`            | `mssql:mytag`       | Defines a specific image that should be used when spinning up a SQL server engine. |
 
 ### S3
 

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -198,8 +198,8 @@ The OpenSearch configuration variables are used to manage both, OpenSearch and E
 | - | - | - |
 | `RDS_PG_CUSTOM_VERSIONS` | `0` / `1` (default) | Whether to install and use custom Postgres versions for RDS (or alternatively, use default version 11). |
 | `RDS_MYSQL_DOCKER`       | `0` (default) / `1` | Whether to enable MySQL engines (instead of MariaDB). Will run the MySQL cluster/instances in a new docker container. |
-| `MYSQL_IMAGE`            | `mysql:mytag`       | Defines a specific MySQL image that should be used when spinning up the MySQL engine. Only available if `RDS_MYSQL_DOCKER` is enabled. |
-| `MSSQL_IMAGE`            | `mssql:mytag`       | Defines a specific image that should be used when spinning up a SQL server engine. |
+| `MYSQL_IMAGE`            | `mysql:8.0`       | Defines a specific MySQL image that should be used when spinning up the MySQL engine. Only available if `RDS_MYSQL_DOCKER` is enabled. |
+| `MSSQL_IMAGE`            | `mcr.microsoft.com/mssql/server:2022-latest` | Defines a specific image that should be used when spinning up a SQL server engine. |
 
 ### S3
 

--- a/content/en/user-guide/aws/rds/index.md
+++ b/content/en/user-guide/aws/rds/index.md
@@ -42,12 +42,12 @@ Snapshots are currently not supported for MariaDB.
 
 By default, a MariaDB installation is used when requesting a MySQL engine type. 
 
-If you wish to use a real MySQL version, you can do so by setting the environment variable `RDS_MYSQL_DOCKER=1`. With this feature enabled, MySQL community server will be started in a new docker container when requesting the MySQL engine. The `engine-version` will be used as the tag for the image, meaning you can freely select the desired MySQL version that is listed on the the [official MySQL docker hub](https://hub.docker.com/_/mysql).
+If you wish to use a real MySQL version, you can do so by setting the environment variable `RDS_MYSQL_DOCKER=1`. With this feature enabled, MySQL community server will be started in a new Docker container when requesting the MySQL engine. The `engine-version` will be used as the tag for the image, meaning you can freely select the desired MySQL version that is listed on the [official MySQL Docker Hub](https://hub.docker.com/_/mysql).
 
 In case you want to use a special image, you can also set the environment variable `MYSQL_IMAGE=<my-image:tag>`.
 
 {{< alert title="Note" >}}
-Please be aware that MySQL images for `arm64` are only available for newer versions. Please check the [docker hub](https://hub.docker.com/_/mysql) for details on the availability.
+Please be aware that MySQL images for `arm64` are only available for newer versions. Please check the [MySQL Docker Hub repository](https://hub.docker.com/_/mysql) for details on the availability.
 {{< /alert >}}
 
 Please note that the `MasterUserPassword` defined for the database cluster/instance will be used as the `MYSQL_ROOT_PASSWORD` environment for user `root` in the MySQL container. The user for `MasterUserName` will use the same password, and will have full access to the defined database.
@@ -141,24 +141,23 @@ Please consider the following notes regarding default usernames/passwords and da
 IAM auth token can be used to connect to RDS. This feature is currently only supported for Postgres in LocalStack.
 
 {{< alert title="Note" >}}
-Please be aware that the IAM authentication is not verified at this point. Meaning any user that is granted the role `rds_iam` will receive a valid token.
+Please be aware that the IAM authentication is not verified at this point, which means that any DB user that is granted the role `rds_iam` will receive a valid token and will be able to connect to the database.
 {{< /alert >}}
 
 ### Using IAM example
 
-The following show cases the IAM functionality for Postgres:
+The following example showcases the IAM authentication flow for RDS Postgres:
 
 * create a DB instance, and retrieve the host and port for the instance
 * connect to the DB using the master username and password. Then create a new user and grant it the role `rds_iam`:
    * `CREATE USER <username> WITH LOGIN`
    * `GRANT rds_iam TO <username>`
-* receive a token for the `<username>`:
-   * awslocal rds generate-db-auth-token --username $USER --hostname $HOST --port $PORT
-* connect to the DB with the user you have a created and the token you have received in the previous step as password
+* generate a token for the `<username>` via the `generate-db-auth-token` command
+* connect to the DB with the user you have a created and the token generated in the previous step as password
 
 {{< command >}}
 $ MASTER_USER=hello
-$ MASTER_PW=MyPassw0rd!
+$ MASTER_PW='MyPassw0rd!'
 $ DB_NAME=test
 
 $ awslocal rds create-db-instance --master-username $MASTER_USER --master-user-password $MASTER_PW --db-instance-identifier mydb --engine postgres --db-name $DB_NAME --enable-iam-database-authentication --db-instance-class db.t3.small

--- a/content/en/user-guide/aws/rds/index.md
+++ b/content/en/user-guide/aws/rds/index.md
@@ -42,9 +42,13 @@ Snapshots are currently not supported for MariaDB.
 
 By default, a MariaDB installation is used when requesting a MySQL engine type. 
 
-If you wish to use a real MySQL version, you can do so by setting the environment variable `RDS_MYSQL_DOCKER=1`. With this feature enabled, MySQL community server will be started in a new docker container when requesting the MySQL engine. The `engine-version` will be used as the tag for the image, meaning you can freely select the desired MySQL version.
+If you wish to use a real MySQL version, you can do so by setting the environment variable `RDS_MYSQL_DOCKER=1`. With this feature enabled, MySQL community server will be started in a new docker container when requesting the MySQL engine. The `engine-version` will be used as the tag for the image, meaning you can freely select the desired MySQL version that is listed on the the [official MySQL docker hub](https://hub.docker.com/_/mysql).
 
 In case you want to use a special image, you can also set the environment variable `MYSQL_IMAGE=<my-image:tag>`.
+
+{{< alert title="Note" >}}
+Please be aware that MySQL images for `arm64` are only available for newer versions. Please check the [docker hub](https://hub.docker.com/_/mysql) for details on the availability.
+{{< /alert >}}
 
 Please note that the `MasterUserPassword` defined for the database cluster/instance will be used as the `MYSQL_ROOT_PASSWORD` environment for user `root` in the MySQL container. The user for `MasterUserName` will use the same password, and will have full access to the defined database.
 
@@ -54,6 +58,8 @@ DB Snapshots are currently not supported for MySQL.
 
 {{< alert title="Note" >}}
 In order to use MSSQL databases, you need to explicitly accept the [Microsoft SQL Server End-User Licensing Agreement (EULA)](https://hub.docker.com/_/microsoft-mssql-server) by setting `MSSQL_ACCEPT_EULA=Y` in the LocalStack container environment.
+
+Please note that MSSQL does not yet have official support for `arm64`. 
 {{< /alert >}}
 
 For the MSSQL engine, the database server is started in a new docker container using the `latest` image.
@@ -129,3 +135,42 @@ Please consider the following notes regarding default usernames/passwords and da
 - You can use any `master-username`, except "postgres", for creating a new RDS instance. The user will automatically be created.
 - The user "postgres" is special, and it is not possible to create a new RDS instance with this user name.
 - Do not use `db-name` "postgres" as it is already in use by LocalStack.
+
+## IAM Authentication Support
+
+IAM auth token can be used to connect to RDS. This feature is currently only supported for Postgres in LocalStack.
+
+{{< alert title="Note" >}}
+Please be aware that the IAM authentication is not verified at this point. Meaning any user that is granted the role `rds_iam` will receive a valid token.
+{{< /alert >}}
+
+### Using IAM example
+
+The following show cases the IAM functionality for Postgres:
+
+* create a DB instance, and retrieve the host and port for the instance
+* connect to the DB using the master username and password. Then create a new user and grant it the role `rds_iam`:
+   * `CREATE USER <username> WITH LOGIN`
+   * `GRANT rds_iam TO <username>`
+* receive a token for the `<username>`:
+   * awslocal rds generate-db-auth-token --username $USER --hostname $HOST --port $PORT
+* connect to the DB with the user you have a created and the token you have received in the previous step as password
+
+{{< command >}}
+$ MASTER_USER=hello
+$ MASTER_PW=MyPassw0rd!
+$ DB_NAME=test
+
+$ awslocal rds create-db-instance --master-username $MASTER_USER --master-user-password $MASTER_PW --db-instance-identifier mydb --engine postgres --db-name $DB_NAME --enable-iam-database-authentication --db-instance-class db.t3.small
+
+$ PORT=$(awslocal rds describe-db-instances --db-instance-identifier mydb | jq -r ".DBInstances[0].Endpoint.Port")
+$ HOST=$(awslocal rds describe-db-instances --db-instance-identifier mydb | jq -r ".DBInstances[0].Endpoint.Address")
+
+$ PGPASSWORD=$MASTER_PW psql -d $DB_NAME -U $MASTER_USER -p $PORT -h $HOST -w -c 'CREATE USER myiam WITH LOGIN'
+
+$ PGPASSWORD=$MASTER_PW psql -d $DB_NAME -U $MASTER_USER -p $PORT -h $HOST -w -c 'GRANT rds_iam TO myiam'
+
+$ TOKEN=$(awslocal rds generate-db-auth-token --username myiam --hostname $HOST --port $PORT)
+
+$ PGPASSWORD=$TOKEN psql -d $DB_NAME -U myiam -w -p $PORT -h $HOST
+{{< / command >}}


### PR DESCRIPTION
* Added notes about `arm64` support, which is limited for MySQL and not available for MSSQL at this time. 
* Added missing configuration parameters in the `Configuration` overview
* Added description + example for using IAM authentication