### PR TITLE
add workaround for JS SDK V2

### DIFF
--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -54,6 +54,12 @@ const s3 = new AWS.S3({
   region: 'us-east-1',
 });
 
+// if your region is `us-east-1`, you will need to override the globalEndpoint of the client
+// due to an issue in the SDK with `createBucket`.
+// you will need to set it to the hostname of your endpoint specified right above
+// if your region is different than `us-east-1`, you can skip that line
+s3.api.globalEndpoint = 's3.localhost.localstack.cloud';
+
 // Call an S3 API using the LocalStack endpoint
 s3.listBuckets((err, data) => {
   if (err) {


### PR DESCRIPTION
It seems we're having issue with AWS JS SDK v2, because it does a weird check to verify if the region is `us-east-1`: instead of checking the client region config, it checks if the endpoint is the global AWS S3 region. 

See related issue here: https://github.com/localstack/serverless-localstack/pull/214
And here: https://github.com/localstack/localstack/issues/8000

Basically, the change is to manually set the globalEndpoint of the client to the hostname of the endpoint configured above to skip the check: `s3.api.globalEndpoint = 's3.localhost.localstack.cloud';`
See https://github.com/localstack/localstack/issues/8000#issuecomment-1488788710

Here's the code in the SDK:
```javascript
  createBucket: function createBucket(params, callback) {
    // When creating a bucket *outside* the classic region, the location
    // constraint must be set for the bucket and it must match the endpoint.
    // This chunk of code will set the location constraint param based
    // on the region (when possible), but it will not override a passed-in
    // location constraint.
    if (typeof params === 'function' || !params) {
      callback = callback || params;
      params = {};
    }
    var hostname = this.endpoint.hostname;
    // copy params so that appending keys does not unintentioinallly
    // mutate params object argument passed in by user
    var copiedParams = AWS.util.copy(params);
    if (hostname !== this.api.globalEndpoint && !params.CreateBucketConfiguration) {
      copiedParams.CreateBucketConfiguration = { LocationConstraint: this.config.region };
    }
    return this.makeRequest('createBucket', copiedParams, callback);
  }
```

Another workaround from @lukqw was to manually set the `LocationConstraint` when creating a bucket to `null`, which the SDK won't override, but LocalStack will accept.
This solution in the docs seems the least intrusive and does not require the user to change their code if they target `us-east-1`. 

\cc @lukqw @whummer 