### PR TITLE
fix script for docs update

### DIFF
--- a/scripts/create_data_coverage.py
+++ b/scripts/create_data_coverage.py
@@ -168,6 +168,7 @@ def main(
             service = impl_details.setdefault(row["service"], {})
             # update all operations that are available in community
             if row["is_implemented"] == "True":
+                service.setdefault(row["operation"], {"implemented": True})
                 service[row["operation"]]["pro"] = False
 
     services = sorted(impl_details.keys())


### PR DESCRIPTION
Latest [failing workflow for updating the docs](https://github.com/localstack/docs/actions/runs/5308007605/jobs/9607061813), revealed that community results might have operations included, that pro doesn't have yet. This could be as we consider the latest successful master build, and the repositories are split.

Fixed the KeyError issue, by setting defaults.