### PR TITLE
Clarify LocalStack lazy loading behaviour wrt MQTT broker

### DIFF
--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -108,7 +108,7 @@ networks:
 
 ### Wildcard DNS access
 
-{{<alert title="Pro only" color="alert">}}
+{{<alert title="Note">}}
 The Wildcard DNS access feature is part of [LocalStack's Pro/Team offering](https://localstack.cloud/pricing) and requires an API key to be configured.
 {{</alert>}}
 

--- a/content/en/user-guide/aws/iot/index.md
+++ b/content/en/user-guide/aws/iot/index.md
@@ -25,6 +25,12 @@ $ awslocal iot describe-endpoint
 
 This endpoint can then be used with any MQTT client to publish and subscribe to topics.
 
+{{< alert title="Hint" color="success" >}}
+LocalStack lazy-loads services by default.
+The MQTT broker may not be automatically available on a fresh launch of LocalStack.
+You should make a `DescribeEndpoint` call to ensure the broker is running.
+{{< /alert >}}
+
 ## Lifecycle Events
 
 LocalStack also publishes the [lifecycle events](https://docs.aws.amazon.com/iot/latest/developerguide/life-cycle-events.html) to the standard endpoints.

--- a/content/en/user-guide/aws/ses/index.md
+++ b/content/en/user-guide/aws/ses/index.md
@@ -34,7 +34,7 @@ $ awslocal ses send-email \
     --destination 'ToAddresses=recipient1@example.com'
 {{< / command >}}
 
-{{< alert title="Hint" color="info" >}}
+{{< alert title="Hint" color="success" >}}
 If you receive a "Email address not verified message", simply call
 ```sh
 awslocal ses verify-email-identity --email-address user1@yourdomain.com

--- a/content/en/user-guide/tools/cloud-pods/_index.md
+++ b/content/en/user-guide/tools/cloud-pods/_index.md
@@ -17,7 +17,7 @@ Cloud Pods are a mechanism that allows you to take a snapshot of the state in yo
 
 ![Persistence versus Cloud Pods](pods-persistence.png)
 
-{{< alert title="Hint" color="info">}}
+{{< alert title="Hint" color="success">}}
 To quickly see cloud pods in action, we prepared a small sample application that uses cloud pods to inject its state into a running LocalStack container. [Cloud Pod Thumbnail Sample App](https://app.localstack.cloud/quickstart/demo4)
 {{< /alert >}}
 


### PR DESCRIPTION
Adds a hint in the IOT page:

---

![image](https://github.com/localstack/docs/assets/5170829/a6ace6dd-11e8-4a41-893a-60202f85ffb4)


