### PR TITLE
Fixes error in sqs user guide

### DIFF
--- a/content/en/user-guide/aws/sqs/index.md
+++ b/content/en/user-guide/aws/sqs/index.md
@@ -32,7 +32,7 @@ $ awslocal sqs list-queues
 {{< / command >}}
 
 {{< command >}}
-$ awslocal sqs send-message --queue-url http://localhost:4566/00000000000/sample-queue --message-body test
+$ awslocal sqs send-message --queue-url http://localhost:4566/000000000000/sample-queue --message-body test
 {
     "MD5OfMessageBody": "098f6bcd4621d373cade4e832627b4f6",
     "MessageId": "74861aab-05f8-0a75-ae20-74d109b7a76e"


### PR DESCRIPTION
Fixes issue #634

According to the [credentials docs](https://docs.localstack.cloud/references/credentials/), the account-id must be a valid 12-digit number or an alpha-numeric string and the default 000000000000 is used as a fallback.