### PR TITLE
Improve deprecated Lambda debug docs

### DIFF
--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -153,11 +153,11 @@ If your Lambda function references a layer in real AWS, you can integrate it int
 To grant access to your layer, run the following command:
 
 {{< command >}}
-$ aws lambda add-layer-version-permission
-  --layer-name test-layer
-  --version-number 1
-  --statement-id layerAccessFromLocalStack
-  --principal 886468871268
+$ aws lambda add-layer-version-permission \
+  --layer-name test-layer \
+  --version-number 1 \
+  --statement-id layerAccessFromLocalStack \
+  --principal 886468871268 \
   --action lambda:GetLayerVersion
 {{< / command >}}
 

--- a/content/en/user-guide/tools/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/tools/lambda-tools/debugging/index.md
@@ -40,9 +40,7 @@ There, the necessary code fragments for enabling debugging are already present.
 First, make sure that LocalStack is started with the following configuration (see the [Configuration docs]({{< ref "configuration#lambda" >}}) for more information):
 
 {{< command >}}
-$ LAMBDA_REMOTE_DOCKER=0 \
-    LAMBDA_DOCKER_FLAGS='-p 19891:19891' \
-    DEBUG=1 localstack start
+$ LAMBDA_DOCKER_FLAGS='-p 19891:19891' localstack start
 {{< /command >}}
 
 #### Preparing your code
@@ -136,7 +134,7 @@ You can [follow the steps in the offical docs](https://www.jetbrains.com/help/py
 
 #### Preparing your code
 
-PyCharm provides a its own debugging package, called `pydevd-pycharm`. Essentially, you will add the following code to your lambda:
+PyCharm provides its own debugging package, called `pydevd-pycharm`. Essentially, you will add the following code to your lambda:
 
 ```python
 import pydevd_pycharm
@@ -284,7 +282,7 @@ lambda function.
 
 ### Configure LocalStack for remote Node.js debugging
 
-`LAMBDA_REMOTE_DOCKER` has to be disabled, and `LAMBDA_DOCKER_FLAGS` needs to enable the debugger using `NODE_OPTIONS`:
+Set the `LAMBDA_DOCKER_FLAGS` to enable the debugger using `NODE_OPTIONS`:
 
 ```yaml
 #docker-compose.yml
@@ -294,7 +292,6 @@ services:
     ...
     environment:
       ...
-      - LAMBDA_REMOTE_DOCKER=0
       - LAMBDA_DOCKER_FLAGS=-e NODE_OPTIONS=--inspect-brk=0.0.0.0:9229 -p 9229:9229
 ```
 


### PR DESCRIPTION
* [Fix missing trailing slashes in add-layer-version-permission command](https://github.com/localstack/docs/commit/6ae0c6cc8cc1e87daa8b437d0b6661c193363a55)
* [Remove deprecated and unrelated configuration](https://github.com/localstack/docs/commit/a58a28e41b14431fde87fa6aaadab3c860c1a405)
  * `LAMBDA_REMOTE_DOCKER` is deprecated and not required since LocalStack 2.0 anymore
  * `DEBUG=1` is not related to remote debugging. It might provide extra information but is not required for remote debugging.