### PR TITLE
remove serverless from title and description of sagemaker sample

### DIFF
--- a/data/developerhub/applications.json
+++ b/data/developerhub/applications.json
@@ -98,8 +98,8 @@
       "pro": true
     },
     {
-      "title": "MNIST handwritten digit recognition model running on a local serverless SageMaker endpoint",
-      "description": "Full-Stack application showcasing the deployment and invocation of a serverless SageMaker endpoint on LocalStack",
+      "title": "MNIST handwritten digit recognition model running on a local SageMaker endpoint",
+      "description": "Full-Stack application showcasing the deployment and invocation of a SageMaker endpoint on LocalStack",
       "url": "https://github.com/localstack/mnist-sagemaker",
       "teaser": "https://raw.githubusercontent.com/localstack/mnist-sagemaker/main/assets/architecture-diagram.png",
       "services": ["sgm", "lmb", "s3"],


### PR DESCRIPTION
Removing `serverless` from title and description of sagemaker sample since the sample now provides a non-serverless endpoint by default.