### PR TITLE
Change provider naming from asf to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+all: dev
+
+serve:
+	hugo serve
+
+dev:
+	hugo serve --watch=true --disableFastRender -D
+
+install:
+	git submodule update --init --recursive
+	@which hugo && echo "Please install Hugo extended: https://gohugo.io/installation/"
+
+.PHONY: serve dev install

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -147,7 +147,7 @@ The OpenSearch configuration variables are used to manage both, OpenSearch and E
 | `KINESIS_LATENCY` | `500` (default), `0` (to disable)| Integer value of milliseconds, causing the Kinesis API to delay returning a response in order to mimic latency from a live AWS call. |
 | `KINESIS_INITIALIZE_STREAMS` | `"my-first-stream:1,my-other-stream:2:us-west-2,my-last-stream:1"` | A comma-delimited string of stream names, its corresponding shard count and an optional region to initialize during startup. If the region is not provided, the default region is used. Only works with the `kinesis-mock` `KINESIS_PROVIDER`. |
 
-### Lambda (New / `asf`)
+### Lambda (New / `v2`)
 
 | Variable| Example Values | Description |
 | - | - | - |

--- a/content/en/references/lambda-v2-provider.md
+++ b/content/en/references/lambda-v2-provider.md
@@ -3,6 +3,8 @@ title: "Lambda Provider Behavioral Changes"
 weight: 5
 description: >
   Behavioral changes to become default with the new lambda provider
+aliases:
+  /references/lambda-asf-provider/
 ---
 
 ## Overview
@@ -30,7 +32,7 @@ Timeouts are now properly supported, and will, as in AWS, not kill the environme
 
 ## Changes in Hot Swapping
 The magic key for hot reloading (or swapping) buckets has changed from `__local__` to `hot-reload`.
-While the former is still supported in the old provider, the new one (`asf`) will only support the latter.
+While the former is still supported in the old provider, the new one (`v2`) will only support the latter.
 The configuration variable `BUCKET_MARKER_LOCAL` is still respected. Use this if you want to customize its name.
 Since the new Lambda provider does not restart the containers after each invocation, even for hot reloading, the filesystem will stay the same.
 

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -10,10 +10,10 @@ aliases:
 
 {{< alert title="Warning" color="warning" >}}
 A new implementation of the Lambda service is available since LocalStack 1.3.
-Set `PROVIDER_OVERRIDE_LAMBDA=asf` when starting LocalStack and let us know if you experience any issues!
+Set `PROVIDER_OVERRIDE_LAMBDA=v2` when starting LocalStack and let us know if you experience any issues!
 
 Starting with LocalStack 2.0 the current Lambda implementation will be deprecated in favor of this new provider.
-For more information about behavioral changes, please consult the [Lambda Behavioral Changes]({{< ref "references/lambda-asf-provider" >}}) page.
+For more information about behavioral changes, please consult the [Lambda Behavioral Changes]({{< ref "references/lambda-v2-provider" >}}) page.
 {{< /alert >}}
 
 
@@ -23,10 +23,10 @@ LocalStack allows you to execute your Lambda functions locally, without the need
 
 ## Lambda Providers
 
-LocalStack's Lambda support is available via two providers, the old one and our new and more stable provider (labeled `asf` after our new internal service framework). Set the `PROVIDER_OVERRIDE_LAMBDA` variable to switch between the two providers, e.g. `PROVIDER_OVERRIDE_LAMBDA=asf`. 
+LocalStack's Lambda support is available via two providers, the old one `legacy` and our new and more stable provider `v2` (formerly known as `asf`). Set the `PROVIDER_OVERRIDE_LAMBDA` variable to switch between the two providers, e.g. `PROVIDER_OVERRIDE_LAMBDA=v2`. 
 
 By default LocalStack still uses the old provider.
-With LocalStack v2.0, this will be changed to ASF, but the old provider will still be available, in case you need some additional time to migrate.
+With LocalStack v2.0, this will be changed to `v2`, but the old provider will still be available (`legacy`), in case you need some additional time to migrate.
 This fallback option will then be removed in further releases. 
 
 ## Special tooling for Lambdas

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -66,9 +66,9 @@ All other requests will be considered path-style requests. It is advised to use 
 
 ## S3 Providers
 
