### PR TITLE
fix syntax error in snippet

### DIFF
--- a/content/en/user-guide/aws/security-token-service/index.md
+++ b/content/en/user-guide/aws/security-token-service/index.md
@@ -135,7 +135,7 @@ The following output would be retrieved:
 ```bash
 {
     "Credentials": {
-        "AccessKeyId": "<ACCESS_KEY_ID>,
+        "AccessKeyId": "ACCESS_KEY_ID",
         "SecretAccessKey": "SECRET_ACCESS_KEY",
         "SessionToken": "SESSION_TOKEN",
         "Expiration": "TIMESTAMP",


### PR DESCRIPTION
Encountered a tiny snippet syntax error that broke syntax highlighting.

Fix it and normalized display of output payload.

Thanks for your work !