### PR TITLE
add instructions on how to have daemons command available for pro

### DIFF
--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -43,7 +43,7 @@ Attempting to launch Dockerised instances with these AMIs will return `InvalidAM
 LocalStack supports assignment of unique private IP addresses for Dockerised instances.
 To leverage this feature, it is necessary to run the LocalStack daemon process on the host which takes care of creating and managing networking on the host system.
 
-Make sure this command is available, by first logging in using `localstack login` with your Pro credentials (the same ones used for <https://app.localstack.cloud>).
+Make sure this command is available by first logging in using `localstack login` with your Pro credentials (the same ones used for <https://app.localstack.cloud>).
 To verify this, use `localstack --help` and check if `daemons` is part of the command list.
 
 {{< command >}}

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -43,6 +43,9 @@ Attempting to launch Dockerised instances with these AMIs will return `InvalidAM
 LocalStack supports assignment of unique private IP addresses for Dockerised instances.
 To leverage this feature, it is necessary to run the LocalStack daemon process on the host which takes care of creating and managing networking on the host system.
 
+Make sure this command is available, by first logging in using `localstack login` with your Pro credentials (the same ones used for app.localstack.cloud).
+To verify this, use `localstack --help` and check if `daemons` is part of the command list.
+
 {{< command >}}
 $ pip install localstack[runtime]
 $ export LOCALSTACK_API_KEY=...

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -43,7 +43,7 @@ Attempting to launch Dockerised instances with these AMIs will return `InvalidAM
 LocalStack supports assignment of unique private IP addresses for Dockerised instances.
 To leverage this feature, it is necessary to run the LocalStack daemon process on the host which takes care of creating and managing networking on the host system.
 
-Make sure this command is available, by first logging in using `localstack login` with your Pro credentials (the same ones used for app.localstack.cloud).
+Make sure this command is available, by first logging in using `localstack login` with your Pro credentials (the same ones used for <https://app.localstack.cloud>).
 To verify this, use `localstack --help` and check if `daemons` is part of the command list.
 
 {{< command >}}


### PR DESCRIPTION
A user pointed out that it was not clear that the `daemons` command is available only after logging in. I added this instruction to hopefully avoid support tickets related to this in the future. regardless of whether or not it goes away in the future, for now it's beneficial.