### PR TITLE
update persistence docs

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -248,7 +248,7 @@ The old lambda provider is temporarily available in Localstack&nbsp;v2 using `PR
 | `SQS_DELAY_RECENTLY_DELETED` | `0` (default) | Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it. |
 | `SQS_ENDPOINT_STRATEGY`| `domain`\|`path`\|`off` | Configures the format of Queue URLs (see [SQS Queue URLs]({{< ref "sqs#queue-urls" >}}))
 
-## Security 
+## Security
 
 Please be aware that the following configurations may have severe security implications!
 
@@ -290,7 +290,7 @@ Some of the services can be configured to switch to a particular provider:
 LocalStack supports configuration profiles which are stored in the `~/.localstack` config directory. A configuration profile is a set of environment variables stored in an `.env` file in the LocalStack config directory. Here is an example of what configuration profiles might look like:
 
 ```sh
-% tree ~/.localstack 
+% tree ~/.localstack
 /home/username/.localstack
 ├── default.env
 ├── dev.env
@@ -312,7 +312,7 @@ You can load a profile by either setting the `env` variable `CONFIG_PROFILE=<pro
 python -m localstack.cli.main --profile=dev start
 {{< / command >}}
 
-If no profile is specified, the `default.env` profile will be loaded. While explicitly specified, the environment variables will always overwrite the profile. 
+If no profile is specified, the `default.env` profile will be loaded. While explicitly specified, the environment variables will always overwrite the profile.
 
 To display the config environment variables, you can use the following command:
 
@@ -320,7 +320,16 @@ To display the config environment variables, you can use the following command:
 python -m localstack.cli.main --profile=dev config show
 {{< / command >}}
 
-## Miscellaneous 
+## Persistence
+
+To learn more about these configuration options, see our docs on [Persistence]({{< ref "persistence-mechanism" >}}).
+
+| Variable | Valid options | Description |
+| - | - | - |
+| `SNAPSHOT_SAVE_STRATEGY` | `ON_SHUTDOWN`\|`ON_REQUEST`\|`SCHEDULED`\|`MANUAL` | Strategy that governs when LocalStack should make state snapshots |
+| `SNAPSHOT_LOAD_STRATEGY` | `ON_STARTUP`\|`ON_REQUEST`\|`MANUAL` | Strategy that governs when LocalStack restores state snapshots |
+
+## Miscellaneous
 
 | Variable | Example Values | Description |
 | - | - | - |
@@ -382,7 +391,6 @@ More information [here]({{< ref "dns-server" >}}).
 | `USE_SSL` | `false` (default) | Whether to use https://... URLs with SSL encryption. Deprecated as of version 0.11.3. Each service endpoint now supports multiplexing HTTP/HTTPS traffic over the same port. |
 | `DEFAULT_REGION` | | *Deprecated*. AWS region to use when talking to the API (needs to be activated via `USE_SINGLE_REGION=1`). LocalStack now has full multi-region support. |
 | `USE_SINGLE_REGION` | | *Deprecated*. Whether to use the legacy single-region mode, defined via `DEFAULT_REGION`. |
-| `PERSISTENCE_SINGLE_FILE` | `true` (default)| Specify if persistence files should be combined (only relevant for legacy persistence in Community version, not relevant for advanced persistence in Pro version). |
 | `DATA_DIR`| blank (disabled/default), `/tmp/localstack/data` | Local directory for saving persistent data. This option is deprecated since LocalStack v1 and will be ignored. Please use `PERSISTENCE`. Using this option will set `PERSISTENCE=1` as a deprecation path. The state will be stored in your LocalStack volume in the `state/` directory |
 | `HOST_TMP_FOLDER` | `/some/path` | Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false.` |
 | `TMPDIR`| `/tmp` (default)| Temporary folder on the host running the CLI and inside the LocalStack container .|

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -1,84 +1,153 @@
 ---
-title: "Persistence Mechanism"
+title: "Persistence"
 weight: 5
 description: >
-  Configuration and internals of LocalStack persistence mechanism
+  How LocalStack stores state on disk
 aliases:
   - /localstack/persistence-mechanism/
 ---
 
