### PR TITLE
Add docs for attaching EBS block devices to EC2 instances

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -111,6 +111,8 @@ This section covers configuration options that are specific to certain AWS servi
 | - | - | - |
 | `EC2_DOCKER_FLAGS` | `--privileged` | Additional flags passed to Docker when launching containerized instances. Same restrictions as `LAMBDA_DOCKER_FLAGS`. |
 | `EC2_DOWNLOAD_DEFAULT_IMAGES` | `0`\|`1` (default) | At startup, LocalStack Pro downloads latest Ubuntu images from Docker Hub for use as AMIs. This can be disabled for security reasons. |
+| `EC2_MOUNT_BLOCK_DEVICES` | `1`\|`0` (default) | Whether to create and mount user-specified EBS block devices into EC2 container instances. |
+| `EC2_EBS_MAX_VOLUME_SIZE` | `1000` (default) | Maximum size (in MBs) of user-specified EBS block devices mounted into EC2 container instances. |
 
 ### EKS
 

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -36,7 +36,7 @@ Run the following command to create the key pair and pipe the output to a file n
 
 {{< command >}}
 $ awslocal ec2 create-key-pair \
-    --key-name foobar \
+    --key-name my-key \
     --query 'KeyMaterial' \
     --output text | tee key.pem
 {{< /command >}}
@@ -45,6 +45,11 @@ You can assign necessary permissions to the key pair file using the following co
 
 {{< command >}}
 $ chmod 400 key.pem
+{{< /command >}}
+
+Alternatively, we can import an existing keypair, for example if you have an SSH public key in your home directory under `~/.ssh/id_rsa.pub`:
+{{< command >}}
+$ awslocal ec2 import-key-pair --key-name my-key --public-key-material file://~/.ssh/id_rsa.pub
 {{< /command >}}
 
 ### Add rules to your security group
@@ -107,7 +112,7 @@ $ awslocal ec2 run-instances \
     --image-id ami-ff0fea8310f3 \
     --count 1 \
     --instance-type t3.nano \
-    --key-name foobar \
+    --key-name my-key \
     --security-group-ids '<SECURITY_GROUP_ID>' \
     --user-data file://./user_script.sh
 {{< /command >}}
@@ -155,12 +160,7 @@ Any execution of this data is recorded in the `/var/log/cloud-init-output.log` f
 
 You can also set up an SSH connection to the locally emulated EC2 instance using the instance IP address.
 
-First, we need to create or import an SSH keypair. For example, you can use an existing SSH public key in your home directory under `~/.ssh/id_rsa.pub`:
-{{< command >}}
-$ awslocal ec2 import-key-pair --key-name my-key --public-key-material file://~/.ssh/id_rsa.pub
-{{< /command >}}
-
-When running the EC2 instance, make sure to pass the `--key-name` parameter to the command:
+This section assumes that you have created or imported an SSH keypair named `my-key` (see [instructions above](#create-a-key-pair)). When running the EC2 instance, make sure to pass the `--key-name` parameter to the command:
 {{< command >}}
 $ awslocal ec2 run-instances --key-name my-key ...
 {{< /command >}}

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -167,7 +167,7 @@ $ awslocal ec2 run-instances --key-name my-key ...
 
 Once the instance is up and running, we can use the `ssh` command to set up an SSH connection. Assuming the instance is available under `127.0.0.1:12862` (as per the LocalStack log output), use this command:
 {{< command >}}
-$ ssh -p 12862 -i ~/.ssh/id_rsa root@127.0.0.1
+$ ssh -p 12862 -i key.pem root@127.0.0.1
 {{< /command >}}
 {{< alert title="Hint" color="info">}}
 If the `ssh` command throws an error like "Identity file not accessible" or "bad permissions", then please make sure that the key file has a restrictive `0400` permission as illustrated [here](#create-a-key-pair).

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -169,7 +169,9 @@ Once the instance is up and running, we can use the `ssh` command to set up an S
 {{< command >}}
 $ ssh -p 12862 -i ~/.ssh/id_rsa root@127.0.0.1
 {{< /command >}}
-
+{{< alert title="Hint" color="info">}}
+If the `ssh` command throws an error like "Identity file not accessible" or "bad permissions", then please make sure that the key file has a restrictive `0400` permission as illustrated [here](#create-a-key-pair).
+{{< /alert >}}
 ## Docker backend
 
 LocalStack Pro supports the Docker backend, enabling the execution of emulated EC2 instances.


### PR DESCRIPTION
* Add docs for attaching EBS block devices to EC2 instances
* Add entries for new configuration variables to EC2 config section
* Slightly revise the description around SSH connections for EC2 instances, to make them more self-contained. The docs now also contain a pointer to the `import-key-pair` command, which can be used to import an existing local SSH public key, to connect to the instance with the corresponding private key.

/cc @viren-nadkarni @cabeaulac 