### PR TITLE
IoT: Add lifecycle events

### DIFF
--- a/content/en/user-guide/aws/iot/index.md
+++ b/content/en/user-guide/aws/iot/index.md
@@ -8,8 +8,8 @@ aliases:
   - /aws/iot/
 ---
 
-LocalStack Pro supports IoT Core, IoT Analytics, IoT Data and related APIs.
-The main endpoints for creating and updating entities are implemented along with the CloudFormation integrations.
+LocalStack Pro supports IoT Core, IoT Data, IoT Analytics and related APIs.
+Common operations for creating and updating things, groups, policies, certificates and other entities are implemented with full CloudFormation support.
 
 ## MQTT Broker
 
@@ -27,7 +27,7 @@ This endpoint can then be used with any MQTT client to publish and subscribe to 
 
 ## Lifecycle Events
 
-LocalStack also publishes the [IoT lifecycle events](https://docs.aws.amazon.com/iot/latest/developerguide/life-cycle-events.html) to the standard endpoints.
+LocalStack also publishes the [lifecycle events](https://docs.aws.amazon.com/iot/latest/developerguide/life-cycle-events.html) to the standard endpoints.
 
 - `$aws/events/presence/connected/clientId`: when a client connects
 - `$aws/events/presence/disconnected/clientId`: when a client disconnects
@@ -40,4 +40,6 @@ Currently the `principalIdentifier` and `sessionIdentifier` fields in event payl
 
 It is also possible to use advanced features like SQL queries for IoT topic rules.
 
-For example, you can use the [`CreateTopicRule`](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateTopicRule.html) operation to define a topic rule with a SQL query `SELECT * FROM 'my/topic' where attr=123` which will trigger a Lambda function whenever a message with attribute `attr=123` is received on the MQTT topic `my/topic`.
+For example, you can use the [`CreateTopicRule`](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateTopicRule.html) operation to define a topic rule with a SQL query `SELECT * FROM 'my/topic' where attr=123` which will execute a trigger whenever a message with attribute `attr=123` is received on the MQTT topic `my/topic`.
+
+Supported triggers include Kinesis, Lambda, SQS and Firehose.

--- a/content/en/user-guide/aws/iot/index.md
+++ b/content/en/user-guide/aws/iot/index.md
@@ -8,16 +8,36 @@ aliases:
   - /aws/iot/
 ---
 
-Basic support for [IoT](https://aws.amazon.com/iot/) (including IoT Analytics, IoT Data, and related APIs) is provided in the Pro version. The main endpoints for creating and updating entities are currently implemented, as well as the CloudFormation integrations for creating them.
+LocalStack Pro supports IoT Core, IoT Analytics, IoT Data and related APIs.
+The main endpoints for creating and updating entities are implemented along with the CloudFormation integrations.
 
-The IoT API ships with a built-in MQTT message broker. In order to get the MQTT endpoint, the `describe-endpoint` API can be used; for example, using [`awslocal`](https://github.com/localstack/awscli-local):
+## MQTT Broker
+
+LocalStack ships with a built-in MQTT broker.
+To retrieve the MQTT endpoint, use the [`DescribeEndpoint`](https://docs.aws.amazon.com/iot/latest/apireference/API_DescribeEndpoint.html) operation.
+
 {{< command >}}
 $ awslocal iot describe-endpoint
 {
-    "endpointAddress": "localhost:4510"
+    "endpointAddress": "localhost.localstack.cloud:4510"
 }
 {{< / command >}}
 
-This endpoint can then be used with any MQTT client to send/receive messages (e.g., using the endpoint URL `mqtt://localhost:4510`).
+This endpoint can then be used with any MQTT client to publish and subscribe to topics.
 
-LocalStack Pro also supports advanced features like SQL queries for IoT topic rules. For example, you can use the [`CreateTopicRule` API](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateTopicRule.html) to define a topic rule with a SQL query `SELECT * FROM 'my/topic' where attr=123` which will trigger a Lambda function whenever a message with attribute `attr=123` is received on the MQTT topic `my/topic`.
+## Lifecycle Events
+
+LocalStack also publishes the [IoT lifecycle events](https://docs.aws.amazon.com/iot/latest/developerguide/life-cycle-events.html) to the standard endpoints.
+
+- `$aws/events/presence/connected/clientId`: when a client connects
+- `$aws/events/presence/disconnected/clientId`: when a client disconnects
+- `$aws/events/subscriptions/subscribed/clientId`: when a client subscribes to a topic
+- `$aws/events/subscriptions/unsubscribed/clientId`: when a client unsubscribes from a topic
+
+Currently the `principalIdentifier` and `sessionIdentifier` fields in event payload contain dummy values.
+
+## Topic Rules
+
+It is also possible to use advanced features like SQL queries for IoT topic rules.
+
+For example, you can use the [`CreateTopicRule`](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateTopicRule.html) operation to define a topic rule with a SQL query `SELECT * FROM 'my/topic' where attr=123` which will trigger a Lambda function whenever a message with attribute `attr=123` is received on the MQTT topic `my/topic`.


### PR DESCRIPTION
Introduces sections to IoT docs and adds documentation related lifecycle events.

Jump to <https://localstack-docs-preview-pr-557.surge.sh/user-guide/aws/iot/>