### PR TITLE
Document wildcard DNS access

### DIFF
--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -109,34 +109,40 @@ networks:
 ### Wildcard DNS access
 
 {{<alert title="Pro only" color="alert">}}
-This feature is part of our [pro](https://localstack.cloud/pricing/) offering.
+The Wildcard DNS access feature is part of [LocalStack's Pro/Team offering](https://localstack.cloud/pricing) and requires an API key to be configured.
 {{</alert>}}
 
-Some resources created by LocalStack are accessible via virtual host addressing, for example an S3 bucket can be accessed at `<bucket>.s3.<region>.localhost.localstack.cloud`.
-The LocalStack container is not reachable at this address from containers running in your Docker network, since by default any subdomains of `localhost.localstack.cloud` resolve to `127.0.0.1`.
+Certain resources created by LocalStack can be accessed using virtual host addressing. For example, an S3 bucket can be accessed at the following address format: `<bucket>.s3.<region>.localhost.localstack.cloud`. 
+
+By default, the LocalStack container cannot be reached from containers running in your Docker network at the above address. This is because any subdomains of `localhost.localstack.cloud` is resolved to `127.0.0.1` within the Docker network. 
+
 If Docker supported wildcard DNS configuration with `--network-alias` (Docker CLI) or `aliases:` (`docker-compose`), this could be solved with Docker configuration alone.
 
-In order to map more complex domain names to the LocalStack container within the Docker network, the LocalStack container can be used as a DNS server, but this requires more configuration.
-Specifically the LocalStack container must have a static IP address within the network.
-This can be achieved with the following example:
+To map more complex domain names to the LocalStack container within the Docker network, the LocalStack container can be utilized as a DNS server. However, this approach requires additional configuration steps. 
+
+Specifically, the LocalStack container must have a static IP address within the network. To set up the LocalStack container as a DNS server, a static IP address must be assigned within the Docker network. 
+
+Here is an example of how you can set it up:
 
 {{<tabpane>}}
 {{<tab header="Docker" lang="bash">}}
-# create the network
+# Create the network
 docker network create my-network --subnet <ip address range CIDR>
-# start LocalStack
+
+# Start LocalStack
 docker run --rm -it \
     --network my-network \
     --ip 10.0.2.20 \
     -e DNS_RESOLVE_IP=10.0.2.20 \
     <other flags> \
     localstack/localstack-pro
-# start your application container
+
+# Start your application container
 docker run --rm -it \
     --dns 10.0.2.20 \
     --network my-network \
     <args>
-# then your code can access LocalStack at <subdomain>.localhost.localstack.cloud
+# Your code can now access LocalStack at <subdomain>.localhost.localstack.cloud
 {{</tab>}}
 {{<tab header="docker-compose.yml" lang="yaml">}}
 services:
@@ -164,11 +170,11 @@ networks:
 {{</tab>}}
 {{</tabpane>}}
 
-Requests from the *application* container to `<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key>`, will reach the LocalStack container.
+To access LocalStack resources from the *application* container, you can make requests to the following address format: `<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key>`. This will ensure that the requests reach the LocalStack container.
 
 {{<alert title="Note">}}
-We suggest using a private IP address range for your containers, such as 10.0.0.0/8 since this does not conflict with IP addresses assigned by Docker.
-Also avoid using `X.X.X.1` as this often represents the host within that subnet.
+For optimal configuration, we recommend using a private IP address range, such as 10.0.0.0/8, for your containers. This helps avoid conflicts with IP addresses assigned by Docker.
+Additionally, it's advisable to avoid using `X.X.X.1` as an IP address, as it is commonly reserved for the host within that subnet.
 {{</alert>}}
 
 ## From a separate host

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -113,10 +113,10 @@ This feature is part of our [pro](https://localstack.cloud/pricing/) offering.
 {{</alert>}}
 
 Some resources created by LocalStack are accessible via virtual host addressing, for example an S3 bucket can be accessed at `<bucket>.s3.<region>.localhost.localstack.cloud`.
-The LocalStack container is not reachable at this address from containers running in your docker network, since by default any subdomains of `localhost.localstack.cloud` resolve to `127.0.0.1`.
-If docker supported wildcard DNS configuration with `--network-alias` (docker CLI) or `aliases:` (`docker-compose`), this could be solved with docker configuration alone.
+The LocalStack container is not reachable at this address from containers running in your Docker network, since by default any subdomains of `localhost.localstack.cloud` resolve to `127.0.0.1`.
+If Docker supported wildcard DNS configuration with `--network-alias` (Docker CLI) or `aliases:` (`docker-compose`), this could be solved with Docker configuration alone.
 
-In order to map more complex domain names to the LocalStack container within the docker network, the LocalStack container can be used as a DNS server, but this requires more configuration.
+In order to map more complex domain names to the LocalStack container within the Docker network, the LocalStack container can be used as a DNS server, but this requires more configuration.
 Specifically the LocalStack container must have a static IP address within the network.
 This can be achieved with the following example:
 
@@ -167,7 +167,7 @@ networks:
 Requests from the *application* container to `<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key>`, will reach the LocalStack container.
 
 {{<alert title="Note">}}
-We suggest using a private IP address range for your containers, such as 10.0.0.0/8 since this does not conflict with IP addresses assigned by docker.
+We suggest using a private IP address range for your containers, such as 10.0.0.0/8 since this does not conflict with IP addresses assigned by Docker.
 Also avoid using `X.X.X.1` as this often represents the host within that subnet.
 {{</alert>}}
 

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -108,6 +108,10 @@ networks:
 
 ### Wildcard DNS access
 
+{{<alert title="Pro only" color="warning">}}
+This feature is only part of our pro offering.
+{{</alert>}}
+
 Resources created by LocalStack are accessible via virtual host addressing, for example an S3 bucket can be accessed at `<bucket>.s3.<region>.localhost.localstack.cloud`, however this hostname resolves to the ip address `127.0.0.1`.
 This domain name may not be resolvable from containers running in your docker network, since by default any subdomains of `localhost.localstack.cloud` are aliased to `127.0.0.1`.
 If docker supported wildcard DNS configuration with `--network-alias` (docker CLI) or `aliases:` (`docker-compose`), this could be solved with docker configuration alone.

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -108,13 +108,15 @@ networks:
 
 ### Wildcard DNS access
 
-Resources created by LocalStack may be accessible via virtual host addressing, for example an S3 bucket can be accessed at `<bucket>.s3.<region>.localhost.localstack.cloud`, however this hostname resolves to the ip address `127.0.0.1`.
-This may not be accessible from containers running in your docker network.
-Also, docker does not support wildcard DNS configuration with `--add-host` (`docker` CLI) or `extra_hosts:` (`docker-compose`) so generated resource URLs cannot be easily mapped to the LocalStack container within the docker netwwork.
+Resources created by LocalStack are accessible via virtual host addressing, for example an S3 bucket can be accessed at `<bucket>.s3.<region>.localhost.localstack.cloud`, however this hostname resolves to the ip address `127.0.0.1`.
+This domain name may not be resolvable from containers running in your docker network, since by default any subdomains of `localhost.localstack.cloud` are aliased to `127.0.0.1`.
+If docker supported wildcard DNS configuration with `--network-alias` (docker CLI) or `aliases:` (`docker-compose`), this could be solved with docker configuration alone.
 
 In order to map more complex domain names to the LocalStack container within the docker network, the LocalStack container can be used as a DNS server, but this requires more configuration.
 Specifically the LocalStack container must have a static IP address within the network.
 This can be achieved with the following `docker-compose.yml` example:
+
+**TODO(srw)**: docker cli example
 
 ```yaml
 services:
@@ -143,8 +145,10 @@ networks:
 
 For example, with the following values:
 
-* private ip address: 10.0.2.20
-* ip address range CIDR: 10.0.2.0/24
+* private ip address: 10.0.2.20;
+* ip address range CIDR: 10.0.2.0/24,
+
+requests from the *application* container to `<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key>`, will reach the LocalStack container.
 
 {{<alert>}}
 We suggest using a private IP address range for your containers, such as 10.0.0.0/8 since this does not conflict with IP addresses assigned by docker.

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -108,8 +108,8 @@ networks:
 
 ### Wildcard DNS access
 
-{{<alert title="Pro only" color="warning">}}
-This feature is only part of our pro offering.
+{{<alert title="Pro only" color="alert">}}
+This feature is part of our [pro](https://localstack.cloud/pricing/) offering.
 {{</alert>}}
 
 Some resources created by LocalStack are accessible via virtual host addressing, for example an S3 bucket can be accessed at `<bucket>.s3.<region>.localhost.localstack.cloud`.
@@ -118,7 +118,7 @@ If docker supported wildcard DNS configuration with `--network-alias` (docker CL
 
 In order to map more complex domain names to the LocalStack container within the docker network, the LocalStack container can be used as a DNS server, but this requires more configuration.
 Specifically the LocalStack container must have a static IP address within the network.
-This can be achieved with the following `docker-compose.yml` example:
+This can be achieved with the following example:
 
 {{<tabpane>}}
 {{<tab header="Docker" lang="bash">}}
@@ -127,31 +127,31 @@ docker network create my-network --subnet <ip address range CIDR>
 # start LocalStack
 docker run --rm -it \
     --network my-network \
-    --ip <private ip address> \
-    -e DNS_RESOLVE_IP=<private ip address> \
+    --ip 10.0.2.20 \
+    -e DNS_RESOLVE_IP=10.0.2.20 \
     <other flags> \
     localstack/localstack-pro
 # start your application container
 docker run --rm -it \
-    --dns <private ip address> \
+    --dns 10.0.2.20 \
     --network my-network \
     <args>
 # then your code can access LocalStack at <subdomain>.localhost.localstack.cloud
 {{</tab>}}
-{{<tab header="docker-compose" lang="yaml">}}
+{{<tab header="docker-compose.yml" lang="yaml">}}
 services:
   localstack:
     # ... other configuration here
     environment:
-      - DNS_RESOLVE_IP=<private ip address>
+      - DNS_RESOLVE_IP=10.0.2.20
     networks:
       ls:
-        ipv4_address: <private ip address>
+        ipv4_address: 10.0.2.20
 
   application:
     # ... other configuration here
     dns:
-      - <localstack container ip address>
+      - 10.0.2.20
     networks:
       ls:
 
@@ -160,18 +160,13 @@ networks:
     name: ls
     ipam:
       config:
-        - subnet: <ip address range CIDR>
+        - subnet: 10.0.2.0/24
 {{</tab>}}
 {{</tabpane>}}
 
-For example, with the following values:
+Requests from the *application* container to `<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key>`, will reach the LocalStack container.
 
-* private ip address: 10.0.2.20;
-* ip address range CIDR: 10.0.2.0/24,
-
-requests from the *application* container to `<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key>`, will reach the LocalStack container.
-
-{{<alert>}}
+{{<alert title="Note">}}
 We suggest using a private IP address range for your containers, such as 10.0.0.0/8 since this does not conflict with IP addresses assigned by docker.
 Also avoid using `X.X.X.1` as this often represents the host within that subnet.
 {{</alert>}}


### PR DESCRIPTION
This PR adds documentation regarding wildcard DNS mapping.

Docker does not support mapping `*.localhost.localstack.cloud` to a container. This is required for e.g. virtual host addressing of S3 buckets (`<bucket>.s3.<region>.localhost.localstack.cloud`) or API Gateway urls (e.g. `<apiid>.execute-api.localhost.localstack.cloud`).

This document describes how to achieve this domain mapping by configuring docker containers to use the LocalStack container as their DNS server.

**Preview**: https://localstack-docs-preview-pr-629.surge.sh/references/network-troubleshooting/endpoint-url/#wildcard-dns-access
