### PR TITLE
add all internal-tested operations as implemented 

### DIFF
--- a/scripts/create_data_coverage.py
+++ b/scripts/create_data_coverage.py
@@ -339,8 +339,7 @@ def aggregate_recorded_raw_data(
                 if internal_test and not op_record["implemented"]:
                     print(f"WARN: {service}.{op_name} classified as 'not implemented', but found a test calling it: ({source}) {node_id}")
                     op_record["implemented"] = True
-                    if source == "ls_pro":
-                        op_record["availability"] = "pro"
+                    op_record["availability"] = "pro" if source == "ls_pro" else "community"
                 
                 # test details currently only considered for internal test suite
                 # TODO might change when we include terraform test results


### PR DESCRIPTION
This PR marks operations as implemented, that are tested internally, but have been classified as "not implemented" before.

@bentsku made me aware, that some operations sometimes return a 501, even if implemented (and tested), see https://github.com/localstack/localstack/pull/7981. In this special case the root cause is moto, which [explicitly raises `NotImplementedError` if some special parameters](https://github.com/localstack/moto/blob/localstack/moto/s3/responses.py#L428-L432) are used. 

While running the script locally, I realized that some operations of services that are extended in pro, also seem to be wrongly classified now. Need to be further investigated. 
