### PR TITLE
MediaStore guide

### DIFF
--- a/content/en/user-guide/aws/mediastore/index.md
+++ b/content/en/user-guide/aws/mediastore/index.md
@@ -1,18 +1,18 @@
 ---
 title: Elemental MediaStore
-linkTitle: MediaStore
+linkTitle: Elemental MediaStore
 description: >
-  Get started with MediaStore on LocalStack
+  Get started with Elemental MediaStore on LocalStack
 ---
 
 ## Introduction
 
-LocalStack supports MediaStore via the Pro/Team offering, allowing you to use the MediaStore APIs in your local environment.
-The supported APIs are available on our API Coverage Page, which provides information on the extent of MediaStore integration with LocalStack.
+LocalStack supports Elemental MediaStore via the Pro/Team offering, allowing you to use the Elemental MediaStore APIs in your local environment.
+The supported APIs are available on our API Coverage Page, which provides information on the extent of Elemental MediaStore integration with LocalStack.
 
 ## Getting started
 
-This guide is designed for users new to MediaStore and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+This guide is designed for users new to Elemental MediaStore and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
 We will walk through creating a container, uploading and downloading an asset.
 
 ### Create a container
@@ -71,5 +71,5 @@ $ awslocal mediastore-data get-object \
 
 ## Troubleshooting
 
-The MediaStore service requires use of a custom HTTP/HTTPS endpoint.
+The Elemental MediaStore service requires use of a custom HTTP/HTTPS endpoint.
 If you encounter any problems, please refer to our [Networking documentation]({{< ref "references/network-troubleshooting" >}}).

--- a/content/en/user-guide/aws/mediastore/index.md
+++ b/content/en/user-guide/aws/mediastore/index.md
@@ -22,6 +22,11 @@ The response contains the `Endpoint` value which should be used in subsequent re
 
 {{< command >}}
 $ awslocal mediastore create-container --container-name mycontainer
+{{< / command >}}
+
+You should see the following output:
+
+```bash
 {
     "Container": {
         "Endpoint": "http://mediastore-mycontainer.mediastore.localhost.localstack.cloud:4566",
@@ -30,7 +35,7 @@ $ awslocal mediastore create-container --container-name mycontainer
         "Name": "mycontainer"
     }
 }
-{{< / command >}}
+```
 
 ### Upload an asset
 
@@ -44,11 +49,16 @@ $ awslocal mediastore-data put-object \
     --body myfile.txt \
     --path /myfolder/myfile.txt \
     --content-type binary/octet-stream
+{{< / command >}}
+
+You should see the following output:
+
+```bash
 {
     "ContentSHA256": "",
     "ETag": "\"111d787cdcfcc358fd15684131f586d8\""
 }
-{{< / command >}}
+```
 
 ### Download an asset
 
@@ -60,6 +70,11 @@ $ awslocal mediastore-data get-object \
     --endpoint http://mediastore-mycontainer.mediastore.localhost.localstack.cloud:4566 \
     --path /myfolder/myfile.txt \
     /tmp/out.txt
+{{< / command >}}
+
+You should see the following output:
+
+```bash
 {
     "ContentLength": "716",
     "ContentType": "binary/octet-stream",
@@ -67,7 +82,7 @@ $ awslocal mediastore-data get-object \
     "LastModified": "2023-08-11T08:43:20+00:00",
     "StatusCode": 200
 }
-{{< / command >}}
+```
 
 ## Troubleshooting
 

--- a/content/en/user-guide/aws/mediastore/index.md
+++ b/content/en/user-guide/aws/mediastore/index.md
@@ -1,0 +1,75 @@
+---
+title: Elemental MediaStore
+linkTitle: MediaStore
+description: >
+  Get started with MediaStore on LocalStack
+---
+
+## Introduction
+
+LocalStack supports MediaStore via the Pro/Team offering, allowing you to use the MediaStore APIs in your local environment.
+The supported APIs are available on our API Coverage Page, which provides information on the extent of MediaStore integration with LocalStack.
+
+## Getting started
+
+This guide is designed for users new to MediaStore and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+We will walk through creating a container, uploading and downloading an asset.
+
+### Create a container
+
+A container can be created with the `create-container` command.
+The response contains the `Endpoint` value which should be used in subsequent requests.
+
+{{< command >}}
+$ awslocal mediastore create-container --container-name mycontainer
+{
+    "Container": {
+        "Endpoint": "http://mediastore-mycontainer.mediastore.localhost.localstack.cloud:4566",
+        "CreationTime": "2023-08-11T09:43:19.982754+01:00",
+        "ARN": "arn:aws:mediastore:us-east-1:000000000000:container/mycontainer",
+        "Name": "mycontainer"
+    }
+}
+{{< / command >}}
+
+### Upload an asset
+
+In order to upload a file (in this case, `myfile.txt`) to the container, use the `put-object` method.
+This will upload the file to the path `/myfolder/myfile.txt` in the container.
+Here we pass the `endpoint` from the previous step.
+
+{{< command >}}
+$ awslocal mediastore-data put-object \
+    --endpoint http://mediastore-mycontainer.mediastore.localhost.localstack.cloud:4566 \
+    --body myfile.txt \
+    --path /myfolder/myfile.txt \
+    --content-type binary/octet-stream
+{
+    "ContentSHA256": "",
+    "ETag": "\"111d787cdcfcc358fd15684131f586d8\""
+}
+{{< / command >}}
+
+### Download an asset
+
+In order to fetch the file back from the container, use the `get-object` method.
+We specify the endpoint, path to download, and the output file (`/tmp/out.txt`), and the file is available at the output path.
+
+{{< command >}}
+$ awslocal mediastore-data get-object \
+    --endpoint http://mediastore-mycontainer.mediastore.localhost.localstack.cloud:4566 \
+    --path /myfolder/myfile.txt \
+    /tmp/out.txt
+{
+    "ContentLength": "716",
+    "ContentType": "binary/octet-stream",
+    "ETag": "\"111d787cdcfcc358fd15684131f586d8\"",
+    "LastModified": "2023-08-11T08:43:20+00:00",
+    "StatusCode": 200
+}
+{{< / command >}}
+
+## Troubleshooting
+
+The MediaStore service requires use of a custom HTTP/HTTPS endpoint.
+If you encounter any problems, please refer to our [Networking documentation]({{< ref "references/network-troubleshooting" >}}).

