### PR TITLE
add JavaScript SDK example

### DIFF
--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -44,7 +44,8 @@ lambda.listFunctions({}, (err, data) => {
   }
 });
 
-// Now, we create an S3 client, which has a special endpoint (see S3 documentation to read more about the different endpoints).
+// Now, we create an S3 client, which has a special endpoint
+// (see S3 documentation to read more about the different endpoints).
 const s3 = new AWS.S3({
   endpoint: 'http://s3.localhost.localstack.cloud:4566',
   s3ForcePathStyle: true,  // If you want to use virtual host addressing of buckets, you can remove `s3ForcePathStyle: true`. 
@@ -64,6 +65,7 @@ s3.listBuckets((err, data) => {
 {{< /tab >}}
 {{< tab header="aws-sdk-js-v3" lang="javascript" >}}
 const { LambdaClient, ListFunctionsCommand } = require('@aws-sdk/client-lambda');
+const { S3Client, ListBucketsCommand } = require('@aws-sdk/client-s3');
 
 // Configure the AWS SDK to use the LocalStack endpoint and credentials
 const lambda = new LambdaClient({
@@ -81,13 +83,15 @@ lambda.send(new ListFunctionsCommand({}))
   .catch((error) => console.error(error));
 
 
-/* By default, @aws-sdk/client-s3 will using virtual host addressing (http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>). To allow those requests to be directed to LocalStack, you need to set a specific endpoint. If this is not possible, you can set the special S3 configuration flag to use path addressing instead (http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>). You can read S3 documentation to learn more about the different endpoints. 
-*/
-const { S3Client, ListBucketsCommand } = require('@aws-sdk/client-s3');
+// By default, @aws-sdk/client-s3 will using virtual host addressing (http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>).
+// To allow those requests to be directed to LocalStack, you need to set a specific endpoint.
+// If this is not possible, you can set the special S3 configuration flag to 
+// use path addressing instead (http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>).
+// You can read S3 documentation to learn more about the different endpoints. 
 
-const s3Client = new S3({
+const s3 = new S3({
   region: 'us-east-1',
-  forcePathStyle: true,  // If you want to use virtual host addressing of buckets, you can remove `forcePathStyle: true`. 
+  forcePathStyle: true, // If you want to use virtual host addressing of buckets, you can remove `forcePathStyle: true`. 
   endpoint: 'http://s3.localstack.localhost.cloud:4566',
   credentials: {
     accessKeyId: 'test',
@@ -96,7 +100,7 @@ const s3Client = new S3({
 });
 
 // Call an S3 API using the LocalStack endpoint
-s3Client.send(new ListBucketsCommand({}))
+s3.send(new ListBucketsCommand({}))
   .then((data) => console.log(data))
   .catch((error) => console.error(error));
   
@@ -105,7 +109,7 @@ s3Client.send(new ListBucketsCommand({}))
 {{< /tabpane >}}
 
 {{< alert title="Note">}}
-In case of issues resolving S3 DNS record, we can fallback to http://localhost:4566 in combination with the provider setting `forcePathStyle: true` (see the specific way of setting this parameter for each SDK above). The S3 service endpoint is slightly different from the other service endpoints, because AWS is deprecating path-style based access for hosting buckets. See [S3 documentation]({{< ref "S3" >}}) about endpoints.
+In case of issues resolving S3 DNS record, we can fallback to `http://localhost:4566` in combination with the provider setting `forcePathStyle: true` (see the specific way of setting this parameter for each SDK above). The S3 service endpoint is slightly different from the other service endpoints, because AWS is deprecating path-style based access for hosting buckets. See [S3 documentation]({{< ref "S3" >}}) about endpoints.
 {{< /alert >}}
 
 

--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -45,7 +45,7 @@ lambda.listFunctions({}, (err, data) => {
 });
 
 // Now, we create an S3 client, which has a special endpoint
-// (see S3 documentation to read more about the different endpoints).
+// You can read the S3 documentation to learn more about the different endpoints.
 const s3 = new AWS.S3({
   endpoint: 'http://s3.localhost.localstack.cloud:4566',
   s3ForcePathStyle: true,  // If you want to use virtual host addressing of buckets, you can remove `s3ForcePathStyle: true`. 
@@ -83,11 +83,13 @@ lambda.send(new ListFunctionsCommand({}))
   .catch((error) => console.error(error));
 
 
-// By default, @aws-sdk/client-s3 will using virtual host addressing (http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>).
+// By default, @aws-sdk/client-s3 will using virtual host addressing:
+// -> http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>
 // To allow those requests to be directed to LocalStack, you need to set a specific endpoint.
-// If this is not possible, you can set the special S3 configuration flag to 
-// use path addressing instead (http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>).
-// You can read S3 documentation to learn more about the different endpoints. 
+// If this is not possible, you can set the special S3 configuration flag to use path
+// addressing instead: 
+// -> http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>
+// You can read the S3 documentation to learn more about the different endpoints. 
 
 const s3 = new S3({
   region: 'us-east-1',

--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -1,0 +1,56 @@
+---
+title: "JavaScript"
+categories: []
+tags: ["sdk"]
+description: >
+  How to use the JavaScript AWS SDK with LocalStack.
+aliases:
+  - /integrations/sdks/javascript/
+---
+
+## Overview
+
+The [AWS SDK for JavaScript](https://aws.amazon.com/sdk-for-javascript/), like other AWS SDKs, lets you set the endpoint when creating resource clients,
+which is the preferred way of integrating the JavaScript SDK with LocalStack.
+
+The JavaScript SDK has two major versions, each with their own way of specifying the LocalStack endpoint:
+
+* [aws-sdk-js](https://github.com/aws/aws-sdk-js)
+* [aws-sdk-js-v3](https://github.com/aws/aws-sdk-js-v3)
+
+## Examples
+
+Here is an example of how to create a Lambda client and an S3 client with the endpoint set to LocalStack.
+
+{{< tabpane >}}
+{{< tab header="aws-sdk-js" lang="javascript" >}}
+
+WIP
+
+{{< /tab >}}
+{{< tab header="aws-sdk-js-v3" lang="javascript" >}}
+
+WIP
+
+/* By default, @aws-sdk/client-s3 will using virtual host addressing (http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>). To allow those requests to be directed to LocalStack, you need to set a specific endpoint. If this is not possible, you can set the special S3 configuration flag to use path addressing instead (http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>). 
+*/
+
+const client = new S3({
+  region: "us-east-1",
+  forcePathStyle: true,
+  endpoint: "http://s3.localstack.localhost.cloud:4566"
+});
+
+{{< /tab >}}
+{{< /tabpane >}}
+
+{{< alert title="Note">}}
+In case of issues resolving S3 DNS record, we can fallback to http://localhost:4566 in combination with the provider setting `forcePathStyle: true` (see the specific way of setting this parameter for each SDK above). The S3 service endpoint is slightly different from the other service endpoints, because AWS is deprecating path-style based access for hosting buckets.
+{{< /alert >}}
+
+
+## Resources
+
+* [AWS SDK for Go](https://aws.amazon.com/sdk-for-javascript/)
+* [Official repository of the AWS SDK for JavaScript (v2)](https://github.com/aws/aws-sdk-js)
+* [Official repository of the AWS SDK for JavaScript (v3)](https://github.com/aws/aws-sdk-js-v3)

--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -91,10 +91,10 @@ lambda.send(new ListFunctionsCommand({}))
 // -> http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>
 // You can read the S3 documentation to learn more about the different endpoints. 
 
-const s3 = new S3({
+const s3 = new S3Client({
   region: 'us-east-1',
   forcePathStyle: true, // If you want to use virtual host addressing of buckets, you can remove `forcePathStyle: true`. 
-  endpoint: 'http://s3.localstack.localhost.cloud:4566',
+  endpoint: 'http://s3.localhost.localstack.cloud:4566',
   credentials: {
     accessKeyId: 'test',
     secretAccessKey: 'test',

--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -25,32 +25,92 @@ Here is an example of how to create a Lambda client and an S3 client with the en
 {{< tabpane >}}
 {{< tab header="aws-sdk-js" lang="javascript" >}}
 
-WIP
+const AWS = require('aws-sdk');
 
+// Configure the AWS SDK to use the LocalStack endpoint and credentials
+const lambda = new AWS.Lambda({
+  endpoint: 'http://localhost:4566',
+  accessKeyId: 'test',
+  secretAccessKey: 'test',
+  region: 'us-east-1',
+});
+
+// List the Lambda functions using the LocalStack endpoint
+lambda.listFunctions({}, (err, data) => {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(data);
+  }
+});
+
+// Now, we create an S3 client, which has a special endpoint (see S3 documentation to read more about the different endpoints).
+const s3 = new AWS.S3({
+  endpoint: 'http://s3.localhost.localstack.cloud:4566',
+  s3ForcePathStyle: true,  // If you want to use virtual host addressing of buckets, you can remove `s3ForcePathStyle: true`. 
+  accessKeyId: 'test',
+  secretAccessKey: 'test',
+  region: 'us-east-1',
+});
+
+// Call an S3 API using the LocalStack endpoint
+s3.listBuckets((err, data) => {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(data);
+  }
+});
 {{< /tab >}}
 {{< tab header="aws-sdk-js-v3" lang="javascript" >}}
+const { LambdaClient, ListFunctionsCommand } = require('@aws-sdk/client-lambda');
 
-WIP
-
-/* By default, @aws-sdk/client-s3 will using virtual host addressing (http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>). To allow those requests to be directed to LocalStack, you need to set a specific endpoint. If this is not possible, you can set the special S3 configuration flag to use path addressing instead (http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>). 
-*/
-
-const client = new S3({
-  region: "us-east-1",
-  forcePathStyle: true,
-  endpoint: "http://s3.localstack.localhost.cloud:4566"
+// Configure the AWS SDK to use the LocalStack endpoint and credentials
+const lambda = new LambdaClient({
+  endpoint: 'http://localhost:4566',
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'test',
+    secretAccessKey: 'test',
+  },
 });
+
+// Call a Lambda API using the LocalStack endpoint
+lambda.send(new ListFunctionsCommand({}))
+  .then((data) => console.log(data))
+  .catch((error) => console.error(error));
+
+
+/* By default, @aws-sdk/client-s3 will using virtual host addressing (http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name>). To allow those requests to be directed to LocalStack, you need to set a specific endpoint. If this is not possible, you can set the special S3 configuration flag to use path addressing instead (http://s3.localhost.localstack.cloud:4566/<bucket-name>/<key-name>). You can read S3 documentation to learn more about the different endpoints. 
+*/
+const { S3Client, ListBucketsCommand } = require('@aws-sdk/client-s3');
+
+const s3Client = new S3({
+  region: 'us-east-1',
+  forcePathStyle: true,  // If you want to use virtual host addressing of buckets, you can remove `forcePathStyle: true`. 
+  endpoint: 'http://s3.localstack.localhost.cloud:4566',
+  credentials: {
+    accessKeyId: 'test',
+    secretAccessKey: 'test',
+  },
+});
+
+// Call an S3 API using the LocalStack endpoint
+s3Client.send(new ListBucketsCommand({}))
+  .then((data) => console.log(data))
+  .catch((error) => console.error(error));
+  
 
 {{< /tab >}}
 {{< /tabpane >}}
 
 {{< alert title="Note">}}
-In case of issues resolving S3 DNS record, we can fallback to http://localhost:4566 in combination with the provider setting `forcePathStyle: true` (see the specific way of setting this parameter for each SDK above). The S3 service endpoint is slightly different from the other service endpoints, because AWS is deprecating path-style based access for hosting buckets.
+In case of issues resolving S3 DNS record, we can fallback to http://localhost:4566 in combination with the provider setting `forcePathStyle: true` (see the specific way of setting this parameter for each SDK above). The S3 service endpoint is slightly different from the other service endpoints, because AWS is deprecating path-style based access for hosting buckets. See [S3 documentation]({{< ref "S3" >}}) about endpoints.
 {{< /alert >}}
 
 
 ## Resources
 
-* [AWS SDK for Go](https://aws.amazon.com/sdk-for-javascript/)
+* [AWS SDK for JavaScript](https://aws.amazon.com/sdk-for-javascript/)
 * [Official repository of the AWS SDK for JavaScript (v2)](https://github.com/aws/aws-sdk-js)
 * [Official repository of the AWS SDK for JavaScript (v3)](https://github.com/aws/aws-sdk-js-v3)


### PR DESCRIPTION
Add JS SDK example configuration for a regular client like lambda and for S3, which we could link to in GH issues. 

fixes #533

(page visible here: https://localstack-docs-preview-pr-538.surge.sh/user-guide/integrations/sdks/javascript/)