-{{< alert title="Note">}}
-Please note that persisted states may not be compatibile across different versions of LocalStack.
-We are actively working on addressing this limitation in the upcoming releases.
-{{< /alert >}}
+## Persistence mechanisms
 
-The persistence mechanism is essentially a "pause and resume" feature for your LocalStack application state.
-For instance, you may want to run consecutive integration tests where each test loads in a different context but depends on the state produced by a previous test.
-Commonly, you may simply have a local development server that relies on a non-ephemeral application state.
+By default, LocalStack is an _ephemeral_ environment, meaning that, once you terminate your LocalStack instance, all state will be discarded.
+Persistence is a LocalStack Pro feature that can save and restore the state of LocalStack including all AWS resources and their data.
 
-{{< alert title="Note">}}
-The persistence mechanism aims to support all services.
-If you encounter any bugs, please report them on our [GitHub issue tracker](https://github.com/localstack/localstack/issues/new/choose).
-{{< /alert >}}
+LocalStack has two distinct persistence mechanisms
 
-To enable the persistence mechanism simply set the `PERSISTENCE` environment variable to `1`.
-Note that persistence is a Pro feature, therefore the `LOCALSTACK_API_KEY` must also be set.
- 
-```yaml
+* **Snapshot-based persistence**: essentially a "pause and resume" feature for your LocalStack container, which takes a snapshot of your LocalStack instance and dumps the data to disk.
+* **Cloud Pods**: a way to store, distribute, inspect, and version snapshots.
+
+This document is concerned with snapshot-based persistence.
+To learn more about cloud pods and their use cases, please refer to our documentation on [**Cloud pods**]({{< ref "cloud-pods">}}).
+
+## Snapshot-based persistence
+
+To get started with snapshot-based persistence, start LocalStack with the [configuration option]({{< ref "configuration#core" >}}) `PERSISTENCE=1`.
+LocalStack will store any AWS resources and all their application state, such as RDS databases or OpenSearch cluster data, into the [LocalStack Volume Directory]({{< ref "filesystem#localstack-volume-directory" >}}).
+When you restart LocalStack, you can resume your work from where you left off.
+
+{{< tabpane >}}
+{{< tab header="LocalStack CLI" lang="bash" >}}
+LOCALSTACK_API_KEY=... PERSISTENCE=1 localstack start
+{{< /tab >}}
+{{< tab header="Docker Compose" lang="yaml" >}}
     ...
+    image: localstack/localstack-pro
     environment:
       - LOCALSTACK_API_KEY=...
       - PERSISTENCE=1
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+{{< /tab >}}
+{{< tab header="Docker" lang="bash" >}}
+docker run -e LOCALSTACK_API_KEY=... -e PERSISTENCE=1 -v ./volume:/var/lib/localstack -p 4566:4566 localstack/localstack-pro
+{{< /tab >}}
+{{< /tabpane >}}
+
+{{< alert title="Note">}}
+Snapshots may not be compatible across different versions of LocalStack.
+It is possible that snapshots from older versions can be restored, but there are no guarantees to whether LocalStack will start into a consistent state.
+We are actively working on a solution for this problem.
+{{< /alert >}}
+
+### Save strategies
+
+LocalStack takes point-in-time snapshot of its state and dumps them to disk.
+There are four strategies that you can choose from that govern when these snapshots are taken.
+You can select a particular save strategy by setting `SNAPSHOT_SAVE_STRATEGY=<strategy>`.
+
+* **`ON_REQUEST`**: on every AWS API call that potentially modifies the state of a service, LocalStack will save the state of that service.
+  This was the default strategy until v2.0. It minimizes the chance for data loss, but also has significant performance implications. The service has to be locked during snapshotting, meaning that any requests to the particular AWS service will be blocked until the snapshot is complete.  In many cases this is just a few milliseconds, but can become significant in some services.
+* **`ON_SHUTDOWN`**: the state of all services are saved during the shutdown phase of LocalStack.
+  This strategy has zero performance impact, but is not good when you want to minimize the chance for data loss. Should LocalStack for some reason not shut down properly or is terminated before it can finalize the snapshot, you may be left with an incomplete state on disk.
+* **`SCHEDULED`**: (**default**) every 15 seconds, the state of all services that have been modified since the last snapshot are saved.
+  This is a compromise between `ON_REQUEST` and `ON_SHUTDOWN` in terms of performance and reliability.
+* **`MANUAL`**: turns off automatic snapshotting and gives you control through the internal state endpoints.
+
+### Load Strategies
+
+You can also configure when LocalStack should restore the state snapshots.
+
+* **`ON_REQUEST`**: the state is loaded lazily when the service is requested. This maintains LocalStack's lazy-loading behavior for AWS services.
+* **`ON_STARTUP`**: (**default**) the state of all services in the snapshot is restored when LocalStack starts up. This means that services that have stored state are also started on LocalStack start, which will increase the startup time, but also give you immediate feedback whether the state was restored correctly.
+* **`MANUAL`**: turns off automatic loading of snapshots and gives you control through the internal state endpoints.
+
+### Endpoints
+
+As mentioned, with the `MANUAL` save or load strategy you can trigger snapshotting manually when it best suits your application flow.
+
+* `POST /_localstack/state/<service>/save` take a snapshot the given service
+* `POST /_localstack/state/<service>/load` load the most recent snapshot of the given service
+
+For example, a snapshot for a particular service (e.g., `s3`) can be triggered by running the following command.
+The service name refers to the AWS service code.
+```console
+curl -X POST http://localhost:4566/_localstack/state/s3/save
 ```
 
-Once the application has been set and configured properly, the `/_localstack/health` endpoint of LocalStack will indicate whether the persistence mechanism has been initialized successfully.
-```json
-"features": {
-    "persistence": "initialized"
-}
-```
+## Service coverage
 
-Otherwise, the endpoint will inform you that the mechanism is disabled.
+Although we are working to support both snapshot-based persistence and Cloud pods for all AWS services,
+there are some common issues, known limitations, and also services that are not well tested for persistence support.
+Please help us improve persistence support by reporting bugs on our [GitHub issue tracker](https://github.com/localstack/localstack/issues/new/choose).
 
-```json
-"features": {
-    "persistence": "disabled"
-}
-```
+Here is a list of currently supported services and known issues.
+Persistence for services that are _not_ listed here _may_ work correctly, but are untested and unsupported.
+
+
+### Supported & tested
+
+* API Gateway
+* DynamodDB
+* Kinesis
+* Lambda
+* S3
+* SNS
+* SQS
+* Stepfunctions
+* ... TODO
+
+### Known limitations
+
+* **ElastiCache**: Redis instances are not restored
+* **MSK**: Kafka brokers are not restored
+* **EC2**: works for most resources, but emulated VM data is not restored
+* **Firehose**: Kinesis delivery streams are not restored
+* ... TODO
 
 ## Technical Details
 
-The persistence mechanism in LocalStack Pro is based on [Pickle][pickle] object serialization.
+State persistence in LocalStack works on a per-service basis and uses a custom state serialization protocol based on [Python's pickle mechanism](https://docs.python.org/3/library/pickle.html).
+Some services also store application-specific data, which we call _assets_.
+For example, when you start an RDS PostgreSQL database, LocalStack not only stores the RDS resource information, but also the PostgreSQL data.
+Another example is Kinesis, which persists some data in form of JSON objects per account, or DynamoDB that serializes its stat into an SQLite database per account and region.
 
-On service invocation, LocalStack traverses the state directory and deserializes state files and loads it into the memory.
-Each service has a single state file for all regions and accounts.
-LocalStack stores and Moto backend objects are serialized separately.
-
-Certain services may keep additional data files apart from serialized states.
-For instance, Kinesis persists some data in form of JSON while DynamoDB serializes a SQLite database.
+The current LocalStack snapshot is stored into `/var/lib/localstack/state`, and separated into `api_states` (LocalStack internal state), and assets (one directory per service).
+Here is what this looks like:
 
 ```plaintext
 /var/lib/localstack/state    # state directory
-├── api_states
-│   ├── dynamodb
-│   │   └── store.state      # serialised LocalStack stores
-│   ├── ec2
-│   │   └── backend.state    # serialised Moto backends
-│   ├── iot
-│   │   └── store.state
-│   └── lambda
-│       └── store.state
-├── dynamodb
-│   ├── 000000000000_eu-central-1.db
-│   └── 886002141588_us-east-1.db
-└── kinesis
-    ├── 000000000000.json
-    └── 886002141588.json
+├── api_states               # serialized LocalStack stores
+│   ├── dynamodb
+│   │   └── store.state
+│   ├── ec2
+│   │   └── backend.state
+│   ├── iot
+│   │   └── store.state
+│   └── lambda
+│       └── store.state
+├── dynamodb                # dynamodb assets
+│   ├── 000000000000_eu-central-1.db
+│   └── 886002141588_us-east-1.db
+└── kinesis                 # kinesis assets
+    ├── 000000000000.json
+    └── 886002141588.json
 ```
 
-Restoring the persisted state usually only takes a few milliseconds, even for large projects.
-Moreover, since the files store accurate snapshots of the application state, they can restore a state that is identical to the one before restarting the instance.
+To load a snapshot, LocalStack traverses the state directory and deserializes state files to loads them into the memory.
+When we restore server backends (like an RDS server or DynamoDB server), we make sure that they are configured to use the state stored in the respective asset directory.
 
-[pickle]: https://docs.python.org/3/library/pickle.html
+When LocalStack saves snapshots, it has to lock the particular service to avoid state pollution.
+That means that, while a snapshot for a particular service is created, all requests to the service are blocked.
+Depending on what you are building, you may find this behavior is slowing down your application.
+In most cases, the `ON_SHUTDOWN` save strategy should solve this problem.

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -152,7 +152,7 @@ Here is what this looks like:
 │   │   └── store.state
 │   └── lambda
 │       └── store.state
-└── api_states               # assets directory
+└── assets                   # assets directory
     ├── dynamodb             # dynamodb assets
     │   ├── 000000000000_eu-central-1.db
     │   └── 886002141588_us-east-1.db

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -56,11 +56,11 @@ LocalStack takes point-in-time snapshot of its state and dumps them to disk.
 There are four strategies that you can choose from that govern when these snapshots are taken.
 You can select a particular save strategy by setting `SNAPSHOT_SAVE_STRATEGY=<strategy>`.
 
-* **`ON_REQUEST`**: on every AWS API call that potentially modifies the state of a service, LocalStack will save the state of that service.
+* **`ON_REQUEST`**: (**default**) on every AWS API call that potentially modifies the state of a service, LocalStack will save the state of that service.
   This was the default strategy until v2.0. It minimizes the chance for data loss, but also has significant performance implications. The service has to be locked during snapshotting, meaning that any requests to the particular AWS service will be blocked until the snapshot is complete.  In many cases this is just a few milliseconds, but can become significant in some services.
 * **`ON_SHUTDOWN`**: the state of all services are saved during the shutdown phase of LocalStack.
   This strategy has zero performance impact, but is not good when you want to minimize the chance for data loss. Should LocalStack for some reason not shut down properly or is terminated before it can finalize the snapshot, you may be left with an incomplete state on disk.
-* **`SCHEDULED`**: (**default**) every 15 seconds, the state of all services that have been modified since the last snapshot are saved.
+* **`SCHEDULED`**: every 15 seconds, the state of all services that have been modified since the last snapshot are saved.
   This is a compromise between `ON_REQUEST` and `ON_SHUTDOWN` in terms of performance and reliability.
 * **`MANUAL`**: turns off automatic snapshotting and gives you control through the internal state endpoints.
 
@@ -126,7 +126,7 @@ Some services also store application-specific data, which we call _assets_.
 For example, when you start an RDS PostgreSQL database, LocalStack not only stores the RDS resource information, but also the PostgreSQL data.
 Another example is Kinesis, which persists some data in form of JSON objects per account, or DynamoDB that serializes its stat into an SQLite database per account and region.
 
-The current LocalStack snapshot is stored into `/var/lib/localstack/state`, and separated into `api_states` (LocalStack internal state), and assets (one directory per service).
+The current LocalStack snapshot is stored into `/var/lib/localstack/state`, and separated into `api_states` (LocalStack internal state), and `assets` (one directory per service).
 Here is what this looks like:
 
 ```plaintext
@@ -140,12 +140,13 @@ Here is what this looks like:
 │   │   └── store.state
 │   └── lambda
 │       └── store.state
-├── dynamodb                # dynamodb assets
-│   ├── 000000000000_eu-central-1.db
-│   └── 886002141588_us-east-1.db
-└── kinesis                 # kinesis assets
-    ├── 000000000000.json
-    └── 886002141588.json
+└── api_states               # assets directory
+    ├── dynamodb             # dynamodb assets
+    │   ├── 000000000000_eu-central-1.db
+    │   └── 886002141588_us-east-1.db
+    └── kinesis              # kinesis assets
+        ├── 000000000000.json
+        └── 886002141588.json
 ```
 
 To load a snapshot, LocalStack traverses the state directory and deserializes state files to loads them into the memory.

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -105,6 +105,7 @@ Persistence for services that are _not_ listed here _may_ work correctly, but ar
 * SNS
 * SQS
 * Stepfunctions
+* RDS: Postgres, MariaDB, MySQL
 * ... TODO
 
 ### Known limitations
@@ -113,6 +114,9 @@ Persistence for services that are _not_ listed here _may_ work correctly, but ar
 * **MSK**: Kafka brokers are not restored
 * **EC2**: works for most resources, but emulated VM data is not restored
 * **Firehose**: Kinesis delivery streams are not restored
+* **RDS**: MSSQL database is not restored
+* **Neptune**: database is not restored
+* **DocDB**: database is not restored
 * ... TODO
 
 ## Technical Details

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -57,7 +57,7 @@ There are four strategies that you can choose from that govern when these snapsh
 You can select a particular save strategy by setting `SNAPSHOT_SAVE_STRATEGY=<strategy>`.
 
 * **`ON_REQUEST`**: (**default**) on every AWS API call that potentially modifies the state of a service, LocalStack will save the state of that service.
-  This was the default strategy until v2.0. It minimizes the chance for data loss, but also has significant performance implications. The service has to be locked during snapshotting, meaning that any requests to the particular AWS service will be blocked until the snapshot is complete.  In many cases this is just a few milliseconds, but can become significant in some services.
+  This strategy minimizes the chance for data loss, but also has significant performance implications. The service has to be locked during snapshotting, meaning that any requests to the particular AWS service will be blocked until the snapshot is complete.  In many cases this is just a few milliseconds, but can become significant in some services.
 * **`ON_SHUTDOWN`**: the state of all services are saved during the shutdown phase of LocalStack.
   This strategy has zero performance impact, but is not good when you want to minimize the chance for data loss. Should LocalStack for some reason not shut down properly or is terminated before it can finalize the snapshot, you may be left with an incomplete state on disk.
 * **`SCHEDULED`**: every 15 seconds, the state of all services that have been modified since the last snapshot are saved.
@@ -97,16 +97,26 @@ Persistence for services that are _not_ listed here _may_ work correctly, but ar
 
 ### Supported & tested
 
+* ACM
+* Amplify
 * API Gateway
+* AppConfig
+* AppSync
+* CloudWatch
+* Cognito
 * DynamodDB
+* IAM
 * Kinesis
+* KMS
 * Lambda
+* RDS: Postgres, MariaDB, MySQL
+* Route53
 * S3
+* SecresManager
 * SNS
 * SQS
+* SSM
 * Stepfunctions
-* RDS: Postgres, MariaDB, MySQL
-* ... TODO
 
 ### Known limitations
 
@@ -117,7 +127,9 @@ Persistence for services that are _not_ listed here _may_ work correctly, but ar
 * **RDS**: MSSQL database is not restored
 * **Neptune**: database is not restored
 * **DocDB**: database is not restored
-* ... TODO
+
+### Not Implemented
+* MQ
 
 ## Technical Details
 

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -56,11 +56,11 @@ LocalStack takes point-in-time snapshot of its state and dumps them to disk.
 There are four strategies that you can choose from that govern when these snapshots are taken.
 You can select a particular save strategy by setting `SNAPSHOT_SAVE_STRATEGY=<strategy>`.
 
-* **`ON_REQUEST`**: (**default**) on every AWS API call that potentially modifies the state of a service, LocalStack will save the state of that service.
+* **`ON_REQUEST`**: on every AWS API call that potentially modifies the state of a service, LocalStack will save the state of that service.
   This strategy minimizes the chance for data loss, but also has significant performance implications. The service has to be locked during snapshotting, meaning that any requests to the particular AWS service will be blocked until the snapshot is complete.  In many cases this is just a few milliseconds, but can become significant in some services.
 * **`ON_SHUTDOWN`**: the state of all services are saved during the shutdown phase of LocalStack.
   This strategy has zero performance impact, but is not good when you want to minimize the chance for data loss. Should LocalStack for some reason not shut down properly or is terminated before it can finalize the snapshot, you may be left with an incomplete state on disk.
-* **`SCHEDULED`**: every 15 seconds, the state of all services that have been modified since the last snapshot are saved.
+* **`SCHEDULED`**: (**default**) every 15 seconds, the state of all services that have been modified since the last snapshot are saved.
   This is a compromise between `ON_REQUEST` and `ON_SHUTDOWN` in terms of performance and reliability.
 * **`MANUAL`**: turns off automatic snapshotting and gives you control through the internal state endpoints.
 

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -68,8 +68,8 @@ You can select a particular save strategy by setting `SNAPSHOT_SAVE_STRATEGY=<st
 
 You can also configure when LocalStack should restore the state snapshots.
 
-* **`ON_REQUEST`**: the state is loaded lazily when the service is requested. This maintains LocalStack's lazy-loading behavior for AWS services.
-* **`ON_STARTUP`**: (**default**) the state of all services in the snapshot is restored when LocalStack starts up. This means that services that have stored state are also started on LocalStack start, which will increase the startup time, but also give you immediate feedback whether the state was restored correctly.
+* **`ON_REQUEST`**: (**default**) the state is loaded lazily when the service is requested. This maintains LocalStack's lazy-loading behavior for AWS services.
+* **`ON_STARTUP`**: the state of all services in the snapshot is restored when LocalStack starts up. This means that services that have stored state are also started on LocalStack start, which will increase the startup time, but also give you immediate feedback whether the state was restored correctly.
 * **`MANUAL`**: turns off automatic loading of snapshots and gives you control through the internal state endpoints.
 
 ### Endpoints

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -138,7 +138,7 @@ Some services also store application-specific data, which we call _assets_.
 For example, when you start an RDS PostgreSQL database, LocalStack not only stores the RDS resource information, but also the PostgreSQL data.
 Another example is Kinesis, which persists some data in form of JSON objects per account, or DynamoDB that serializes its stat into an SQLite database per account and region.
 
-The current LocalStack snapshot is stored into `/var/lib/localstack/state`, and separated into `api_states` (LocalStack internal state), and `assets` (one directory per service).
+The current LocalStack snapshot is stored into `/var/lib/localstack/state`, and separated into `api_states` (LocalStack internal state), and assets (one directory per service).
 Here is what this looks like:
 
 ```plaintext
@@ -152,13 +152,12 @@ Here is what this looks like:
 │   │   └── store.state
 │   └── lambda
 │       └── store.state
-└── assets                   # assets directory
-    ├── dynamodb             # dynamodb assets
-    │   ├── 000000000000_eu-central-1.db
-    │   └── 886002141588_us-east-1.db
-    └── kinesis              # kinesis assets
-        ├── 000000000000.json
-        └── 886002141588.json
+├── dynamodb                # dynamodb assets
+│   ├── 000000000000_eu-central-1.db
+│   └── 886002141588_us-east-1.db
+└── kinesis                 # kinesis assets
+    ├── 000000000000.json
+    └── 886002141588.json
 ```
 
 To load a snapshot, LocalStack traverses the state directory and deserializes state files to loads them into the memory.


### PR DESCRIPTION
This PR updates the [persistence documentation](https://localstack-docs-preview-pr-522.surge.sh/references/persistence-mechanism/) to the current version that uses our new persistence plugin.

There are still some TODOs left to document the current limitations of services