### PR TITLE
Update Testcontainers for Java docs

### DIFF
--- a/content/en/user-guide/integrations/testcontainers/index.md
+++ b/content/en/user-guide/integrations/testcontainers/index.md
@@ -49,12 +49,12 @@ go get github.com/testcontainers/testcontainers-go/modules/localstack
 <dependency>
     <groupId>org.testcontainers</groupId>
     <artifactId>localstack</artifactId>
-    <version>1.17.6</version>
+    <version>1.18.0</version>
     <scope>test</scope>
 </dependency>
 {{< /tab >}}
 {{< tab header="Java (Gradle)" lang="gradle">}}
-testImplementation 'org.testcontainers:localstack:1.17.6'
+testImplementation 'org.testcontainers:localstack:1.18.0'
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -87,8 +87,7 @@ await localStackContainer.StartAsync()
 container, err := localstack.StartContainer(ctx, localstack.NoopOverrideContainerRequest)
 {{< /tab >}}
 {{< tab header="Java" lang="java">}}
-LocalStackContainer localstack = new LocalStackContainer("localstack/localstack:1.4.0")
-    .withServices(LocalStackContainer.Service.S3);
+LocalStackContainer localstack = new LocalStackContainer("localstack/localstack:2.0.0");
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -166,10 +165,9 @@ The Testcontainer can be created like this:
   * In this sample we only map 5 ports, however, depending on your use case you may need to map ports up to 4559
 */
 @Rule
-public LocalStackContainer localstack = new LocalStackContainer(localstackImage)
+public LocalStackContainer localstack = new LocalStackContainer("localstack/localstack:2.0.0")
                                                     .withExposedPorts(4510, 4511, 4512, 4513, 4514) // TODO the port can have any value between 4510-4559, but LS starts from 4510
-                                                    .withEnv("LOCALSTACK_API_KEY", api_key) // TODO add your API key here
-                                                    .withServices(LocalStackContainer.EnabledService.named("rds"));
+                                                    .withEnv("LOCALSTACK_API_KEY", api_key); // TODO add your API key here
 
 ```
 


### PR DESCRIPTION
Testcontainers for Java doesn't need to declare the `SERVICES` env
var and it is compatible with LocalStack 2.0.0.
