### PR TITLE
Disable taxonomies

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,13 +23,13 @@ category = "categories"
 
 [params.taxonomy]
 # set taxonomyCloud = [] to hide taxonomy clouds
-taxonomyCloud = ["tags", "categories"] 
+taxonomyCloud = [] 
 
 # If used, must have same length as taxonomyCloud
 taxonomyCloudTitle = ["Tag Cloud", "Categories"] 
 
 # set taxonomyPageHeader = [] to hide taxonomies on the page headers
-taxonomyPageHeader = ["tags", "categories"] 
+taxonomyPageHeader = [] 
 
 
 # Highlighting config


### PR DESCRIPTION
This PR disables the taxonomy feature of Hugo and hides the 'Categories' and 'Tags' section in the sidebar and page frontmatter.

We currently have no system in place for categories and tags. As a result, there is a confused mixture of taxonomies in majority of documentation pages. 

Disabling this gives our docs a cleaner and less busy look, hopefully making them more approachable and presentable to new users.

If we reconsider this change in the future, it is easy to enable it by reverting this commit. The tags and categories in individual pages are not removed.