### PR TITLE
coverage table enhancement for lambda

### DIFF
--- a/layouts/partials/coverage/coverage_table.html
+++ b/layouts/partials/coverage/coverage_table.html
@@ -1,3 +1,4 @@
+{{ $service := $.service }} 
 <div class="coverage-report">
     <table>
         <thead>
@@ -11,7 +12,9 @@
             <th class="coverage-report-header-2">Implemented</th>
             <th class="coverage-report-header-2">Edition</th>
             <th class="coverage-report-header-1">Internal Test Suite</th>
+            {{ if not (eq "lambda" $service) }} 
             <th class="coverage-report-header-1">External Test Suite</th>
+            {{ end }}
             <th class="coverage-report-header-1">Terraform Validated</th>
             <th class="coverage-report-header-1">AWS Validated</th>
             <th class="coverage-report-header-1">Snapshot Tested</th>

--- a/layouts/partials/coverage/coverage_table.html
+++ b/layouts/partials/coverage/coverage_table.html
@@ -29,7 +29,9 @@
     <h3 id="terminology">Terminology</h3>
     <ul>
     <li><b>Internal Test Suite:</b> tested by LocalStack's internal integration test suite</li>
+    {{ if not (eq "lambda" $service) }} 
     <li><b>External Test Suite:</b> covered by an external integration test suite, that runs against LocalStack</li>
+    {{ end }}
     <li><b>Terraform Validated:</b> operation tested with <a href="/user-guide/integrations/terraform/">Terraform</a></li>
     <li><b>AWS Validated:</b> the integration test that includes this operation call was validated against AWS</li>
     <li><b>Snapshot Tested:</b> the operation is part of a <a href="/contributing/parity-testing/">snapshot parity test</a>, which verifies the responses by LocalStack and AWS are the same</li>

--- a/layouts/partials/coverage/coverage_table_row.html
+++ b/layouts/partials/coverage/coverage_table_row.html
@@ -1,5 +1,6 @@
 {{ range $operation := $.operations }} 
 {{ range $op_name, $op := $operation }}
+{{ $service := $.service }}
 <tr>
     <!-- Operation -->
     {{ if ($op.implemented) }} 
@@ -18,8 +19,10 @@
     <td style="text-align: center;">{{ if ($op.implemented) }} {{ $op.availability }} {{ end }}</td>
     <!-- Internal Test Suite -->
     <td class="coverage-shadow-overlay-green">{{ if ($op.internal_test_suite) }} ✔️ {{ end }}</td>
+    {{ if not (eq "lambda" $service) }} 
     <!-- External Test Suite --> 
     <td class="coverage-shadow-overlay-green">{{ if ($op.external_test_suite) }} ✔️ {{ end }}</td>
+    {{ end }}
     <!-- Terraform Validated -->
     <td class="coverage-shadow-overlay-green">{{ if ($op.terraform_test_suite) }} ✔️ {{ end }}</td>
     <!-- AWS Validated -->


### PR DESCRIPTION
Skip the "external-test-suite" column for lambda in the coverage-overview, as we do not have any external tests.

Initially the column for "external tests" was added to show an improvement of the coverage. Mainly for services where we rely on moto, and which are therefore covered by moto-tests. 
However, for lambda this does not make sense, as the external test suite is not working, but do we have all tests covered internally (which is the end goal anyhow).

As the table looked now lambda is missing tests (which it doesn't), we decided to take the approach of excluding the "external test suite" for now with @joe4dev. Other services could be added to the exclusion. 

/cc @HarshCasper @whummer 