### PR TITLE
Polish lambda v2 docs

### DIFF
--- a/content/en/references/arm64-support/index.md
+++ b/content/en/references/arm64-support/index.md
@@ -8,7 +8,7 @@ aliases:
   - /localstack/arm64-support/
 ---
 
-With [version 0.13](https://github.com/localstack/localstack/releases/tag/v0.13.0), LocalStack officially publishes a [multi-architecture Docker manifest](https://hub.docker.com/r/localstack/localstack).
+Since [version 0.13](https://github.com/localstack/localstack/releases/tag/v0.13.0), LocalStack officially publishes a [multi-architecture Docker manifest](https://hub.docker.com/r/localstack/localstack).
 This manifest contains links to a Linux AMD64 as well as a Linux ARM64 image.
 
 {{< alert title="Note">}}
@@ -33,13 +33,13 @@ $ docker inspect localstack/localstack | jq '.[0].Architecture'
 
 ## Lambda multi-architecture support
 
-LocalStack executes Lambda functions in Docker containers with the target platform `linux/amd64` or `linux/arm64`
+Since LocalStack&nbsp;2.0, Lambda functions execute in Docker containers with the target platform `linux/amd64` or `linux/arm64`
 depending on the [instruction set architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) configured for the function (`x86_64` by default or `arm64`).
 This behavior can lead to errors if the host system, the Docker image, or the code/layer of the function do not support the target architecture.
 If you prefer to execute Lambda functions natively, you can set the [configuration]({{< ref "configuration#lambda" >}}) variable `LAMBDA_IGNORE_ARCHITECTURE=1`.
 
 Host systems with [multi-architecture support](https://docs.docker.com/build/building/multi-platform/) can run containers for different Linux architectures using emulation.
-For example, an Apple Silicon MacBook can execute `linux/arm64` (`arm64`) lambda functions natively or emulate them for `linux/arm64` (`x86_64`).
+For example, an Apple Silicon MacBook can execute `linux/arm64` (`arm64`) Lambda functions natively or emulate them for `linux/arm64` (`x86_64`).
 However, emulation through qemu is only best-effort and certain features such as [ptrace](https://github.com/docker/for-mac/issues/5191#issuecomment-834154431) for debugging might not work.
 
 You can check the supported architectures on your host system with:

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -151,17 +151,17 @@ The OpenSearch configuration variables are used to manage both, OpenSearch and E
 
 ### Lambda
 
-**New [Lambda]({{< ref "lambda" >}}) implementation active since Localstack&nbsp;v2.0 (Docker `latest` since 2023-03-23)**<br>
+**New [Lambda]({{< ref "lambda" >}}) implementation active since LocalStack&nbsp;2.0 (Docker `latest` since 2023-03-23)**<br>
 Please consult the page [Lambda Provider Behavioral Changes]({{< ref "lambda-provider-v2" >}}) for more information.
 
 | Variable| Example Values | Description |
 | - | - | - |
-| `BUCKET_MARKER_LOCAL` | `hot-reload` (default) | Magic S3 bucket name for [Hot Reloading]({{< ref "user-guide/tools/lambda-tools/hot-reloading" >}}). |
+| `BUCKET_MARKER_LOCAL` | `hot-reload` (default) | Magic S3 bucket name for [Hot Reloading]({{< ref "user-guide/tools/lambda-tools/hot-reloading" >}}). The S3Key points to the source code on the local file system. |
 | `LAMBDA_DOCKER_FLAGS` | `-e KEY=VALUE`, `-v host:container`, `-p host:container`, `--add-host domain:ip` | Additional flags passed to Docker `run`\|`create` commands. Supports environment variables, ports, volume mounts, extra hosts, networks, labels, ulimits, user, platform, and privileged mode. |
 | `LAMBDA_DOCKER_NETWORK` | `bridge` (Docker default) | [Docker network driver](https://docs.docker.com/network/) for the Lambda and ECS containers. Needs to be set to the network the LocalStack container is connected to. Limitation: `host` mode currently not supported. |
 | `LAMBDA_DOWNLOAD_AWS_LAYERS` | `1` (default, pro) | Whether to download public Lambda layers from AWS through a LocalStack proxy when creating or updating functions. |
 | `LAMBDA_IGNORE_ARCHITECTURE` | `0` (default) | Whether to ignore the AWS architectures (x86_64 or arm64) configured for the lambda function. Set to `1` to run cross-platform compatible lambda functions natively (i.e., Docker selects architecture). |
-| `LAMBDA_K8S_IMAGE_PREFIX` | `amazon/aws-lambda-` (default) | Prefix for images that will be used to execute Lambda functions in Kubernetes. |
+| `LAMBDA_K8S_IMAGE_PREFIX` | `amazon/aws-lambda-` (default, pro) | Prefix for images that will be used to execute Lambda functions in Kubernetes. |
 | `LAMBDA_KEEPALIVE_MS` | `600000` (default 10min) | Time in milliseconds until lambda shuts down the execution environment after the last invocation has been processed. Set to `0` to immediately shut down the execution environment after an invocation. |
 | `LAMBDA_LIMITS_CONCURRENT_EXECUTIONS` | `1000` (default) | The maximum number of events that functions can process simultaneously in the current Region. See [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/lambda-service.html) |
 | `LAMBDA_REMOVE_CONTAINERS` | `1` (default) | Whether to remove any Lambda Docker containers. |
@@ -171,8 +171,8 @@ Please consult the page [Lambda Provider Behavioral Changes]({{< ref "lambda-pro
 | `LAMBDA_RUNTIME_IMAGE_MAPPING` | [base images for Lambda](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-images.html) (default) | Customize the Docker image of Lambda runtimes, either by:<br> a) pattern with `<runtime>` placeholder, e.g. `custom-repo/lambda-<runtime>:2022` <br> b) json dict mapping the `<runtime>` to an image, e.g. `{"python3.9": "custom-repo/lambda-py:thon3.9"}` |
 | `LAMBDA_SYNCHRONOUS_CREATE` | `0` (default) | Set to `1` to create lambda functions synchronously (not recommended). |
 | `LAMBDA_TRUNCATE_STDOUT` | `2000` (default) | Allows increasing the default char limit for truncation of lambda log lines when printed in the console. This does not affect the logs processing in CloudWatch. |
-| `PROVIDER_OVERRIDE_LAMBDA` | `v2` (default) | Currently supported implementation of our [local Lambda service]({{< ref "lambda" >}}) active since Localstack&nbsp;v2.0 (Docker `latest` since 2023-03-23). |
-| | `legacy` (**Deprecated**) | Use the old lambda provider (not recommended).<br>**See [Lambda Provider Behavioral Changes]({{< ref "lambda-provider-v2" >}}).** |
+| `PROVIDER_OVERRIDE_LAMBDA` | `v2` (default) | Currently supported implementation of our [local Lambda service]({{< ref "lambda" >}}) active since LocalStack&nbsp;2.0 (Docker `latest` since 2023-03-23). |
+| | `legacy` (**deprecated**) | Use the old lambda provider (not recommended).<br>**See [Lambda Provider Behavioral Changes]({{< ref "lambda-provider-v2" >}}).** |
 
 ### Lambda (Legacy)
 

--- a/content/en/references/lambda-executors.md
+++ b/content/en/references/lambda-executors.md
@@ -1,5 +1,5 @@
 ---
-title: "Lambda Executor Modes"
+title: "Lambda Executor Modes (Deprecated)"
 weight: 5
 description: >
   Overview of the different Lambda execution modes
@@ -9,8 +9,9 @@ aliases:
 
 {{< alert title="Warning" color="warning">}}
 Lambda executor modes are **deprecated** and only used by the old lambda provider.
-The new lambda provider (default since Localstack&nbsp;v2.0) requires no such configuration and behaves like the old `docker-reuse` executor.<br>
-Please refer to [Lambda Provider Behavioral Change]({{< ref "lambda-provider-v2" >}}) for more details about the new lambda implementation.
+The new lambda provider (active since LocalStack&nbsp;2.0) requires no such configuration and behaves similar to the old `docker-reuse` executor.
+Please add the Docker volume mount `"/var/run/docker.sock:/var/run/docker.sock"` to your LocalStack startup as exemplified in our official [docker-compose.yml](https://github.com/localstack/localstack/blob/master/docker-compose.yml).<br>
+Refer to [Lambda Provider Behavioral Changes]({{< ref "lambda-provider-v2" >}}) for more details about the new lambda implementation.
 {{< /alert >}}
 
 ## Overview

--- a/content/en/references/lambda-provider-v2.md
+++ b/content/en/references/lambda-provider-v2.md
@@ -9,8 +9,8 @@ aliases:
 ---
 
 {{< alert title="Note">}}
-**New implementation active since Localstack&nbsp;v2.0 (Docker `latest` since 2023-03-23)**<br>
-The old lambda provider is temporarily available in Localstack&nbsp;v2 using `PROVIDER_OVERRIDE_LAMBDA=legacy` but we highly recommend migrating to the new lambda provider.
+**New implementation active since LocalStack&nbsp;2.0 (Docker `latest` since 2023-03-23)**<br>
+The old lambda provider is temporarily available in LocalStack&nbsp;v2 using `PROVIDER_OVERRIDE_LAMBDA=legacy` but we highly recommend migrating to the new lambda provider.
 {{< /alert >}}
 
 ## Overview
@@ -220,4 +220,4 @@ An error occurred (InternalFailure) when calling the CreateFunction operation (r
 {{< / command >}}
 
 Please check your [configuration]({{< ref "configuration#lambda" >}}) for `PROVIDER_OVERRIDE_LAMBDA`.
-If you are not using Localstack&nbsp;v2.0 yet, remove `PROVIDER_OVERRIDE_LAMBDA=legacy`.
+If you are not using LocalStack&nbsp;2.0 yet, remove `PROVIDER_OVERRIDE_LAMBDA=legacy`.

--- a/content/en/references/lambda-provider-v2.md
+++ b/content/en/references/lambda-provider-v2.md
@@ -156,7 +156,7 @@ as exemplified in our official [docker-compose.yml](https://github.com/localstac
   ```log
   Lambda 'arn:aws:lambda:us-east-1:000000000000:function:my-function:$LATEST' changed to failed. Reason: Docker not available
   ...
-  raise ContainerException("Docker not available")
+  raise DockerNotAvailable("Docker not available")
   ```
 
   ```log

--- a/content/en/references/lambda-provider-v2.md
+++ b/content/en/references/lambda-provider-v2.md
@@ -21,6 +21,21 @@ Docker Execution Environment,
 Configuration,
 and Hot Reloading.
 
+## Highlights
+
+- **[Feature coverage]({{< ref "coverage_lambda" >}}):** LocalStack&nbsp;2.0 supports 95% of all Lambda API operations.
+- **[AWS Parity](https://localstack.cloud/blog/2022-08-04-parity-explained/):** The local Lambda API behaves like in AWS with 90% parity test coverage.
+- **[Official AWS images](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-images.html):** Lambda functions use the official Docker base images pulled from `public.ecr.aws/lambda/`.
+- **[Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html):** All supported managed runtimes from AWS are available and tested in LocalStack. The new provider added `nodejs18.x`.
+- **[ARM support]({{< ref "arm64-support#lambda-multi-architecture-support" >}}):** Run arm64 and x86_64 Lambda functions on hosts with multi-architecture support.
+- **[Extensions API](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html):** Use third-party extensions to customize the Lambda execution environment. This deep integration enables monitoring, observability, or advanced developer tooling.
+- **[Lambda concurrency](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html):** Prevent cold-starts with provisioned concurrency and limit the number of concurrent function instances with reserved concurrency.
+- **Performance:** 10ms warm-start and 600ms cold-start for an Echo Python Lambda
+- **[Hot reloading]({{< ref "hot-reloading" >}}):** Continuously apply code changes to Lambda functions and layers (Pro) for all managed runtimes.
+- **[Persistence]({{< ref "persistence-mechanism" >}}) and [Cloud Pods]({{< ref "cloud-pods" >}}):** Save your Lambda state across restarts and share a snapshot of your Lambda infrastructure.
+
+Check out our [Lambda release announcement](https://discuss.localstack.cloud/t/new-lambda-implementation-in-localstack-2-0/258) for more details about further improvements.
+
 ## Lambda API
 
 **Improved parity compared to AWS:**

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -9,9 +9,9 @@ aliases:
 ---
 
 {{< alert title="Note">}}
-**New implementation active since Localstack&nbsp;v2.0 (Docker `latest` since 2023-03-23)**<br>
+**New implementation active since LocalStack&nbsp;2.0 (Docker `latest` since 2023-03-23)**<br>
 The new lambda provider `v2` (formerly known as `asf`) offers a completely re-written implementation with improved performance, [feature coverage]({{< ref "references/coverage/coverage_lambda" >}}), and [AWS parity](https://localstack.cloud/blog/2022-08-04-parity-explained/).
-The old lambda provider is temporarily available in Localstack&nbsp;v2 using `PROVIDER_OVERRIDE_LAMBDA=legacy` but we highly recommend [migrating]({{< ref "lambda-provider-v2" >}}) to the new lambda provider.
+The old lambda provider is temporarily available in LocalStack&nbsp;v2 using `PROVIDER_OVERRIDE_LAMBDA=legacy` but we highly recommend [migrating]({{< ref "lambda-provider-v2" >}}) to the new lambda provider.
 
 If you encounter an error related to `Docker not available`,
 mount the Docker socket `/var/run/docker.sock` as a volume when starting LocalStack (see troubleshooting [here]({{< ref "lambda-provider-v2#docker-not-available" >}})).

--- a/content/en/user-guide/tools/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/tools/lambda-tools/hot-reloading/index.md
@@ -17,7 +17,7 @@ LocalStack enables fast feedback cycles during development by automatically relo
 Pro users can also hot-reload Lambda layers.
 
 {{< alert title="Note" >}}
-**The magic S3 bucket name changed from `__local__` to `hot-reload` in Localstack&nbsp;v2.0**
+**The magic S3 bucket name changed from `__local__` to `hot-reload` in LocalStack&nbsp;2.0**
 
 Please change your deployment configuration accordingly because the old value is an invalid bucket name.
 The configuration `BUCKET_MARKER_LOCAL` is still supported.

--- a/content/en/user-guide/tools/transparent-endpoint-injection/patched-sdks.md
+++ b/content/en/user-guide/tools/transparent-endpoint-injection/patched-sdks.md
@@ -1,5 +1,5 @@
 ---
-title: "Patched AWS SDKs for Lambdas"
+title: "Patched AWS SDKs for Lambdas (Deprecated)"
 categories: ["LocalStack Pro", "Tools"]
 weight: 6
 description: >
@@ -10,7 +10,7 @@ aliases:
 
 {{< alert title="Warning" color="warning">}}
 Patched AWS SDKs for Lambdas are **deprecated** and only used by the old lambda provider.
-The new lambda provider (active since Localstack&nbsp;v2.0) uses DNS-based domain resolution (except for the Ruby runtime).<br>
+The new lambda provider (active since LocalStack&nbsp;2.0) uses DNS-based domain resolution (except for the Ruby runtime).<br>
 Please refer to [Lambda Provider Behavioral Change]({{< ref "lambda-provider-v2" >}}) for more details about the new lambda implementation.
 {{< /alert >}}
 


### PR DESCRIPTION
* Refine formulation and improve consistency (e.g., LocalStack v2 => 2.0)
* Add highlights to Lambda v2 docs + link discuss post
* Emphasize deprecation notes in page titles
* Adjust Docker not available error message to match released version
* Clarify that multi-arch Lambda support is only v2