### PR TITLE
fix dead link to parity-testing details

### DIFF
--- a/layouts/partials/coverage/coverage_details.html
+++ b/layouts/partials/coverage/coverage_details.html
@@ -17,7 +17,7 @@ Some calls might be internal, i.e., they are not explicitly called in the test, 
             <ul>
                 <li><span class="coverage-report-tag-aws-validated">AWS validated</span> the test is validated against AWS, meaning it run successfully against real AWS as well</li>
                 <!-- TODO might need to adapt the link to snapshot tests -->
-                <li><span class="coverage-report-tag-snapshot">Snapshot Tested</span> this is a <a href="../../contributing/parity-testing/">snapshot parity test</a>, meaning the responses are validated against AWS</li>
+                <li><span class="coverage-report-tag-snapshot">Snapshot Tested</span> this is a <a href="/contributing/parity-testing/">snapshot parity test</a>, meaning the responses are validated against AWS</li>
             </ul>
         </ul>
 </ul>

--- a/layouts/partials/coverage/coverage_table.html
+++ b/layouts/partials/coverage/coverage_table.html
@@ -28,6 +28,6 @@
     <li><b>External Test Suite:</b> covered by an external integration test suite, that runs against LocalStack</li>
     <li><b>AWS Validated:</b> the integration test that includes this operation call was validated against AWS</li>
     <!-- TODO might need to adapt the link -->
-    <li><b>Snapshot Tested:</b> the operation is part of a <a href="../../contributing/parity-testing/">snapshot parity test</a>, which verifies the responses by LocalStack and AWS are the same</li>
+    <li><b>Snapshot Tested:</b> the operation is part of a <a href="/contributing/parity-testing/">snapshot parity test</a>, which verifies the responses by LocalStack and AWS are the same</li>
     </ul>
 </div>


### PR DESCRIPTION
The link to `parity-testing` was relative, and pointing to a non-existing page. 

Changed the link to use the path from root. 