### PR TITLE
Fix typo in instructions for adding target to EventBridge

### DIFF
--- a/content/en/user-guide/aws/eventbridge/index.md
+++ b/content/en/user-guide/aws/eventbridge/index.md
@@ -71,7 +71,7 @@ $ awslocal lambda add-permission \
 
 ### Add the Lambda Function as a Target
 
-Create a file names `target.json` with the following content:
+Create a file named `targets.json` with the following content:
 
 ```json
 [


### PR DESCRIPTION
Fixes a grammatical error and makes the filename in the prose match the one in the command below.

Relevant page/section: https://docs.localstack.cloud/user-guide/aws/eventbridge/#add-the-lambda-function-as-a-target