--- a/content/en/user-guide/aws/mediastore/index.md
+++ b/content/en/user-guide/aws/mediastore/index.md
@@ -1,24 +1,28 @@
 ---
 title: Elemental MediaStore
 linkTitle: Elemental MediaStore
-description: >
-  Get started with Elemental MediaStore on LocalStack
+description: Get started with Elemental MediaStore on LocalStack
 ---
 
 ## Introduction
 
-LocalStack supports Elemental MediaStore via the Pro/Team offering, allowing you to use the Elemental MediaStore APIs in your local environment.
-The supported APIs are available on our API Coverage Page, which provides information on the extent of Elemental MediaStore integration with LocalStack.
+MediaStore is a scalable and highly available object storage service designed specifically for media content. 
+It provides a reliable way to store, manage, and serve media assets, such as audio, video, and images, with low latency and high performance. 
+MediaStore seamlessly integrates with other AWS services like Elemental MediaConvert, Elemental MediaLive, Elemental MediaPackage, and CloudFront.
+
+LocalStack supports Elemental MediaStore via the Pro/Team offering, allowing you to use the Elemental MediaStore APIs as a high-performance storage solution for media content in your local environment.
+The supported APIs are available on our [API Coverage Page](https://docs.localstack.cloud/references/coverage/coverage_mediastore/), which provides information on the extent of Elemental MediaStore integration with LocalStack.
 
 ## Getting started
 
 This guide is designed for users new to Elemental MediaStore and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
-We will walk through creating a container, uploading and downloading an asset.
+
+Start your LocalStack container using your preferred method. We will demonstrate how you can create a MediaStore container, upload an asset, and download the asset.
 
 ### Create a container
 
-A container can be created with the `create-container` command.
-The response contains the `Endpoint` value which should be used in subsequent requests.
+You can create a container using the [`CreateContainer`](https://docs.aws.amazon.com/mediastore/latest/apireference/API_CreateContainer.html) API. 
+Run the following command to create a container and retrieve the the `Endpoint` value which should be used in subsequent requests:
 
 {{< command >}}
 $ awslocal mediastore create-container --container-name mycontainer
@@ -39,9 +43,10 @@ You should see the following output:
 
 ### Upload an asset
 
-In order to upload a file (in this case, `myfile.txt`) to the container, use the `put-object` method.
-This will upload the file to the path `/myfolder/myfile.txt` in the container.
-Here we pass the `endpoint` from the previous step.
+To upload a file named `myfile.txt` to the container, utilize the [`PutObject`](https://docs.aws.amazon.com/mediastore/latest/apireference/API_PutObject.html) API. 
+This action will transfer the file to the specified path, `/myfolder/myfile.txt`, within the container. 
+Provide the `endpoint` obtained in the previous step for the operation to be successful. 
+Run the following command to upload the file:
 
 {{< command >}}
 $ awslocal mediastore-data put-object \
@@ -62,8 +67,10 @@ You should see the following output:
 
 ### Download an asset
 
-In order to fetch the file back from the container, use the `get-object` method.
-We specify the endpoint, path to download, and the output file (`/tmp/out.txt`), and the file is available at the output path.
+To retrieve the file from the container, utilize the [`GetObject`](https://docs.aws.amazon.com/mediastore/latest/apireference/API_GetObject.html) API. 
+In this process, you need to specify the endpoint, the path for downloading the file, and the location where the output file, such as `/tmp/out.txt`, will be stored. 
+The downloaded file will then be accessible at the specified output path. 
+Run the following command to download the file:
 
 {{< command >}}
 $ awslocal mediastore-data get-object \
@@ -86,5 +93,4 @@ You should see the following output:
 
 ## Troubleshooting
 
-The Elemental MediaStore service requires use of a custom HTTP/HTTPS endpoint.
-If you encounter any problems, please refer to our [Networking documentation]({{< ref "references/network-troubleshooting" >}}).
+The Elemental MediaStore service requires the use of a custom HTTP/HTTPS endpoint. In case you encounter any issues, please consult our [Networking documentation]({{< ref "references/network-troubleshooting" >}}) for assistance.


### PR DESCRIPTION
A user guide for AWS Elemental MediaStore


# Questions

* [ ] In the limitations section, should we include areas where we lack parity? In particular, we don't support the `ListObjects` operation, nor range downloading - which I was planning on including in the example.
