### PR TITLE
Fix ordering of reference pages

### DIFF
--- a/content/en/references/arm64-support/index.md
+++ b/content/en/references/arm64-support/index.md
@@ -1,8 +1,8 @@
 ---
 title: "ARM64 Support"
-weight: 30
+weight: 50
 description: >
-  Describes the support for the ARM64 CPU architecture in LocalStack.
+  Running LocalStack on ARM64 CPUs
 tags: ["apple", "silicon", "m1", "raspberry pi"]
 aliases:
   - /localstack/arm64-support/

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -1,8 +1,8 @@
 ---
 title: "Configuration"
-weight: 1
+weight: 10
 description: >
-  Environment variables which affect LocalStack.
+  Using environment variables to configure LocalStack
 aliases:
   - /localstack/configuration/
 ---

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -2,19 +2,22 @@
 title: "Configuration"
 weight: 10
 description: >
-  Using environment variables to configure LocalStack
+  Overview of configuration options in LocalStack
 aliases:
   - /localstack/configuration/
 ---
 
-LocalStack allows for many different configuration options.
-You can pass these via environment variables, e.g., like the following:
+LocalStack exposes various configuration options to control its behaviour.
+
+These options can be passed to LocalStack as environment variables like so:
 
 {{< command >}}
 $ DEBUG=1 localstack start
 {{< / command >}}
 
 ## Core
+
+Options that affect the core LocalStack system.
 
 | Variable | Example Values | Description |
 | - | - | - |
@@ -41,7 +44,7 @@ $ DEBUG=1 localstack start
 
 ### CLI
 
-These variables are only relevant when using the CLI to start LocalStack.
+These options are applicable when using the CLI to start LocalStack.
 
 | Variable | Example Values | Description |
 | - | - | - |
@@ -51,7 +54,7 @@ These variables are only relevant when using the CLI to start LocalStack.
 
 ### Docker
 
-Docker is used extensively by LocalStack, and there are several configuration parameters for how LocalStack interacts with Docker.
+Options to configure how LocalStack interacts with Docker.
 
 | Variable | Example Values | Description |
 | - | - | - |
@@ -64,16 +67,7 @@ Docker is used extensively by LocalStack, and there are several configuration pa
 
 ## Local AWS Services
 
-This section covers configuration values that are specific to certain AWS services.
-
-* [AppSync]({{< ref "#appsync" >}})
-* [Batch]({{< ref "#batch" >}})
-* [DynamoDB]({{< ref "#dynamodb" >}})
-* [Elastic Kubernetes Service (EKS)]({{< ref "#eks" >}})
-* [Elasticsearch]({{< ref "#elasticsearch" >}})
-* [Kinesis]({{< ref "#kinesis" >}})
-* [Lambda]({{< ref "#lambda" >}})
-* [Stepfunctions]({{< ref "#stepfunctions" >}})
+This section covers configuration options that are specific to certain AWS services.
 
 ### AppSync
 
@@ -160,8 +154,10 @@ The OpenSearch configuration variables are used to manage both, OpenSearch and E
 
 ### Lambda
 
-**New [Lambda]({{< ref "user-guide/aws/lambda" >}}) implementation active since LocalStack&nbsp;2.0 (Docker `latest` since 2023-03-23)**<br>
+{{< alert title="Note" >}}
+New [Lambda]({{< ref "user-guide/aws/lambda" >}}) implementation active since LocalStack&nbsp;2.0 (Docker `latest` since 2023-03-23).
 Please consult the page [Lambda providers]({{< ref "user-guide/aws/lambda" >}}) for more information.
+{{</alert>}}
 
 | Variable| Example Values | Description |
 | - | - | - |
