### PR TITLE
Fix Configuration `INIT_SCRIPTS_PATH` Description

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -32,7 +32,7 @@ Options that affect the core LocalStack system.
 | `PERSISTENCE` | `0` (default) | Enable persistence. See [persistence mechanism]({{< ref "persistence-mechanism" >}}) and [filesystem layout]({{< ref "filesystem" >}}). |
 | `PERSIST_ALL` | `true` (default) | Whether to persist all resources (including user code like Lambda functions), or only "light-weight" resources (e.g., SQS queues, or Cognito users). Can be set to `false` to reduce storage size of `DATA_DIR` folders or Cloud Pods. |
 | `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
-| `INIT_SCRIPTS_PATH` | `/some/path` | *Deprecated*. Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`. |
+| `INIT_SCRIPTS_PATH` | `/some/path` | *Deprecated*. Specify the path to the initializing files with extensions `.sh` that are found default in `/etc/localstack/init/ready.d`. |
 | `LS_LOG` | `trace`, `trace-internal`, `debug`, `info`, `warn`, `error`, `warning`| Specify the log level. Currently overrides the `DEBUG` configuration. `trace` for detailed request/response, `trace-internal` for internal calls, too. |
 | `EXTERNAL_SERVICE_PORTS_START` | `4510` (default) | Start of [the external service port range]({{< ref "external-ports" >}}) (included). |
 | `EXTERNAL_SERVICE_PORTS_END` | `4560` (default) | End of [the external service port range]({{< ref "external-ports" >}}) (excluded). |


### PR DESCRIPTION
On the page, https://docs.localstack.cloud/references/configuration/ This section:
> _Deprecated_. Specify the path to the initializing files with extensions `.sh` that are found default in `/docker-entrypoint-initaws.d`.

Should read:
> _Deprecated_. Specify the path to the initializing files with extensions `.sh` that are found default in `/etc/localstack/init/ready.d`.

This was confusing for me as the [init-hooks](https://docs.localstack.cloud/references/init-hooks/) reference page is not as easily found.

Alternatively, the docs for `INIT_SCRIPTS_PATH` could link to the init-hooks docs.