### PR TITLE
Fix Typo In SQS Docs

### DIFF
--- a/content/en/user-guide/aws/sqs/index.md
+++ b/content/en/user-guide/aws/sqs/index.md
@@ -81,10 +81,10 @@ You can control the format of the generated Queue URLs by setting the environmen
 | `path` | `localhost:4566/queue/<region>/<account_id>/<queue_name>` | An alternative that can be useful if you cannot resolve LocalStack's localhost domain |
 | `off` | `localhost:4566/<account_id>/<queue_name>` | Currently the default for backwards compatibility. Since this format does not encode the region, you cannot query queues that exist in different regions with the same name. |
 
-### Enabling QueueDeletedRecently errors
+### Enabling PurgeQueue errors
 
 AWS only allows one call to `PurgeQueue` every 60 seconds.
-See the [DeleteQueue API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_PurgeQueue.html).
+See the [PurgeQueue API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_PurgeQueue.html).
 LocalStack disables this behavior by default, but it can be enabled by starting LocalStack with `SQS_DELAY_PURGE_RETRY=1`.
 
 ### Enabling QueueDeletedRecently errors


### PR DESCRIPTION
Linked Issue: https://github.com/localstack/docs/issues/584

Changes:
- Renamed duplicated heading title in SQS docs
- Fixed name of link to AWS docs