-LocalStack's S3 support is currently available via two providers: `old` and `asf`. For users, switching between the two providers has a lot of impacts. Using the `PROVIDER_OVERRIDE_S3`, you can switch between the two providers. The `old` provider is the default provider, and the `asf` provider is ASF, our new and more stable provider. The `old` provider is loaded by default, and you need to set `PROVIDER_OVERRIDE_S3=asf` to use the ASF provider. Licensed users can use `asf_pro` to use the ASF provider with the [Pro features]({{< ref "references/coverage#s3" >}}).
+LocalStack's S3 support is currently available via two providers: `legacy` and `v2` (formerly known as `asf`). For users, switching between the two providers has a lot of impacts. Using the `PROVIDER_OVERRIDE_S3`, you can switch between the two providers. The `legacy` provider is the default provider and the `v2` provider is our new and more stable provider. The `legacy` provider is loaded by default, and you need to set `PROVIDER_OVERRIDE_S3=v2` to use the new provider. Licensed users can use `v2_pro` to use the new provider with the [Pro features]({{< ref "references/coverage#s3" >}}).
 
-With v2.0, the default will be changed to ASF, but the old provider will still be available (using the feature flag with the value `legacy`), though it will be removed in further releases.
+With v2.0, the default will be changed to `v2`, but the legacy provider will still be available (using the feature flag with the value `legacy`), though it will be removed in further releases.
 
 ## Storage Configuration
 

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -66,7 +66,7 @@ All other requests will be considered path-style requests. It is advised to use 
 
 ## S3 Providers
 
-LocalStack's S3 support is currently available via two providers: `legacy` and `v2` (formerly known as `asf`). For users, switching between the two providers has a lot of impacts. Using the `PROVIDER_OVERRIDE_S3`, you can switch between the two providers. The `legacy` provider is the default provider and the `v2` provider is our new and more stable provider. The `legacy` provider is loaded by default, and you need to set `PROVIDER_OVERRIDE_S3=v2` to use the new provider. Licensed users can use `v2_pro` to use the new provider with the [Pro features]({{< ref "references/coverage#s3" >}}).
+LocalStack's S3 support is currently available via two providers: `legacy` and `v2` (formerly known as `asf`). For users, switching between the two providers has a lot of impacts. Using the `PROVIDER_OVERRIDE_S3`, you can switch between the two providers. The `legacy` provider is the default provider and the `v2` provider is our new and more stable provider. The `legacy` provider is loaded by default, and you need to set `PROVIDER_OVERRIDE_S3=v2` to use the new provider.
 
 With v2.0, the default will be changed to `v2`, but the legacy provider will still be available (using the feature flag with the value `legacy`), though it will be removed in further releases.
 

--- a/content/en/user-guide/tools/lambda-tools/hot-swapping/index.md
+++ b/content/en/user-guide/tools/lambda-tools/hot-swapping/index.md
@@ -38,7 +38,7 @@ This way, any saved change inside your source file directly affects the already 
 When using the new Lambda provider, hot-reloading does not conflict with fast execution times, and it is not needed to spawn a new container for every invocation.
 Also, hot reloading for Lambda layers (Pro) is now supported, it works identical to functions, but only 1 layer is allowed per function if hot-reloading is active in the layer.
 
-For more information about behavioral changes, please consult the [Lambda Behavioral Changes]({{< ref "references/lambda-asf-provider" >}}) page.
+For more information about behavioral changes, please consult the [Lambda Behavioral Changes]({{< ref "references/lambda-v2-provider" >}}) page.
 
 ## Application Configuration Examples
 


### PR DESCRIPTION
* Adjust provider naming for S3 and Lambda from `asf` to `v2` in line with:
  * https://github.com/localstack/localstack/pull/7648
  * https://github.com/localstack/localstack/pull/7625
* Add a `Makefile` to automate common commands 