### PR TITLE
artifact retrieval circleci

### DIFF
--- a/scripts/get_latest_circleci_metrics.sh
+++ b/scripts/get_latest_circleci_metrics.sh
@@ -39,7 +39,10 @@ wget -m --cut-dirs 5 --no-host-directories $ARTIFACT_URLS
 
 echo "Moving raw community metrics data to $METRICS_RAW"
 mkdir -p $METRICS_RAW
-mv parity_metrics/metric-report-*.csv $METRICS_RAW/community-integration-test.csv
+for file in parity_metrics/*.csv; do
+      org_file_name=$(echo $file | sed "s/.*\///")
+      mv -- "$file" "$METRICS_RAW/community-integration-test-$org_file_name"
+done
 
 echo "Moving community metrics implementation details to $METRICS_IMPL..."
 mkdir -p $METRICS_IMPL


### PR DESCRIPTION
prepare workflow to retrieve several raw-metric files from circleci, relates to https://github.com/localstack/localstack/pull/8003:
* Previously, we had a script in CircleCI that was merging the outputs from the tests into one CSV. It also created some coverage information in `html` and `json` format.
* The coverage scripts will now be deleted, because they are not required anymore. 
* CircleCI will now store the artifacts from the test runs without prior modification. 
* This means that the docs update workflow need to retrieve several artifacts for the parity-metrics. The pattern is: `parity_metrics/*.csv`

[Tested the workflow](https://github.com/localstack/docs/actions/runs/4573032265/), by running against companion branch `cleanup_coverage_scripts`:
```
Moving raw community metrics data to ./target/metrics-raw/
Moving community metrics implementation details to ./target/metrics-implementation-details/...
Resulting file structure:
./target
├── metrics-implementation-details
│   ├── community
│   │   ├── implementation_coverage_aggregated.csv
│   │   └── implementation_coverage_full.csv
│   └── pro
│       ├── implementation_coverage_aggregated.csv
│       └── implementation_coverage_full.csv
└── metrics-raw
    ├── community-integration-test-metric-report-raw-data-2023-03-30__08_45_56-test-report-amd64-1.csv
    ├── community-integration-test-metric-report-raw-data-2023-03-30__08_45_57-test-report-amd64-0.csv
    ├── community-integration-test-metric-report-raw-data-2023-03-30__08_45_58-test-report-amd64-2.csv
    ├── community-integration-test-metric-report-raw-data-2023-03-30__08_46_03-test-report-amd64-3.csv
    ├── moto-integration-test-metric_data_raw.csv
    ├── pro-integration-test-metric-report-raw-data-2023-03-30__17_11_31-pytest-junit-main-amd64-1.csv
    └── pro-integration-test-metric-report-raw-data-2023-03-30__17_11_37-pytest-junit-main-amd64-2.csv
```