### PR TITLE
inclusion of terraform test results in Coverage Docs

### DIFF
--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Download metrics data from Terraform Integration test pipeline (GitHub)
         working-directory: docs
-        run: ./scripts/get_latest_github_metrics.sh ./target metric-collection # TODO change to main
+        run: ./scripts/get_latest_github_metrics.sh ./target main # TODO change to main
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-terraform-test 

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Download metrics data from Terraform Integration test pipeline (GitHub)
         working-directory: docs
-        run: ./scripts/get_latest_github_metrics.sh ./target main # TODO change to main
+        run: ./scripts/get_latest_github_metrics.sh ./target main
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-terraform-test 

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -41,6 +41,16 @@ jobs:
           PREFIX_ARTIFACT: moto-integration-test
           FILTER_SUCCESS: 0
 
+      - name: Download metrics data from Terraform Integration test pipeline (GitHub)
+        working-directory: docs
+        run: ./scripts/get_latest_github_metrics.sh ./target metric-collection # TODO change to main
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
+          REPOSITORY_NAME: localstack-terraform-test 
+          ARTIFACT_ID: test-metrics
+          WORKFLOW: "Terraform Tests"
+          FILTER_SUCCESS: 0
+
       - name: Download metrics data from Pro pipeline (GitHub)
         working-directory: docs
         run: ./scripts/get_latest_github_metrics.sh ./target master

--- a/layouts/partials/coverage/coverage_details.html
+++ b/layouts/partials/coverage/coverage_details.html
@@ -16,7 +16,6 @@ Some calls might be internal, i.e., they are not explicitly called in the test, 
             <li>information about validation:</li>
             <ul>
                 <li><span class="coverage-report-tag-aws-validated">AWS validated</span> the test is validated against AWS, meaning it run successfully against real AWS as well</li>
-                <!-- TODO might need to adapt the link to snapshot tests -->
                 <li><span class="coverage-report-tag-snapshot">Snapshot Tested</span> this is a <a href="/contributing/parity-testing/">snapshot parity test</a>, meaning the responses are validated against AWS</li>
             </ul>
         </ul>

--- a/layouts/partials/coverage/coverage_table.html
+++ b/layouts/partials/coverage/coverage_table.html
@@ -4,7 +4,7 @@
             <tr>
                 <th class="coverage-report-header-1"></th>
                 <th class="coverage-report-header-2" colspan="2" style="text-align: center;padding-bottom: 0;" >Availability</th>
-                <th colspan="5" style="text-align: center;padding-bottom: 0" class="coverage-report-header-1"><a href="#terminology">Testing*</a></th>
+                <th colspan="6" style="text-align: center;padding-bottom: 0" class="coverage-report-header-1"><a href="#terminology">Testing*</a></th>
             </tr>
             <tr>
             <th class="coverage-report-header-1">Operation</th>
@@ -12,6 +12,7 @@
             <th class="coverage-report-header-2">Edition</th>
             <th class="coverage-report-header-1">Internal Test Suite</th>
             <th class="coverage-report-header-1">External Test Suite</th>
+            <th class="coverage-report-header-1">Terraform Validated</th>
             <th class="coverage-report-header-1">AWS Validated</th>
             <th class="coverage-report-header-1">Snapshot Tested</th>
             <th class="coverage-report-header-1">Details</th>
@@ -26,8 +27,8 @@
     <ul>
     <li><b>Internal Test Suite:</b> tested by LocalStack's internal integration test suite</li>
     <li><b>External Test Suite:</b> covered by an external integration test suite, that runs against LocalStack</li>
+    <li><b>Terraform Validated:</b> operation tested with <a href="/user-guide/integrations/terraform/">Terraform</a></li>
     <li><b>AWS Validated:</b> the integration test that includes this operation call was validated against AWS</li>
-    <!-- TODO might need to adapt the link -->
     <li><b>Snapshot Tested:</b> the operation is part of a <a href="/contributing/parity-testing/">snapshot parity test</a>, which verifies the responses by LocalStack and AWS are the same</li>
     </ul>
 </div>

--- a/layouts/partials/coverage/coverage_table_row.html
+++ b/layouts/partials/coverage/coverage_table_row.html
@@ -20,6 +20,8 @@
     <td class="coverage-shadow-overlay-green">{{ if ($op.internal_test_suite) }} ✔️ {{ end }}</td>
     <!-- External Test Suite --> 
     <td class="coverage-shadow-overlay-green">{{ if ($op.external_test_suite) }} ✔️ {{ end }}</td>
+    <!-- Terraform Validated -->
+    <td class="coverage-shadow-overlay-green">{{ if ($op.terraform_test_suite) }} ✔️ {{ end }}</td>
     <!-- AWS Validated -->
     <td class="coverage-shadow-overlay-green">{{ if ($op.aws_validated) }} ✔️ {{ end }}</td>
     <!-- Snapshot Tested -->

--- a/scripts/create_data_coverage.py
+++ b/scripts/create_data_coverage.py
@@ -317,7 +317,7 @@ def aggregate_recorded_raw_data(
 
                 if external_test and metric.get("response_code") in ["500", "501"]:
                     # some external tests (e.g seen for terraform) seem to succeed even though single operation calls fail
-                    # we do not include those are "passed tests"
+                    # we do not include those as "passed tests"
                     print(f"skipping {service}.{op_name}: response_code {metric.get('response_code')} ({test_source})")
                     continue 
 


### PR DESCRIPTION
Adds the terraform test results to the Coverage Docs table to indicate that an operation was run using terraform.
- Adapted the workflow to download artifacts from `localstack-terraform-test` project
- Added new column to the table

TODO:

- [x] run workflow with artifacts from feature branch
- [x] change workflow to use main branch
      - tested workflow, resulting PR https://github.com/localstack/docs/pull/571 and preview can be checked here: https://localstack-docs-preview-pr-571.surge.sh/references/coverage/coverage_sqs/
