### PR TITLE
Clarify Lambda ECR tutorial for arm64, use repositoryUri as imageuri

### DIFF
--- a/content/en/tutorials/lambda-ecr-container-images/index.md
+++ b/content/en/tutorials/lambda-ecr-container-images/index.md
@@ -64,10 +64,10 @@ CMD [ "handler.handler" ]
 If your Lambda function has additional dependencies, create a file named `requirements.txt` in the same directory as the Dockerfile. List the required libraries in this file. You can install these dependencies in the `Dockerfile` under the `${LAMBDA_TASK_ROOT}` directory.
 {{< /alert >}}
 
-With the Dockerfile prepared, you can now build the container image using the following command:
+With the Dockerfile prepared, you can now build the container image using the following command, to check if everything works as intended:
 
 {{< command >}}
-$ docker build -t localstack-lambda-container-image .
+$ docker build .
 {{< / command >}}
 
 By executing these steps, you have defined the Dockerfile that instructs Docker on how to build the container image for your Lambda function. The resulting image will contain your function code and any specified dependencies.
@@ -141,11 +141,16 @@ By running this command, you can confirm that the image is now in the ECR reposi
 
 To deploy the container image as a Lambda function, we will create a new Lambda function using the `create-function` command. Run the following command to create the function:
 
+{{< alert title="Note" color="primary">}}
+Before creating the lambda function, please double check under which architecture you have built your image. If your image is built as arm64, you need to specify the lambda architecture when deploying or set `LAMBDA_IGNORE_ARCHTIECTURE=1` when starting LocalStack.
+More information can be found [in our documentation regarding ARM support.]({{< ref "arm64-support" >}})
+{{< /alert >}}
+
 {{< command >}}
 $ awslocal lambda create-function \
     --function-name localstack-lambda-container-image \
     --package-type Image \
-    --code ImageUri="localstack-lambda-container-image" \
+    --code ImageUri="localhost.localstack.cloud:4510/localstack-lambda-container-image" \
     --role arn:aws:iam::000000000000:role/lambda-role \
     --handler handler.handler
 {
@@ -183,7 +188,7 @@ $ awslocal lambda create-function \
 
 The command provided includes several flags to create the Lambda function. Here's an explanation of each flag:
 
-- `ImageUri`: Specifies the image URI of the container image you pushed to the ECR repository (`localstack-lambda-container-image` in this case).
+- `ImageUri`: Specifies the image URI of the container image you pushed to the ECR repository (`localhost.localstack.cloud:4510/localstack-lambda-container-image` in this case. Use the return `repositoryUri` from the create-repository command).
 - `package-type`: Sets the package type to Image to indicate that the Lambda function will be created using a container image.
 - `function-name`: Specifies the name of the Lambda function you want to create.
 - `runtime`: Defines the runtime environment for the Lambda function. In this case, it's specified as provided, indicating that the container image will provide the runtime.


### PR DESCRIPTION
## Motivation
The tutorial does not work on an ARM64 host, as the image built is ARM64, but lambda will try to pull a `x86_64` image.

Also, we should use the `repositoryUri` instead of the repository name as `imageUri`. The latter will work in circumstances, but we should not encourage wrong behavior. It is more stable and correct to use the `repositoryUri`, as we can pull from it.

## Changes
* Add warning regarding arm64 issues
* Use the repositoryUri instead of the repositoryName as imageUri
* Remove tagging when initially building - the step could be removed altogether, but I left it in as verification to avoid changing too much of the tutorial. We do not need to tag it as the name though.