### PR TITLE
Add docs for EKS_K3S_IMAGE_TAG and _custom_id_ in Cognito

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -117,6 +117,7 @@ This section covers configuration values that are specific to certain AWS servic
 | Variable | Example Values | Description |
 | - | - | - |
 | `EKS_LOADBALANCER_PORT` | `8081` (default) | Local port on which the Kubernetes load balancer is exposed on the host. |
+| `EKS_K3S_IMAGE_TAG` | `v1.22.6-k3s1` (default) | Custom tag of the `k8s/rancher` image used to spin up Kubernetes clusters locally. |
 
 ### Elasticsearch
 

--- a/content/en/user-guide/aws/cognito/index.md
+++ b/content/en/user-guide/aws/cognito/index.md
@@ -80,6 +80,22 @@ Now we add a client to our newly created pool. Again, we will also need the ID o
 $ client_id=$(awslocal cognito-idp create-user-pool-client --user-pool-id $pool_id --client-name test-client | jq -rc ".UserPoolClient.ClientId")
 {{< /command >}}
 
+### Using predefined IDs on pool creation
+
+It is possible to use a predefined ID when creating Cognito user or identity pools, by setting the tag `_custom_id_`. This can
+be helpful when testing auth flows with LocalStack frequently being restarted and resourced re-created.
+For example:
+
+{{< command >}}
+$ awslocal cognito-idp create-user-pool --pool-name p1 --user-pool-tags "_custom_id_=myid123"
+{
+    "UserPool": {
+        "Id": "myid123",
+        "Name": "p1",
+    ...
+{{< /command >}}
+
+
 ### Signing up and confirming a user
 
 With these steps already taken, we can now sign up a user:


### PR DESCRIPTION
Add docs for two recently added features:

* `EKS_K3S_IMAGE_TAG` in EKS - allowing to specify a custom image tag for the Rancher k8s image when creating Kube clusters. /cc @alexrashed  
* `_custom_id_` in Cognito - allowing to specify custom IDs on user/identity pool creation. /cc @giograno 