### PR TITLE
upgrade to actions/checkout@v4, add actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alexrashed"
+    labels:
+      - "dependencies"

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout docs
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: docs

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Broken link checker
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive


### PR DESCRIPTION
## Motivation
This PR performs the same actions as https://github.com/localstack/localstack/pull/9065, just for the docs repo.
We are still seeing build issues related to https://github.com/actions/checkout/issues/1448, even though the incident should already be fixed (according to https://www.githubstatus.com/).
Some comments in this issue imply that an upgrade to the just newly released version 4 of [actions/checkout](https://github.com/actions/checkout) might fix the issue.
I used this opportunity toi also 

<!-- What notable changes does this PR make? -->
## Changes
- Upgrades all usages of [actions/checkout](https://github.com/actions/checkout) to version 4.
- Add GitHub actions to the dependabot config to file these upgrade PRs automatically in the future.