### PR TITLE
remove docs on DISABLE_TERM_HANDLER

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -328,7 +328,6 @@ python -m localstack.cli.main --profile=dev config show
 | `OUTBOUND_HTTP_PROXY` | `http://10.10.1.3` | HTTP Proxy used for downloads of runtime dependencies and connections outside LocalStack itself
 | `OUTBOUND_HTTPS_PROXY` | `https://10.10.1.3` | HTTPS Proxy used for downloads of runtime dependencies and connections outside LocalStack itself
 | `REQUESTS_CA_BUNDLE` | `/var/lib/localstack/lib/ca_bundle.pem` | CA Bundle to be used to verify HTTPS requests made by LocalStack
-| `DISABLE_TERM_HANDLER` | | Whether to disable signal passing to LocalStack when running in docker. Enabling this will prevent an orderly shutdown when running inside LS in docker.
 
 
 ## Debugging


### PR DESCRIPTION
Removes a small entry in the configuration reference documenting the `DISABLE_TERM_HANDLER` environment variable. This variable will be removed with 2.0.
This flag has just been introduced to document the changed default behavior (but this "new" default behavior is actually just to correctly handle signals).