### PR TITLE
Add tutorial on using Crossplane AWS provider with LocalStack

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -559,5 +559,10 @@ table tfoot {
     }
   }
 }
+.disable-copy-btn {
+  .code-copy-button{
+    display: none !important;
+  }
+}
 
 @import "modules/academy-styles.scss";

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -29,6 +29,8 @@ In the following, we provide a step-by-step guide for installing Crossplane in a
   * Alternatively, you can [create a local EKS cluster](https://docs.localstack.cloud/user-guide/aws/elastic-kubernetes-service/#create-an-embedded-kubernetes-cluster) in LocalStack directly, which will spin up a light-weight embedded `k3d` Kubernetes cluster in your Docker environment
 * The [`helm`](https://helm.sh) and [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) command-line clients installed
 
+## Installing Crossplane in local Kubernetes
+
 Once your `kubectl` is configured to point to the local Kubernetes cluster, we first install Crossplane via `helm`:
 {{<command>}}
 $ helm repo add crossplane-stable https://charts.crossplane.io/stable

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -26,7 +26,7 @@ In the following, we provide a step-by-step guide for installing Crossplane in a
 
 As a prerequisite, we need the following:
 * LocalStack running in local Docker
-* A Kubernetes cluster: We can use the embedded Kubernetes cluster that ships with modern versions of Docker Desktop (can be easily enabled in the Docker settings)
+* A Kubernetes cluster: We can use the [embedded Kubernetes cluster](https://docs.docker.com/desktop/kubernetes) that ships with modern versions of Docker Desktop (can be easily enabled in the Docker settings)
 * The [`helm`](https://helm.sh) and [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) command-line clients installed
 
 We first install Crossplane via `helm`:
@@ -43,10 +43,11 @@ $ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/instal
 $ sudo mv kubectl-crossplane /usr/local/bin
 {{</command>}}
 
-TO confirm that the installation was successful, you can run these commands, which should yield output similar to the following:
+To confirm that the installation was successful, we can run these `kubectl` commands, which should yield output similar to the following:
 {{<command>}}
 $ kubectl crossplane --version
 v1.13.2
+
 $ kubectl get crds | grep crossplane
 compositions.apiextensions.crossplane.io                     2023-09-03T11:30:36Z
 configurations.pkg.crossplane.io                             2023-09-03T11:30:36Z
@@ -55,7 +56,7 @@ configurations.pkg.crossplane.io                             2023-09-03T11:30:36
 
 ### Step 2: Installing the Crossplane AWS Provider
 
-Once the basic Crossplane installation is running properly, we can proceed with installing the AWS Provider.
+Once the basic Crossplane installation is running properly, we can proceed with installing the AWS provider.
 Newer versions of Crossplane promote the use of [provider families](https://docs.upbound.io/providers/provider-families), which are collections of providers for different groups of resources.
 For example, there is a separate provider for each individual AWS service (like S3, SQS, Lambda, etc), and in addition provider family provides shared resources for common configuration of all services (e.g., credentials, etc).
 
@@ -161,7 +162,7 @@ EOF
 {{</command>}}
 
 If everything is wired up correctly, you should now see some activity in the LocalStack log outputs, where Crossplane starts deploying the S3 bucket against LocalStack.
-After some time, the bucket should be transitioning into `ready` status within Crossplane:
+After some time, the bucket should be transitioning into `ready` state within Crossplane:
 {{<command>}}
 $ kubectl get buckets
 NAME                     READY   SYNCED   EXTERNAL-NAME            AGE
@@ -174,7 +175,7 @@ $ awslocal s3 ls
 2023-09-03 15:18:47 crossplane-test-bucket
 {{</command>}}
 
-We can repeat the same exercise for creating a local SQS queue:
+We can repeat the same exercise for creating a local SQS queue named `crossplane-test-queue`:
 {{<command>}}
 $ cat <<EOF | kubectl apply -f -
 apiVersion: sqs.aws.upbound.io/v1beta1
@@ -188,7 +189,7 @@ spec:
 EOF
 {{</command>}}
 
-After some time, the queue should transition into status `ready` in Crossplane:
+After some time, the queue should transition into `ready` state in Crossplane:
 {{<command>}}
 $ kubectl get queues
 NAME                    READY   SYNCED   EXTERNAL-NAME                                                         AGE
@@ -214,7 +215,7 @@ Please refer to the additional reading material to learn and explore more advanc
 
 ## Further Reading
 
-* Kubernetes on Docker Desktop: https://docs.docker.com/desktop/kubernetes/
+* Kubernetes on Docker Desktop: https://docs.docker.com/desktop/kubernetes
 * Kubernetes getting started guide: https://kubernetes.io/docs/setup
 * Crossplane user docs: https://docs.crossplane.io
 * Crossplane AWS provider family: https://marketplace.upbound.io/providers/upbound/provider-family-aws

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -62,7 +62,7 @@ Newer versions of Crossplane promote the use of [provider families](https://docs
 For example, there is a separate provider for each individual AWS service (like S3, SQS, Lambda, etc), and in addition provider family provides shared resources for common configuration of all services (e.g., credentials, etc).
 
 In the following, we first install the AWS provider for S3.
-Please note that you can copy/paste the entire multi-line command below into your terminal:
+Note that you can copy/paste the entire multi-line command below into your terminal:
 {{<command>}}
 $ cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -16,7 +16,7 @@ aliases:
 
 Crossplane offers a native [AWS provider](https://github.com/upbound/provider-aws) which can be used to create and manage AWS cloud resources via the Crossplane platform.
 For example, it can be used to create S3 buckets, SQS queues, Lambda functions, among many other resources.
-At the time of writing, the Crossplane AWS provider supports a comprehensive set of some [900+ resource types](https://marketplace.upbound.io/providers/upbound/provider-aws).
+Crossplane AWS provider supports a comprehensive set of some [900+ resource types](https://marketplace.upbound.io/providers/upbound/provider-aws).
 
 ## Tutorial: Creating AWS resources in LocalStack via Crossplane
 

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -41,19 +41,18 @@ $ helm install crossplane crossplane-stable/crossplane --namespace crossplane-sy
 The installation may take a few minutes. In parallel, we can install the `crossplane` command-line extensions for `kubectl`:
 {{<command>}}
 $ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | bash
-...
+<disable-copy>...</disable-copy>
 $ sudo mv kubectl-crossplane /usr/local/bin
 {{</command>}}
-
 To confirm that the installation was successful, we can run these `kubectl` commands, which should yield output similar to the following:
 {{<command>}}
 $ kubectl crossplane --version
-v1.13.2
+<disable-copy>v1.13.2</disable-copy>
 
 $ kubectl get crds | grep crossplane
-compositions.apiextensions.crossplane.io                     2023-09-03T11:30:36Z
+<disable-copy>compositions.apiextensions.crossplane.io                     2023-09-03T11:30:36Z
 configurations.pkg.crossplane.io                             2023-09-03T11:30:36Z
-...
+...</disable-copy>
 {{</command>}}
 
 ### Step 2: Installing the Crossplane AWS Provider
@@ -89,11 +88,12 @@ EOF
 
 After some time, the providers should get into healthy state, which can be confirmed via `kubectl get providers`:
 {{<command>}}
-$ kubectl get providers
+$ kubectl get providers<disable-copy>
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
 upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.40.0   2m
 provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.40.0       2m
 provider-aws-sqs              True        True      xpkg.upbound.io/upbound/provider-aws-sqs:v0.40.0      2m
+</disable-copy>
 {{</command>}}
 
 Next, we install a secret to define the test credentials for the AWS provider:
@@ -167,15 +167,17 @@ EOF
 If everything is wired up correctly, you should now see some activity in the LocalStack log outputs, where Crossplane starts deploying the S3 bucket against LocalStack.
 After some time, the bucket should be transitioning into `ready` state within Crossplane:
 {{<command>}}
-$ kubectl get buckets
+$ kubectl get buckets<disable-copy>
 NAME                     READY   SYNCED   EXTERNAL-NAME            AGE
 crossplane-test-bucket   True    True     crossplane-test-bucket   30s
+</disable-copy>
 {{</command>}}
 
 ... and the bucket it should also be visible when querying the local S3 buckets in LocalStack via [`awslocal`](https://github.com/localstack/awscli-local):
 {{<command>}}
-$ awslocal s3 ls
+$ awslocal s3 ls<disable-copy>
 2023-09-03 15:18:47 crossplane-test-bucket
+</disable-copy>
 {{</command>}}
 
 We can repeat the same exercise for creating a local SQS queue named `crossplane-test-queue`:
@@ -194,19 +196,21 @@ EOF
 
 After some time, the queue should transition into `ready` state in Crossplane:
 {{<command>}}
-$ kubectl get queues
+$ kubectl get queues<disable-copy>
 NAME                    READY   SYNCED   EXTERNAL-NAME                                                         AGE
 crossplane-test-queue   True    True     http://host.docker.internal:4566/000000000000/crossplane-test-queue   40s
+</disable-copy>
 {{</command>}}
 
 ... and the queue should be visible when listing the SQS queues in LocalStack:
 {{<command>}}
-$ awslocal sqs list-queues
+$ awslocal sqs list-queues<disable-copy>
 {
     "QueueUrls": [
         "http://localhost:4566/000000000000/crossplane-test-queue"
     ]
 }
+</disable-copy>
 {{</command>}}
 
 ### Summary

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -18,7 +18,7 @@ Crossplane offers a native [AWS provider](https://github.com/upbound/provider-aw
 For example, it can be used to create S3 buckets, SQS queues, Lambda functions, among many other resources.
 Crossplane AWS provider supports a comprehensive set of some [900+ resource types](https://marketplace.upbound.io/providers/upbound/provider-aws).
 
-## Tutorial: Creating AWS resources in LocalStack via Crossplane
+## Getting started
 
 In the following, we provide a step-by-step guide for installing Crossplane in a local test environment, and creating AWS resources (S3 bucket, SQS queue) in LocalStack via Crossplane.
 

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -22,9 +22,7 @@ Crossplane AWS provider supports a comprehensive set of some [900+ resource type
 
 In the following, we provide a step-by-step guide for installing Crossplane in a local test environment, and creating AWS resources (S3 bucket, SQS queue) in LocalStack via Crossplane.
 
-### Step 1: Installing Crossplane in local Kubernetes
-
-As a prerequisite, we need the following:
+### Prerequisites
 * LocalStack running in local Docker
 * A local Kubernetes cluster:
   * We can use the [embedded Kubernetes cluster](https://docs.docker.com/desktop/kubernetes) that ships with modern versions of Docker Desktop (can be easily enabled in the Docker settings)

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -1,0 +1,221 @@
+---
+title: "Crossplane"
+tags: ["crossplane", "kubernetes", "infrastructure-as-code"]
+weight: 5
+description: >
+  Use the Crossplane cloud-native control plane framework with LocalStack
+aliases:
+  - /integrations/crossplane/
+---
+
+<img src="logo-crossplane.svg" width="500px" alt="Crossplane logo">
+
+## Overview
+
+[Crossplane](https://www.crossplane.io) is a cloud-native control plane framework, which offers an extensible backend that enables orchestrating applications and infrastructure via declarative APIs and resource definitions.
+
+Crossplane offers a native [AWS provider](https://github.com/upbound/provider-aws) which can be used to create and manage AWS cloud resources via the Crossplane platform.
+For example, it can be used to create S3 buckets, SQS queues, Lambda functions, among many other resources.
+At the time of writing, the Crossplane AWS provider supports a comprehensive set of some [900+ resource types](https://marketplace.upbound.io/providers/upbound/provider-aws).
+
+## Tutorial: Creating AWS resources in LocalStack via Crossplane
+
+In the following, we provide a step-by-step guide for installing Crossplane in a local test environment, and creating AWS resources (S3 bucket, SQS queue) in LocalStack via Crossplane.
+
+### Step 1: Installing Crossplane in local Kubernetes
+
+As a prerequisite, we need the following:
+* LocalStack running in local Docker
+* A Kubernetes cluster: We can use the embedded Kubernetes cluster that ships with modern versions of Docker Desktop (can be easily enabled in the Docker settings)
+* The [`helm`](https://helm.sh) and [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) command-line clients installed
+
+We first install Crossplane via `helm`:
+{{<command>}}
+$ helm repo add crossplane-stable https://charts.crossplane.io/stable
+$ helm repo update
+$ helm install crossplane crossplane-stable/crossplane --namespace crossplane-system --create-namespace
+{{</command>}}
+
+The installation may take a few minutes. In parallel, we can install the `crossplane` command-line extensions for `kubectl`:
+{{<command>}}
+$ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | bash
+...
+$ sudo mv kubectl-crossplane /usr/local/bin
+{{</command>}}
+
+TO confirm that the installation was successful, you can run these commands, which should yield output similar to the following:
+{{<command>}}
+$ kubectl crossplane --version
+v1.13.2
+$ kubectl get crds | grep crossplane
+compositions.apiextensions.crossplane.io                     2023-09-03T11:30:36Z
+configurations.pkg.crossplane.io                             2023-09-03T11:30:36Z
+...
+{{</command>}}
+
+### Step 2: Installing the Crossplane AWS Provider
+
+Once the basic Crossplane installation is running properly, we can proceed with installing the AWS Provider.
+Newer versions of Crossplane promote the use of [provider families](https://docs.upbound.io/providers/provider-families), which are collections of providers for different groups of resources.
+For example, there is a separate provider for each individual AWS service (like S3, SQS, Lambda, etc), and in addition provider family provides shared resources for common configuration of all services (e.g., credentials, etc).
+
+In the following, we first install a secret to define the test credentials for the AWS provider. Please note that you can copy/paste the entire multi-line command below in your terminal:
+{{<command>}}
+$ cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: localstack-aws-secret
+stringData:
+  creds: |
+    [default]
+    aws_access_key_id = test
+    aws_secret_access_key = test
+EOF
+{{</command>}}
+
+Next, we create an AWS  `ProviderConfig` that references the secret created above, and defines a static `endpoint` pointing to the LocalStack URL `http://host.docker.internal:4566`:
+{{<command>}}
+$ cat <<EOF | kubectl apply -f -
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      name: localstack-aws-secret
+      namespace: default
+      key: creds
+  endpoint:
+    hostnameImmutable: true
+    # TODO: add more services to this list, as needed
+    services: [iam, s3, sqs, sts]
+    url:
+      type: Static
+      static: http://host.docker.internal:4566
+  skip_credentials_validation: true
+  skip_metadata_api_check: true
+  skip_requesting_account_id: true
+  s3_use_path_style: true
+EOF
+{{</command>}}
+
+{{<alert title="Note">}}
+The endpoint `http://host.docker.internal:4566` in the listing above assumes that you are running Kubernetes in the local Docker engine, and that LocalStack is up and running and available on default port `4566`.
+{{</alert>}}
+
+{{<alert title="Note">}}
+The Crossplane AWS provider currently requires us to specify the list of `services` for which the local `endpoint` is used as the target URL. Please make sure to extend this list accordingly if you're working with additional LocalStack services.
+{{</alert>}}
+
+Next, we continue by installing the AWS provider for S3 ...
+{{<command>}}
+$ cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-s3
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.40.0
+EOF
+{{</command>}}
+
+... as well as the AWS provider for SQS:
+{{<command>}}
+$ cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-sqs
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-sqs:v0.40.0
+EOF
+{{</command>}}
+
+After some time, the providers should get into healthy state, which can be confirmed via `kubectl get providers`:
+{{<command>}}
+$ kubectl get providers
+NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.40.0   2m
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.40.0       2m
+provider-aws-sqs              True        True      xpkg.upbound.io/upbound/provider-aws-sqs:v0.40.0      2m
+{{</command>}}
+
+### Step 3: Deploying sample resources in LocalStack
+
+After the Crossplane AWS provider is properly installed and configured, we can proceed with creating some local resources.
+
+First, we create an S3 bucket named `crossplane-test-bucket`:
+{{<command>}}
+$ cat <<EOF | kubectl apply -f -
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: crossplane-test-bucket
+spec:
+  forProvider:
+    region: us-east-1
+EOF
+{{</command>}}
+
+If everything is wired up correctly, you should now see some activity in the LocalStack log outputs, where Crossplane starts deploying the S3 bucket against LocalStack.
+After some time, the bucket should be transitioning into `ready` status within Crossplane:
+{{<command>}}
+$ kubectl get buckets
+NAME                     READY   SYNCED   EXTERNAL-NAME            AGE
+crossplane-test-bucket   True    True     crossplane-test-bucket   30s
+{{</command>}}
+
+... and the bucket it should also be visible when querying the local S3 buckets in LocalStack via [`awslocal`](https://github.com/localstack/awscli-local):
+{{<command>}}
+$ awslocal s3 ls
+2023-09-03 15:18:47 crossplane-test-bucket
+{{</command>}}
+
+We can repeat the same exercise for creating a local SQS queue:
+{{<command>}}
+$ cat <<EOF | kubectl apply -f -
+apiVersion: sqs.aws.upbound.io/v1beta1
+kind: Queue
+metadata:
+  name: crossplane-test-queue
+spec:
+  forProvider:
+    name: crossplane-test-queue
+    region: us-east-1
+EOF
+{{</command>}}
+
+After some time, the queue should transition into status `ready` in Crossplane:
+{{<command>}}
+$ kubectl get queues
+NAME                    READY   SYNCED   EXTERNAL-NAME                                                         AGE
+crossplane-test-queue   True    True     http://host.docker.internal:4566/000000000000/crossplane-test-queue   40s
+{{</command>}}
+
+... and the queue should be visible when listing the SQS queues in LocalStack:
+{{<command>}}
+$ awslocal sqs list-queues
+{
+    "QueueUrls": [
+        "http://localhost:4566/000000000000/crossplane-test-queue"
+    ]
+}
+{{</command>}}
+
+### Summary
+
+The Crossplane AWS provider is a great way to manage AWS resources, and by leveraging the `endpoint` configuration of the provider, we can seamlessly run resource deployments against LocalStack.
+
+In this tutorial, we have provided an end-to-end walkthrough of how to provision two simple resources - an S3 bucket, and an SQS queue. Crossplane supports a vast range of additional AWS resource types, as well as advanced operations like updating, deleting, or composing resources.
+Please refer to the additional reading material to learn and explore more advanced features.
+
+## Further Reading
+
+* Kubernetes on Docker Desktop: https://docs.docker.com/desktop/kubernetes/
+* Kubernetes getting started guide: https://kubernetes.io/docs/setup
+* Crossplane user docs: https://docs.crossplane.io
+* Crossplane AWS provider family: https://marketplace.upbound.io/providers/upbound/provider-family-aws
+* Crossplane AWS provider source code: https://github.com/upbound/provider-aws

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -55,7 +55,7 @@ configurations.pkg.crossplane.io                             2023-09-03T11:30:36
 ...</disable-copy>
 {{</command>}}
 
-### Step 2: Installing the Crossplane AWS Provider
+### Installing the Crossplane AWS Provider
 
 Once the basic Crossplane installation is running properly, we can proceed with installing the AWS provider.
 Newer versions of Crossplane promote the use of [provider families](https://docs.upbound.io/providers/provider-families), which are collections of providers for different groups of resources.

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -218,7 +218,7 @@ $ awslocal sqs list-queues<disable-copy>
 The Crossplane AWS provider is a great way to manage AWS resources, and by leveraging the `endpoint` configuration of the provider, we can seamlessly run resource deployments against LocalStack.
 
 In this tutorial, we have provided an end-to-end walkthrough of how to provision two simple resources - an S3 bucket, and an SQS queue. Crossplane supports a vast range of additional AWS resource types, as well as advanced operations like updating, deleting, or composing resources.
-Please refer to the additional reading material to learn and explore more advanced features.
+You can refer to the additional reading material to learn and explore more advanced features.
 
 ## Further Reading
 

--- a/content/en/user-guide/integrations/crossplane/index.md
+++ b/content/en/user-guide/integrations/crossplane/index.md
@@ -147,7 +147,7 @@ The endpoint `http://host.docker.internal:4566` in the listing above assumes tha
 The Crossplane AWS provider currently requires us to specify the list of `services` for which the local `endpoint` is used as the target URL. Please make sure to extend this list accordingly if you're working with additional LocalStack services.
 {{</alert>}}
 
-### Step 3: Deploying sample resources in LocalStack
+### Deploying sample resources in LocalStack
 
 After the Crossplane AWS provider is properly installed and configured, we can proceed with creating some local resources.
 

--- a/content/en/user-guide/integrations/crossplane/logo-crossplane.svg
+++ b/content/en/user-guide/integrations/crossplane/logo-crossplane.svg
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1312.19 279.51" style="enable-background:new 0 0 1312.19 279.51;" xml:space="preserve">
+<style type="text/css">
+	.st0{clip-path:url(#SVGID_2_);fill:#F7D186;}
+	.st1{clip-path:url(#SVGID_4_);fill:#FF9234;}
+	.st2{clip-path:url(#SVGID_6_);enable-background:new    ;}
+	.st3{clip-path:url(#SVGID_8_);}
+	.st4{clip-path:url(#SVGID_10_);}
+	.st5{clip-path:url(#SVGID_12_);fill:#FFCD3C;}
+	.st6{clip-path:url(#SVGID_14_);enable-background:new    ;}
+	.st7{clip-path:url(#SVGID_16_);}
+	.st8{clip-path:url(#SVGID_18_);}
+	.st9{clip-path:url(#SVGID_20_);fill:#F3807B;}
+	.st10{clip-path:url(#SVGID_22_);enable-background:new    ;}
+	.st11{clip-path:url(#SVGID_24_);}
+	.st12{clip-path:url(#SVGID_26_);}
+	.st13{clip-path:url(#SVGID_28_);fill:#35D0BA;}
+	.st14{clip-path:url(#SVGID_30_);fill:#D8AE64;}
+	.st15{clip-path:url(#SVGID_32_);fill:#004680;}
+	.st16{clip-path:url(#SVGID_34_);fill:#004680;}
+	.st17{clip-path:url(#SVGID_36_);fill:#004680;}
+	.st18{clip-path:url(#SVGID_38_);fill:#004680;}
+	.st19{clip-path:url(#SVGID_40_);fill:#004680;}
+	.st20{clip-path:url(#SVGID_42_);fill:#004680;}
+	.st21{clip-path:url(#SVGID_44_);fill:#004680;}
+	.st22{clip-path:url(#SVGID_46_);fill:#004680;}
+	.st23{clip-path:url(#SVGID_48_);fill:#004680;}
+	.st24{clip-path:url(#SVGID_50_);fill:#004680;}
+</style>
+<g>
+	<g>
+		<defs>
+			<path id="SVGID_1_" d="M115.47,94.13c-8.4,0-15.22,6.81-15.22,15.22v143.2c0,8.4,6.81,15.22,15.22,15.22s15.22-6.81,15.22-15.22
+				v-143.2C130.68,100.94,123.87,94.13,115.47,94.13"/>
+		</defs>
+		<clipPath id="SVGID_2_">
+			<use xlink:href="#SVGID_1_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="89.53" y="83.41" class="st0" width="51.87" height="195.07"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_3_" d="M176.53,75.36c0.05-0.96,0.07-1.93,0.07-2.9c0-0.95-0.02-1.89-0.07-2.82
+				c-1.47-32.22-28.06-57.88-60.64-57.88S56.72,37.42,55.25,69.64c-0.04,0.94-0.07,1.88-0.07,2.82c0,1.04,0.03,2.07,0.08,3.09
+				c-0.02,0.5-0.08,1-0.08,1.51v99.64c0,19.06,15.59,34.65,34.65,34.65h52.14c19.06,0,34.65-15.59,34.65-34.65V77.07
+				C176.62,76.49,176.56,75.93,176.53,75.36"/>
+		</defs>
+		<clipPath id="SVGID_4_">
+			<use xlink:href="#SVGID_3_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="44.47" y="1.04" class="st1" width="142.87" height="221.04"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_5_" d="M55.55,69.64c-0.04,0.93-0.06,1.87-0.06,2.82c0,1.04,0.02,2.07,0.08,3.09c-0.02,0.51-0.08,1-0.08,1.52
+				v99.64c0,19.05,15.59,34.64,34.64,34.64h52.14c19.06,0,34.65-15.59,34.65-34.64V77.07c0-0.58-0.06-1.14-0.09-1.71
+				c0.05-0.96,0.07-1.93,0.07-2.89c0-0.95-0.02-1.89-0.06-2.82c-1.47-32.22-28.06-57.88-60.64-57.88
+				C83.61,11.76,57.02,37.42,55.55,69.64z"/>
+		</defs>
+		<clipPath id="SVGID_6_">
+			<use xlink:href="#SVGID_5_"  style="overflow:visible;"/>
+		</clipPath>
+		<g class="st2">
+			<g>
+				<defs>
+					<rect id="SVGID_7_" x="16.08" y="24.9" width="197.24" height="197.24"/>
+				</defs>
+				<clipPath id="SVGID_8_">
+					<use xlink:href="#SVGID_7_"  style="overflow:visible;"/>
+				</clipPath>
+				<g class="st3">
+					<defs>
+						
+							<rect id="SVGID_9_" x="9.23" y="92.99" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -54.1638 118.2926)" width="212.95" height="63.07"/>
+					</defs>
+					<clipPath id="SVGID_10_">
+						<use xlink:href="#SVGID_9_"  style="overflow:visible;"/>
+					</clipPath>
+					<g class="st4">
+						<defs>
+							<rect id="SVGID_11_" x="54.67" y="9.89" width="124.35" height="201.53"/>
+						</defs>
+						<clipPath id="SVGID_12_">
+							<use xlink:href="#SVGID_11_"  style="overflow:visible;"/>
+						</clipPath>
+						<rect x="7.4" y="16.22" class="st5" width="216.62" height="216.62"/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_13_" d="M55.55,69.64c-0.04,0.93-0.06,1.87-0.06,2.82c0,1.04,0.02,2.07,0.08,3.09c-0.02,0.51-0.08,1-0.08,1.52
+				v99.64c0,19.05,15.59,34.64,34.64,34.64h52.14c19.06,0,34.65-15.59,34.65-34.64V77.07c0-0.58-0.06-1.14-0.09-1.71
+				c0.05-0.96,0.07-1.93,0.07-2.89c0-0.95-0.02-1.89-0.06-2.82c-1.47-32.22-28.06-57.88-60.64-57.88
+				C83.61,11.76,57.02,37.42,55.55,69.64z"/>
+		</defs>
+		<clipPath id="SVGID_14_">
+			<use xlink:href="#SVGID_13_"  style="overflow:visible;"/>
+		</clipPath>
+		<g class="st6">
+			<g>
+				<defs>
+					<rect id="SVGID_15_" x="-37.52" y="-28.7" width="207.96" height="207.96"/>
+				</defs>
+				<clipPath id="SVGID_16_">
+					<use xlink:href="#SVGID_15_"  style="overflow:visible;"/>
+				</clipPath>
+				<g class="st7">
+					<defs>
+						
+							<rect id="SVGID_17_" x="-40.95" y="35.1" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -33.3744 68.1028)" width="212.95" height="78.48"/>
+					</defs>
+					<clipPath id="SVGID_18_">
+						<use xlink:href="#SVGID_17_"  style="overflow:visible;"/>
+					</clipPath>
+					<g class="st8">
+						<defs>
+							<rect id="SVGID_19_" x="54.67" y="9.89" width="124.35" height="201.53"/>
+						</defs>
+						<clipPath id="SVGID_20_">
+							<use xlink:href="#SVGID_19_"  style="overflow:visible;"/>
+						</clipPath>
+						<rect x="-48.24" y="-39.42" class="st9" width="227.51" height="227.51"/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_21_" d="M55.55,69.64c-0.04,0.93-0.06,1.87-0.06,2.82c0,1.04,0.02,2.07,0.08,3.09c-0.02,0.51-0.08,1-0.08,1.52
+				v99.64c0,19.05,15.59,34.64,34.64,34.64h52.14c19.06,0,34.65-15.59,34.65-34.64V77.07c0-0.58-0.06-1.14-0.09-1.71
+				c0.05-0.96,0.07-1.93,0.07-2.89c0-0.95-0.02-1.89-0.06-2.82c-1.47-32.22-28.06-57.88-60.64-57.88
+				C83.61,11.76,57.02,37.42,55.55,69.64z"/>
+		</defs>
+		<clipPath id="SVGID_22_">
+			<use xlink:href="#SVGID_21_"  style="overflow:visible;"/>
+		</clipPath>
+		<g class="st10">
+			<g>
+				<defs>
+					<rect id="SVGID_23_" x="61.1" y="69.92" width="197.24" height="197.24"/>
+				</defs>
+				<clipPath id="SVGID_24_">
+					<use xlink:href="#SVGID_23_"  style="overflow:visible;"/>
+				</clipPath>
+				<g class="st11">
+					<defs>
+						
+							<rect id="SVGID_25_" x="53.98" y="137.74" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -72.6974 163.0359)" width="212.95" height="63.07"/>
+					</defs>
+					<clipPath id="SVGID_26_">
+						<use xlink:href="#SVGID_25_"  style="overflow:visible;"/>
+					</clipPath>
+					<g class="st12">
+						<defs>
+							<rect id="SVGID_27_" x="54.67" y="9.89" width="124.35" height="201.53"/>
+						</defs>
+						<clipPath id="SVGID_28_">
+							<use xlink:href="#SVGID_27_"  style="overflow:visible;"/>
+						</clipPath>
+						<rect x="52.14" y="60.96" class="st13" width="216.62" height="216.62"/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_29_" d="M104.38,211.52l26.4,26.39V211.3C130.78,211.3,103.72,211.52,104.38,211.52"/>
+		</defs>
+		<clipPath id="SVGID_30_">
+			<use xlink:href="#SVGID_29_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="93.65" y="200.58" class="st14" width="47.85" height="48.06"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_31_" d="M307.52,195.1c-38.8,0-70.21-31.6-70.21-70.41c0-38.6,31.4-70.21,70.21-70.21c20.2,0,39.6,8.8,52.81,24
+				c4.2,5,3.8,12.2-1,16.4c-4.8,4.4-12.2,3.8-16.4-1c-9-10.2-21.8-16-35.4-16c-25.8,0-47.01,21-47.01,46.8
+				c0,26,21.2,47.01,47.01,47.01c13.6,0,26.4-5.8,35.4-16c4.2-4.8,11.6-5.4,16.4-1c4.8,4.2,5.2,11.4,1,16.4
+				C347.12,186.3,327.72,195.1,307.52,195.1"/>
+		</defs>
+		<use xlink:href="#SVGID_31_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_32_">
+			<use xlink:href="#SVGID_31_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="226.59" y="43.77" class="st15" width="147.35" height="162.05"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_33_" d="M438.53,98.89c0,6.4-5.2,11.6-11.8,11.6c-12.8,0-22.4,10.4-22.4,24.6v48.41c0,6.4-5.2,11.6-11.6,11.6
+				c-6.4,0-11.6-5.2-11.6-11.6V96.49c0-6.4,5.2-11.6,11.6-11.6c5.4,0,9.8,3.6,11.2,8.6c6.8-4,14.6-6.2,22.8-6.2
+				C433.33,87.29,438.53,92.49,438.53,98.89"/>
+		</defs>
+		<use xlink:href="#SVGID_33_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_34_">
+			<use xlink:href="#SVGID_33_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="370.4" y="74.17" class="st16" width="78.84" height="131.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_35_" d="M497.53,195.7c-30.4,0-55-24.8-55-55c0-30.4,24.6-55.21,55-55.21c30.4,0,55.21,24.8,55.21,55.21
+				C552.74,170.9,527.94,195.7,497.53,195.7 M497.53,108.69c-17.6,0-31.8,14.4-31.8,32c0,17.4,14.2,31.8,31.8,31.8
+				c17.6,0,31.8-14.4,31.8-31.8C529.34,123.09,515.14,108.69,497.53,108.69"/>
+		</defs>
+		<use xlink:href="#SVGID_35_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_36_">
+			<use xlink:href="#SVGID_35_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="431.81" y="74.77" class="st17" width="131.65" height="131.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_37_" d="M571.94,174.9c-2.8-5.8-0.2-12.8,5.6-15.4c6-2.8,12.8-0.2,15.4,5.6c1.6,3.2,6,6.8,13.8,6.8
+				c10.8,0,14.6-6.6,14.6-11c0-6-1.6-7.8-17.2-11.8c-7-1.6-14.2-3.4-20.4-7.4c-8.4-5.6-13-14-13-24.4c0-8.2,3.6-16.4,9.8-22.4
+				c6.6-6.4,15.8-10,26.2-10c14.8,0,27.41,7.2,32.8,19c2.8,5.8,0.2,12.6-5.6,15.4c-5.8,2.8-12.8,0.2-15.4-5.6
+				c-1.2-2.6-5-5.6-11.8-5.6c-9.2,0-12.6,5.8-12.6,9.2c0,4,0.8,5.6,15.6,9.4c13,3.2,34.8,8.6,34.8,34.2c0,8.6-3.6,17.2-10,23.6
+				c-5,4.8-13.8,10.6-27.8,10.6C590.94,195.1,577.54,187.3,571.94,174.9"/>
+		</defs>
+		<use xlink:href="#SVGID_37_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_38_">
+			<use xlink:href="#SVGID_37_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="560.02" y="74.17" class="st18" width="95.25" height="131.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_39_" d="M663.75,174.9c-2.8-5.8-0.2-12.8,5.6-15.4c6-2.8,12.8-0.2,15.4,5.6c1.6,3.2,6,6.8,13.8,6.8
+				c10.8,0,14.6-6.6,14.6-11c0-6-1.6-7.8-17.2-11.8c-7-1.6-14.2-3.4-20.4-7.4c-8.4-5.6-13-14-13-24.4c0-8.2,3.6-16.4,9.8-22.4
+				c6.6-6.4,15.8-10,26.2-10c14.81,0,27.41,7.2,32.8,19c2.8,5.8,0.2,12.6-5.6,15.4c-5.8,2.8-12.8,0.2-15.4-5.6
+				c-1.2-2.6-5-5.6-11.8-5.6c-9.2,0-12.6,5.8-12.6,9.2c0,4,0.8,5.6,15.6,9.4c13,3.2,34.8,8.6,34.8,34.2c0,8.6-3.6,17.2-10,23.6
+				c-5,4.8-13.8,10.6-27.8,10.6C682.75,195.1,669.35,187.3,663.75,174.9"/>
+		</defs>
+		<use xlink:href="#SVGID_39_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_40_">
+			<use xlink:href="#SVGID_39_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="651.83" y="74.17" class="st19" width="95.25" height="131.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_41_" d="M859.17,139.9c0,14.8-5,28.4-14.4,38.61c-9.8,10.6-23.2,16.6-38,16.6c-10.6,0-20.6-3.2-29-8.8v47.2
+				c0,6.4-5.4,11.6-11.8,11.6c-6.4,0-11.6-5.2-11.6-11.6V96.49c0-6.4,5.2-11.6,11.6-11.6c5.4,0,10.2,3.8,11.4,9
+				c8.6-5.8,18.8-9,29.4-9c14.8,0,28.2,5.8,38,16.4C854.17,111.49,859.17,125.29,859.17,139.9 M835.96,139.9
+				c0-18.4-12.2-31.8-29.2-31.8c-16.8,0-29,13.4-29,31.8c0,18.4,12.2,31.8,29,31.8C823.77,171.7,835.96,158.3,835.96,139.9"/>
+		</defs>
+		<use xlink:href="#SVGID_41_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_42_">
+			<use xlink:href="#SVGID_41_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="743.64" y="74.17" class="st20" width="126.25" height="181.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_43_" d="M889.77,195.1c-6.4,0-11.6-5.2-11.6-11.6V66.29c0-6.4,5.2-11.6,11.6-11.6c6.4,0,11.8,5.2,11.8,11.6V183.5
+				C901.57,189.9,896.17,195.1,889.77,195.1"/>
+		</defs>
+		<use xlink:href="#SVGID_43_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_44_">
+			<use xlink:href="#SVGID_43_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="867.45" y="43.97" class="st21" width="44.84" height="161.85"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_45_" d="M1025.38,96.49v87.01c0,6.4-5.2,11.6-11.6,11.6c-5.6,0-10.2-3.8-11.4-9c-8.4,5.8-18.6,9-29.4,9
+				c-14.8,0-28.2-5.8-38.01-16.6c-9.2-10-14.4-23.8-14.4-38.4c0-14.8,5.2-28.6,14.4-38.61c9.8-10.8,23.21-16.6,38.01-16.6
+				c10.8,0,21,3.2,29.4,9c1.2-5.2,5.8-9,11.4-9C1020.18,84.89,1025.38,90.09,1025.38,96.49 M1002.18,140.1c0-18.6-12.4-32-29.2-32
+				c-17,0-29.2,13.4-29.2,32c0,18.4,12.2,31.8,29.2,31.8C989.78,171.9,1002.18,158.5,1002.18,140.1"/>
+		</defs>
+		<use xlink:href="#SVGID_45_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_46_">
+			<use xlink:href="#SVGID_45_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="909.85" y="74.17" class="st22" width="126.25" height="131.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_47_" d="M1136.79,132.7v50.8c0,6.4-5.2,11.6-11.8,11.6c-6.4,0-11.6-5.2-11.6-11.6v-50.8
+				c0-11.8-6.6-24.6-21.4-24.6c-13.4,0-23.4,10.6-23.4,24.6v0.8v0.8v49.2c0,6.4-5.2,11.6-11.6,11.6c-6.4,0-11.6-5.2-11.6-11.6v-49.4
+				v-1.4V96.49c0-6.4,5.2-11.6,11.6-11.6c4.8,0,8.8,2.8,10.6,6.8c7-4.4,15.4-6.8,24.4-6.8
+				C1117.39,84.89,1136.79,105.49,1136.79,132.7"/>
+		</defs>
+		<use xlink:href="#SVGID_47_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_48_">
+			<use xlink:href="#SVGID_47_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="1034.66" y="74.17" class="st23" width="112.85" height="131.65"/>
+	</g>
+	<g>
+		<defs>
+			<path id="SVGID_49_" d="M1207.2,196.1c-14.8,0-28.2-6.4-38.01-17.2c-9.4-10-14.4-23.81-14.4-38.4c0-31.61,22.2-55.21,51.4-55.21
+				c29.41,0,50.8,23.2,50.8,55.21c0,6.4-5.2,11.6-11.8,11.6h-65.41c4,12.2,14.4,20.8,27.4,20.8c7.83,0,14.48-1.65,19.23-6.21
+				c1.44-1.38,2.7-3.03,3.77-4.99c3.4-5.6,10.6-7.2,16-4c5.6,3.4,7.2,10.6,4,16C1241.2,189.9,1225.6,196.1,1207.2,196.1
+				 M1179.59,128.7h52.61c-4-13.8-15-20.2-26-20.2C1195.4,108.49,1183.79,114.89,1179.59,128.7"/>
+		</defs>
+		<use xlink:href="#SVGID_49_"  style="overflow:visible;fill-rule:evenodd;clip-rule:evenodd;fill:#004680;"/>
+		<clipPath id="SVGID_50_">
+			<use xlink:href="#SVGID_49_"  style="overflow:visible;"/>
+		</clipPath>
+		<rect x="1144.07" y="74.57" class="st24" width="123.65" height="132.25"/>
+	</g>
+</g>
+</svg>

--- a/content/en/user-guide/integrations/terraform/index.md
+++ b/content/en/user-guide/integrations/terraform/index.md
@@ -8,7 +8,7 @@ aliases:
   - /integrations/terraform/
 ---
 
-<img src="logo-terraform-main.svg" width="600px" alt="terraform logo">
+<img src="logo-terraform-main.svg" width="600px" alt="Terraform logo">
 
 ## Overview
 

--- a/layouts/shortcodes/command.html
+++ b/layouts/shortcodes/command.html
@@ -3,11 +3,19 @@
 {{ $inner := trim .Inner "\n " }}
 {{/* We encapsulate, for each line, the prefix (if present) in custom prefix tags so we find it after highlighting */}}
 {{ $inner = replaceRE `(?m)^ *((?:\$|#) )` "###CUSTOM_PREFIX###$1###CUSTOM_PREFIX_END###" $inner}}
+{{ $inner := replaceRE `\<disable-copy\>(?s)(.*?)\<\/disable-copy\>` "###DISABLE_COPY###$1###DISABLE_COPY_END###" $inner }}
 {{/* We need to set a default for the highlighting options here */}}
 {{ $options := "" }}
 {{ with .Get 0 }}
 {{ $options = . }}
 {{ end }}
 {{ $highlighted := highlight $inner "text" $options }}
+{{ $highlighted := replaceRE `###DISABLE_COPY###(?s)(.*?)###DISABLE_COPY_END###` "<span class=\"disable-copy\">$1</span>" $highlighted | safeHTML}}
+{{ with .Get "wrapper" }}
+  <div class="{{ . }}">
+{{ end }}
 {{/* Now we replace the custom prefixes with a span that contains the prefix, which is not selectable by users */}}
 {{- replaceRE `###CUSTOM_PREFIX###((?:\$|#)\s)###CUSTOM_PREFIX_END###` "<span class=\"command-prefix\">$1</span>" $highlighted | safeHTML -}}
+{{ with .Get "wrapper" }}
+  </div>
+{{ end }}

--- a/static/js/global-script.js
+++ b/static/js/global-script.js
@@ -8,6 +8,7 @@ function setupCodeBlockCopyButton() {
     e.preventDefault();
     const elem = $(this).closest('.code-container').find('code').clone();
     elem.find('.command-prefix').remove(); // removing prefix
+    elem.find('.disable-copy').remove(); // removing text which shouldn't be copied
     navigator.clipboard.writeText(elem.text());
     $(this).find('span').text('Copied!');
     setTimeout(() => {


### PR DESCRIPTION
Add tutorial on using [Crossplane](https://crossplane.io/) AWS provider with LocalStack. Motivated by a recent user request in the Discuss forum: https://discuss.localstack.cloud/t/crossplane-integration/507 (addresses point (2) in my response in the thread)

As a follow-up, it would be great if we can update the overview figure in our [integrations page](https://docs.localstack.cloud/user-guide/integrations/) - it is a bit outdated at this point, and a couple more integrations have been added in the meantime. @HarshCasper maybe we can work with @lazarvu on that - we also have a figure in our customer deck that we can build upon. 👍 

---
@HarshCasper I was trying to follow your advice on not using multi-line `<command>` listings that also contain the command output (to prevent users from copying the entire text when using the "copy" button), but tbh it was a bit tricky, as always separating the command and output into separate listings blows up the length of the text, and I kind of like the terse syntax with commands+output combined. Maybe we can introduce a new tag that would render commands, but with the "copy" button disabled? 🤔  To be discussed - happy to hear your thoughts as well..