### PR TITLE
Add credentials documentation

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -35,7 +35,7 @@ $ DEBUG=1 localstack start
 | `EXTERNAL_SERVICE_PORTS_END` | `4560` (default) | End of [the external service port range]({{< ref "external-ports" >}}) (excluded). |
 | `EAGER_SERVICE_LOADING` | `0` (default) | Boolean that toggles lazy loading of services. If eager loading is enabled, services are started at LocalStack startup rather than their first use. Eager loading significantly increases LocalStack startup time. |
 | `ALLOW_NONSTANDARD_REGIONS` | `0` (default) | Allows the use of non-standard AWS regions. By default, LocalStack only accepts [standard AWS regions](https://docs.aws.amazon.com/general/latest/gr/rande.html). |
-| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Allows the use production-like access key IDs. By default, LocalStack will reject keys that start with `ASIA...` or `AKIA...` and use the fallback account ID. |
+| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Enables the use production-like access key IDs. By default, LocalStack issues keys with `LSIA...` and `LKIA...` prefix, and reject keys that start with `ASIA...` or `AKIA...`. |
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/#available-services
 

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -35,7 +35,7 @@ $ DEBUG=1 localstack start
 | `EXTERNAL_SERVICE_PORTS_END` | `4560` (default) | End of [the external service port range]({{< ref "external-ports" >}}) (excluded). |
 | `EAGER_SERVICE_LOADING` | `0` (default) | Boolean that toggles lazy loading of services. If eager loading is enabled, services are started at LocalStack startup rather than their first use. Eager loading significantly increases LocalStack startup time. |
 | `ALLOW_NONSTANDARD_REGIONS` | `0` (default) | Allows the use of non-standard AWS regions. By default, LocalStack only accepts [standard AWS regions](https://docs.aws.amazon.com/general/latest/gr/rande.html). |
-| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Allows the use production-like access key IDs. By default, LocalStack will reject keys that start with `ASIA...` or `AKIA...`. |
+| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Allows the use production-like access key IDs. By default, LocalStack will reject keys that start with `ASIA...` or `AKIA...` and use the fallback account ID. |
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/#available-services
 

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -35,7 +35,7 @@ $ DEBUG=1 localstack start
 | `EXTERNAL_SERVICE_PORTS_END` | `4560` (default) | End of [the external service port range]({{< ref "external-ports" >}}) (excluded). |
 | `EAGER_SERVICE_LOADING` | `0` (default) | Boolean that toggles lazy loading of services. If eager loading is enabled, services are started at LocalStack startup rather than their first use. Eager loading significantly increases LocalStack startup time. |
 | `ALLOW_NONSTANDARD_REGIONS` | `0` (default) | Allows the use of non-standard AWS regions. By default, LocalStack only accepts [standard AWS regions](https://docs.aws.amazon.com/general/latest/gr/rande.html). |
-| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Enables the use production-like access key IDs. By default, LocalStack issues keys with `LSIA...` and `LKIA...` prefix, and reject keys that start with `ASIA...` or `AKIA...`. |
+| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Enables the use production-like access key IDs. By default, LocalStack issues keys with `LSIA...` and `LKIA...` prefix, and will reject keys that start with `ASIA...` or `AKIA...`. |
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/#available-services
 

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -35,6 +35,7 @@ $ DEBUG=1 localstack start
 | `EXTERNAL_SERVICE_PORTS_END` | `4560` (default) | End of [the external service port range]({{< ref "external-ports" >}}) (excluded). |
 | `EAGER_SERVICE_LOADING` | `0` (default) | Boolean that toggles lazy loading of services. If eager loading is enabled, services are started at LocalStack startup rather than their first use. Eager loading significantly increases LocalStack startup time. |
 | `ALLOW_NONSTANDARD_REGIONS` | `0` (default) | Allows the use of non-standard AWS regions. By default, LocalStack only accepts [standard AWS regions](https://docs.aws.amazon.com/general/latest/gr/rande.html). |
+| `PARITY_AWS_ACCESS_KEY_ID` | `0` (default) | Allows the use production-like access key IDs. By default, LocalStack will reject keys that start with `ASIA...` or `AKIA...`. |
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/#available-services
 

--- a/content/en/references/credentials.md
+++ b/content/en/references/credentials.md
@@ -1,0 +1,43 @@
+---
+title: "Credentials"
+linkTitle: "Credentials"
+categories: ["LocalStack"]
+tags: ["access-key-id", "secret-access-key", "account-id"]
+weight: 5
+description: >
+  Credentials for accessing LocalStack services
+---
+
+Like AWS, LocalStack requires access key IDs to be set in all operations.
+The choice of access key ID will affect [multi-account namespacing]({{< ref "multi-account-setups" >}}).
+Values of secret access keys are currently ignored by LocalStack.
+
+Access key IDs can be one of following patterns:
+
+### Accounts IDs
+
+You can specify a 12-digit number which will be taken by LocalStack as the account ID.
+For example, `112233445566`.
+
+### Structured access key ID
+
+You can specify a structured key like `LSIAQAAAAAAVNCBMPNSG` (which translates to account ID `000000000042`).
+This must be atleast 20 characters in length and must be decodable to an account ID.
+
+{{< alert title="Note">}}
+In the future LocalStack will support IAM service which will issue proper access key IDs.
+{{< /alert >}}
+
+By default, LocalStack will only accept access keys that start with the `LSIA...` or `LKIA...` prefix.
+This is a safeguard to prevent misuse of production AWS access key IDs, which start with `ASIA...`/`AKIA...` prefix.
+To disable this safeguard, set the `PARITY_AWS_ACCESS_KEY_ID` configuration variable.
+
+{{< alert title="Warning" color="warning" >}}
+Disabling the access key safeguard and using production access key IDs may cause accidental connections to AWS.
+We strongly recommend leaving it on.
+{{< /alert >}}
+
+### Random alphanumeric string
+
+You can also specify an arbitrary alphanumeric access key ID like `test` or `foobar123`.
+In all such cases, the account ID will be evalutated to `000000000000`.

--- a/content/en/references/credentials.md
+++ b/content/en/references/credentials.md
@@ -38,7 +38,7 @@ Disabling the access key safeguard and using production access key IDs may cause
 We strongly recommend leaving it on.
 {{< /alert >}}
 
-### Random alphanumeric string
+### Alphanumeric string
 
 You can also specify an arbitrary alphanumeric access key ID like `test` or `foobar123`.
 In all such cases, the account ID will be evalutated to `000000000000`.

--- a/content/en/references/credentials.md
+++ b/content/en/references/credentials.md
@@ -29,7 +29,8 @@ In the future LocalStack will support IAM service which will issue proper access
 {{< /alert >}}
 
 By default, LocalStack will only accept access keys that start with the `LSIA...` or `LKIA...` prefix.
-This is a safeguard to prevent misuse of production AWS access key IDs, which start with `ASIA...`/`AKIA...` prefix.
+If keys with `ASIA...`/`AKIA...` prefix are provided, these are rejected and the fallback account ID `000000000000` is used.
+This is a safeguard to prevent misuse of production AWS access key IDs.
 To disable this safeguard, set the `PARITY_AWS_ACCESS_KEY_ID` configuration variable.
 
 {{< alert title="Warning" color="warning" >}}

--- a/content/en/references/credentials.md
+++ b/content/en/references/credentials.md
@@ -24,10 +24,6 @@ For example, `112233445566`.
 You can specify a structured key like `LSIAQAAAAAAVNCBMPNSG` (which translates to account ID `000000000042`).
 This must be at least 20 characters in length and must be decodable to an account ID.
 
-{{< alert title="Note">}}
-In the future LocalStack will support IAM service which will issue proper access key IDs.
-{{< /alert >}}
-
 By default, LocalStack will only accept access keys that start with the `LSIA...` or `LKIA...` prefix.
 If keys with `ASIA...`/`AKIA...` prefix are provided, these are rejected and the fallback account ID `000000000000` is used.
 This is a safeguard to prevent misuse of production AWS access key IDs.

--- a/content/en/references/credentials.md
+++ b/content/en/references/credentials.md
@@ -22,7 +22,7 @@ For example, `112233445566`.
 ### Structured access key ID
 
 You can specify a structured key like `LSIAQAAAAAAVNCBMPNSG` (which translates to account ID `000000000042`).
-This must be atleast 20 characters in length and must be decodable to an account ID.
+This must be at least 20 characters in length and must be decodable to an account ID.
 
 {{< alert title="Note">}}
 In the future LocalStack will support IAM service which will issue proper access key IDs.

--- a/content/en/references/multi-account-setups.md
+++ b/content/en/references/multi-account-setups.md
@@ -27,10 +27,6 @@ This field must either contain a valid 12-digit or an alpha-numeric string.
 In the first case, the value is assumed to be the account ID.
 In the second case, the default account ID `000000000000` is used as fallback.
 
-LocalStack will also ignore possible production AWS Access Key IDs (starting with `ASIA...` or `AKIA...`) and fallback to default.
-
-In the future LocalStack shall support proper access key IDs issued by the local IAM service, which will then be internally translated to corresponding account IDs.
-
 ## Examples
 
 In following examples, we configure the AWS CLI account ID via environment variable.


### PR DESCRIPTION
This PR adds missing documentation regarding access key IDs.

Jump to content: https://localstack-docs-preview-pr-613.surge.sh/references/credentials/

See:
- https://github.com/localstack/localstack/issues/8225
- https://github.com/localstack/localstack/pull/7093#discussion_r1185691341