### PR TITLE
Update LocalStack version to 2.2.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -209,7 +209,7 @@ enable = true
 
 [params.localstack]
 # LocalStack specific configuration values
-latest_version = "2.1.0"
+latest_version = "2.2.0"
 
 [params.localstack.cli_links]
 # Configure the different download links for the cli-binary-download shortcode


### PR DESCRIPTION
Changes the latest_version to 2.2.0, for parts of the documentation + cli download links.

Should be merged after 2.2.0 release is finished.