### PR TITLE
Rename default container name from localstack_main to localstack-main

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -34,6 +34,9 @@
             "pattern": "http://localstack_main:4566"
         },
         {
+            "pattern": "http://localstack-main:4566"
+        },
+        {
             "pattern": "(.*)localhost.localstack.cloud(.*)"
         }
     ],

--- a/content/en/getting-started/faq.md
+++ b/content/en/getting-started/faq.md
@@ -64,10 +64,10 @@ ports:
        …
 ```
 
-Furthermore, use either the default name `localstack_main` for the container, or alternatively configure the environment variable `MAIN_CONTAINER_NAME` to point to the correct name.
+Furthermore, use either the default name `localstack-main` for the container, or alternatively configure the environment variable `MAIN_CONTAINER_NAME` to point to the correct name.
 
 ```yaml
-container_name: localstack_main
+container_name: localstack-main
 ```
 
 Ensure that `127.0.0.1` is configured as the target DNS server for the `bigdata` container:

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -28,7 +28,7 @@ $ DEBUG=1 localstack start
 | `LEGACY_DIRECTORIES` | `0` (default) | Use legacy method of managing internal filesystem layout. See [filesystem layout]({{< ref "filesystem" >}}). |
 | `PERSISTENCE` | `0` (default) | Enable persistence. See [persistence mechanism]({{< ref "persistence-mechanism" >}}) and [filesystem layout]({{< ref "filesystem" >}}). |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, or Cognito users). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
-| `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
+| `MAIN_CONTAINER_NAME` | `localstack-main` (default) | Specify the main docker container name |
 | `INIT_SCRIPTS_PATH` | `/some/path` | *Deprecated*. Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`. |
 | `LS_LOG` | `trace`, `trace-internal`, `debug`, `info`, `warn`, `error`, `warning`| Specify the log level. Currently overrides the `DEBUG` configuration. `trace` for detailed request/response, `trace-internal` for internal calls, too. |
 | `EXTERNAL_SERVICE_PORTS_START` | `4510` (default) | Start of [the external service port range]({{< ref "external-ports" >}}) (included). |

--- a/content/en/references/init-hooks.md
+++ b/content/en/references/init-hooks.md
@@ -129,7 +129,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4566:4566"

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -32,16 +32,16 @@ Suppose your code is running inside an ECS container that LocalStack has created
 docker network create my-network
 # launch localstack
 MAIN_DOCKER_NETWORK=my-network DOCKER_FLAGS="--network my-network" localstack start
-# then your code can access localstack at its container name (by default: localstack_main)
-aws --endpoint-url http://localstack_main:4566 s3api list-buckets
+# then your code can access localstack at its container name (by default: localstack-main)
+aws --endpoint-url http://localstack-main:4566 s3api list-buckets
 {{</tab>}}
 {{<tab header="Docker" lang="bash">}}
 # create the network
 docker network create my-network
 # launch localstack
 docker run --rm -it --network my-network -e MAIN_DOCKER_NETWORK=my-network <other flags> localstack/localstack[-pro]
-# then your code can access localstack at its container name (by default: localstack_main)
-aws --endpoint-url http://localstack_main:4566 s3api list-buckets
+# then your code can access localstack at its container name (by default: localstack-main)
+aws --endpoint-url http://localstack-main:4566 s3api list-buckets
 {{</tab>}}
 {{<tab header="docker-compose.yml" lang="yml">}}
 services:
@@ -75,7 +75,7 @@ docker network create my-network
 DOCKER_FLAGS="--network my-network" localstack start
 # launch your container
 docker run --rm it --network my-network <image name>
-# then your code can access localstack at its container name (by default: localstack_main)
+# then your code can access localstack at its container name (by default: localstack-main)
 {{</tab>}}
 {{<tab header="Docker" lang="bash">}}
 # create the network
@@ -84,7 +84,7 @@ docker network create my-network
 docker run --rm -it --network my-network <other flags> localstack/localstack[-pro]
 # launch your container
 docker run --rm it --network my-network <image name>
-# then your code can access localstack at its container name (by default: localstack_main)
+# then your code can access localstack at its container name (by default: localstack-main)
 {{</tab>}}
 {{<tab header="docker-compose.yml" lang="yml">}}
 services:

--- a/content/en/tutorials/java-notification-app/index.md
+++ b/content/en/tutorials/java-notification-app/index.md
@@ -492,7 +492,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4510-4559:4510-4559"  # external service port range

--- a/content/en/user-guide/aws/elasticsearch/index.md
+++ b/content/en/user-guide/aws/elasticsearch/index.md
@@ -238,7 +238,7 @@ services:
       - data01:/usr/share/elasticsearch/data
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "4566:4566"

--- a/content/en/user-guide/aws/opensearch/index.md
+++ b/content/en/user-guide/aws/opensearch/index.md
@@ -339,7 +339,7 @@ services:
       - data01:/usr/share/opensearch/data
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "4566:4566"

--- a/content/en/user-guide/integrations/kafka/docker-compose.yml
+++ b/content/en/user-guide/integrations/kafka/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - KAFKA_BROKERS=kafka:29092
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro
     ports:
       - "4566:4566"

--- a/content/en/user-guide/tools/transparent-endpoint-injection/dns-server.md
+++ b/content/en/user-guide/tools/transparent-endpoint-injection/dns-server.md
@@ -147,7 +147,7 @@ Also, it configures the DNS route to exclusively (and only) route the following 
 If you want to perform this action manually, please do the following steps:
 
 1. Find out the bridge interface and container IP of your LocalStack container.
-    Use `docker inspect localstack_main` to get the IP address and network, then `docker inspect network` to get the interface name.
+    Use `docker inspect localstack-main` to get the IP address and network, then `docker inspect network` to get the interface name.
     If the interface name is not mentioned, it is usually the first 12 characters of the network ID prefixed with `br-`, like `br-0ae393d3345e`.
     If you use the default bridge network, it is usually `docker0`.
 


### PR DESCRIPTION
Docker can use a container name for DNS resolution, but hostnames cannot include underscores.

This change sets the default container name in the documentation to `localstack-main` to allow it to be used as a hostname.
