### PR TITLE
EC2: Add config option to disable Docker images retrieval

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -109,7 +109,8 @@ This section covers configuration values that are specific to certain AWS servic
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `EC2_DOCKER_FLAGS` | `--privileged` | Additional flags passed to Docker when launching containerized instances. Same restrictions as `LAMBDA_DOCKER_FLAGS`.
+| `EC2_DOCKER_FLAGS` | `--privileged` | Additional flags passed to Docker when launching containerized instances. Same restrictions as `LAMBDA_DOCKER_FLAGS`. |
+| `EC2_DOWNLOAD_DEFAULT_IMAGES` | `0`\|`1` (default) | At startup, LocalStack Pro downloads latest Ubuntu images from Docker Hub for use as AMIs. This can be disabled for security reasons. |
 
 ### EKS
 


### PR DESCRIPTION
Part of v2.1