### PR TITLE
Fixed "disable copy" feature bug

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -524,7 +524,6 @@ table tfoot {
 }
 .td-content, body{
   .code-container {
-    position: relative;
     .code-copy-button {
       position: absolute;
       top: 0;
@@ -563,6 +562,10 @@ table tfoot {
   .code-copy-button{
     display: none !important;
   }
+}
+
+.disable-copy{
+  display: inline;
 }
 
 @import "modules/academy-styles.scss";

--- a/layouts/shortcodes/command.html
+++ b/layouts/shortcodes/command.html
@@ -10,7 +10,7 @@
 {{ $options = . }}
 {{ end }}
 {{ $highlighted := highlight $inner "text" $options }}
-{{ $highlighted := replaceRE `###DISABLE_COPY###(?s)(.*?)###DISABLE_COPY_END###` "<span class=\"disable-copy\">$1</span>" $highlighted | safeHTML}}
+{{ $highlighted := replaceRE `###DISABLE_COPY###(?s)(.*?)###DISABLE_COPY_END###` "<div class=\"disable-copy\">$1</div>" $highlighted | safeHTML}}
 {{ with .Get "wrapper" }}
   <div class="{{ . }}">
 {{ end }}


### PR DESCRIPTION
This PR fixes a reported bug (screenshot attached below) in the newly created "disable-copy" feature as it was acting weird with new lines.

![image](https://github.com/localstack/docs/assets/49054601/8c25d856-5b65-4c74-a79b-1efab09a7426)