@@ -262,7 +258,9 @@ The old lambda provider is temporarily available in Localstack&nbsp;v2 using `PR
 
 ## Security
 
-Please be aware that the following configurations may have severe security implications!
+{{< alert title="Warning" color="warning" >}}
+Please be aware that the following options may have severe security implications.
+{{</alert>}}
 
 | Variable| Example Values | Description |
 | - | - | - |
@@ -338,7 +336,7 @@ The `CONFIG_PROFILE` is a CLI feature and cannot be used with a Docker/Docker Co
 
 ## Persistence
 
-To learn more about these configuration options, see our docs on [Persistence]({{< ref "persistence-mechanism" >}}).
+To learn more about these configuration options, see [Persistence]({{< ref "persistence-mechanism" >}}).
 
 | Variable | Valid options | Description |
 | - | - | - |
@@ -377,7 +375,7 @@ Additionally, the following *read-only* environment variables are available:
 
 ## DNS
 
-More information [here]({{< ref "dns-server" >}}).
+To learn more about these configuration options, see [DNS Server]({{< ref "dns-server" >}}).
 
 | Variable | Example Values | Description |
 | - | - | - |

--- a/content/en/references/coverage/_index.md
+++ b/content/en/references/coverage/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "LocalStack Coverage"
 linkTitle: "LocalStack Coverage"
-weight: 2
+weight: 5
 description: >
   Overview of the implemented AWS APIs in LocalStack
 cascade:

--- a/content/en/references/credentials.md
+++ b/content/en/references/credentials.md
@@ -3,7 +3,7 @@ title: "Credentials"
 linkTitle: "Credentials"
 categories: ["LocalStack"]
 tags: ["access-key-id", "secret-access-key", "account-id"]
-weight: 5
+weight: 50
 description: >
   Credentials for accessing LocalStack services
 ---

--- a/content/en/references/custom-tls-certificates.md
+++ b/content/en/references/custom-tls-certificates.md
@@ -1,10 +1,10 @@
 ---
 title: Custom TLS certificates
-weight: 99
+weight: 50
 tags:
 - ssl
 description: >
-  How to use custom TLS certificates with LocalStack
+  Using custom TLS certificates with LocalStack
 ---
 
 ## Background

--- a/content/en/references/docker-images.md
+++ b/content/en/references/docker-images.md
@@ -1,10 +1,10 @@
 ---
-title: Docker images
-weight: 100
+title: Docker Images
+weight: 50
 tags:
 - docker
 description: >
-  Overview of LocalStack Docker images and their usage
+  Overview of LocalStack Docker images and their purpose
 ---
 
 LocalStack functions as a local “mini-cloud” operating system that runs inside a Docker container. LocalStack has multiple components, which include process management, file system abstraction, event processing, schedulers, and more. Running inside a Docker container, LocalStack exposes external network ports for integrations, SDKs, or CLI interfaces to connect to LocalStack APIs. The LocalStack & LocalStack Pro Docker images have been downloaded over 130+ million times and provide a multi-arch build compatible with AMD/x86 and ARM-based CPU architectures. This section will cover the different Docker images available for LocalStack and how to use them.

--- a/content/en/references/external-ports.md
+++ b/content/en/references/external-ports.md
@@ -1,6 +1,6 @@
 ---
 title: "External Service Port Range"
-weight: 5
+weight: 50
 description: >
     The range of ports used by services not directly provided by LocalStack
 aliases:

--- a/content/en/references/filesystem.md
+++ b/content/en/references/filesystem.md
@@ -1,6 +1,6 @@
 ---
 title: "Filesystem Layout"
-weight: 5
+weight: 50
 description: >
   Overview of runtime directory structure
 aliases:

--- a/content/en/references/init-hooks.md
+++ b/content/en/references/init-hooks.md
@@ -1,8 +1,8 @@
 ---
-title: "Initialization hooks"
-weight: 5
+title: "Initialization Hooks"
+weight: 50
 description: >
-  Write shell or Python scripts to customize or initialize your LocalStack instance.
+  Writing shell or Python scripts to customize or initialize your LocalStack instance
 aliases:
   - /localstack/init-hooks/
 ---

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -1,6 +1,6 @@
 ---
 title: Internal Endpoints
-weight: 120
+weight: 50
 tags:
 - internal-endpoints
 - localstack-endpoints

--- a/content/en/references/localstack-cli-manual.md
+++ b/content/en/references/localstack-cli-manual.md
@@ -1,8 +1,8 @@
 ---
-title: "LocalStack CLI manual"
-weight: 3
+title: "LocalStack CLI Manual"
+weight: 50
 description: >
-  The reference guide for LocalStack CLI commands and how to get started on using them!
+  Reference guide for LocalStack CLI commands
 ---
 
 The LocalStack command-line interface (CLI) is a tool for starting, managing, and configuring your LocalStack container. It provides convenience features that make it easier to use LocalStack, and use LocalStack tools like Cloud Pods, Extensions, and more. The `localstack` CLI syntax is:

--- a/content/en/references/localstack-extensions.md
+++ b/content/en/references/localstack-extensions.md
@@ -1,9 +1,9 @@
 ---
 title: "LocalStack Extensions"
 linkTitle: "LocalStack Extensions"
-weight: 8
+weight: 50
 description: >
-  LocalStack Extensions allows developers to extend and customize LocalStack.
+  Using LocalStack Extensions to extend and customize LocalStack
 categories: ["LocalStack Pro"]
 tags: ["extensions"]
 aliases:

--- a/content/en/references/localstack-on-kubernetes.md
+++ b/content/en/references/localstack-on-kubernetes.md
@@ -1,12 +1,12 @@
 ---
 title: LocalStack on Kubernetes
-weight: 110
+weight: 50
 categories: ["LocalStack Community", "LocalStack Pro"]
 tags:
 - kubernetes
 - k8s
 description: >
-  Overview of how you can run LocalStack on Kubernetes
+  Running LocalStack on Kubernetes
 ---
 
 LocalStack can be deployed on [Kubernetes](https://kubernetes.io/) using the [LocalStack Helm chart](http://helm.localstack.cloud/).

--- a/content/en/references/logging.md
+++ b/content/en/references/logging.md
@@ -1,6 +1,6 @@
 ---
 title: Logging
-weight: 110
+weight: 50
 tags:
 - logging
 description: >

--- a/content/en/references/multi-account-setups.md
+++ b/content/en/references/multi-account-setups.md
@@ -6,7 +6,7 @@ tags: ["multi-tenant", "multi-account", "account-id", "namespaces"]
 aliases:
   - /aws/multi-account-setups/
   - /tools/multi-account-setups/
-weight: 5
+weight: 50
 description: >
   Using LocalStack in multi-tenant setups
 ---

--- a/content/en/references/network-troubleshooting/_index.md
+++ b/content/en/references/network-troubleshooting/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Network troubleshooting
-weight: 2
+weight: 1
 tags:
 - troubleshooting
 - networking

--- a/content/en/references/persistence-mechanism.md
+++ b/content/en/references/persistence-mechanism.md
@@ -1,15 +1,13 @@
 ---
 title: "Persistence"
-weight: 5
+weight: 50
 description: >
-  How LocalStack stores state on disk
+  Internals of LocalStack persistence mechanism
 aliases:
   - /localstack/persistence-mechanism/
 ---
 
-## Persistence mechanisms
-
-By default, LocalStack is an _ephemeral_ environment, meaning that, once you terminate your LocalStack instance, all state will be discarded.
+By default, LocalStack is an ephemeral environment, meaning that, once you terminate your LocalStack instance, all state will be discarded.
 Persistence is a LocalStack Pro feature that can save and restore the state of LocalStack including all AWS resources and their data.
 
 LocalStack has two distinct persistence mechanisms

--- a/content/en/references/podman.md
+++ b/content/en/references/podman.md
@@ -1,8 +1,8 @@
 ---
 title: "Podman"
-weight: 30
+weight: 50
 description: >
-  Describes how to run LocalStack inside Podman.
+  Running LocalStack inside Podman
 tags: ["podman", "docker"]
 aliases:
   - /localstack/podman/

--- a/content/en/references/usage-tracking.md
+++ b/content/en/references/usage-tracking.md
@@ -1,8 +1,8 @@
 ---
 title: Usage Tracking
-weight: 75
+weight: 50
 description: >
-  Understand what data LocalStack collects and how you can opt out of usage tracking.
+  Understand what data LocalStack collects and how you can opt out of usage tracking
 aliases:
   - /localstack/usage-tracking/
 ---


### PR DESCRIPTION
This PR fixes the ordering of Reference pages into alphabetical order. This makes it easier to find the page one is looking for.

The Configuration page is retained at the top.

Furthermore, it also makes the page summary of each page consistent in wording and styling.