### PR TITLE
Enhance docs for xray

### DIFF
--- a/content/en/getting-started/api-key.md
+++ b/content/en/getting-started/api-key.md
@@ -81,7 +81,7 @@ The easiest way to check if LocalStack is activated is to query the health endpo
 $ curl localhost:4566/_localstack/health | jq
 {{< / command >}}
 
-If a Pro-only [service]({{< ref "aws" >}}) -- like [XRay]({{< ref "XRay-Tracing" >}}) -- is running, LocalStack has started successfully. You can also check the logs of the LocalStack container to see if the activation was successful.
+If a Pro-only [service]({{< ref "aws" >}}) -- like [XRay]({{< ref "xray" >}}) -- is running, LocalStack has started successfully. You can also check the logs of the LocalStack container to see if the activation was successful.
 
 {{< command >}}
 [...] Successfully activated API key

--- a/content/en/getting-started/faq.md
+++ b/content/en/getting-started/faq.md
@@ -204,7 +204,7 @@ The easiest way to check if LocalStack Pro or Enterprise is activated is to chec
 $ curl localhost:4566/_localstack/health | jq
 {{< / command >}}
 
-If a Pro-only [service]({{< ref "aws" >}}) -- like [XRay]({{< ref "XRay-Tracing" >}}) -- is running, LocalStack Pro or Enterprise has started successfully. If your API key is invalid, you will see an error message like this in the logs of LocalStack:
+If a Pro-only [service]({{< ref "aws" >}}) -- like [XRay]({{< ref "xray" >}}) -- is running, LocalStack Pro or Enterprise has started successfully. If your API key is invalid, you will see an error message like this in the logs of LocalStack:
 
 ```bash
 Activation key "abc..."(10) is invalid or expired! Reason: ...

--- a/content/en/user-guide/aws/feature-coverage.md
+++ b/content/en/user-guide/aws/feature-coverage.md
@@ -735,7 +735,7 @@ In the coverage table below, the features are marked with their respective avail
 | SSH Public Keys                                                    | ⭐⭐⭐         | CRUD                |       |
 | Tags                                                               | \-             |                 |       |
 | Users                                                              | ⭐⭐⭐         | Emulated                |       |
-| [**X-Ray** (Pro)]({{< ref "xray-tracing" >}})                       | [Details 🔍]({{< ref "references/coverage/coverage_xray" >}}) |                 |       |
+| [**X-Ray** (Pro)]({{< ref "xray" >}})                              | [Details 🔍]({{< ref "references/coverage/coverage_xray" >}}) |                 |       |
 | Encryption Configs                                                 | \-             |                 |       |
 | Groups                                                             | \-           |                 |       |
 | Insights                                                           | \-             |                 |       |

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -241,7 +241,7 @@ The following code snippets and sample applications provide practical examples o
 - [Lambda Layers](https://github.com/localstack/localstack-pro-samples/blob/master/serverless-lambda-layers) demonstrates how to use Lambda layers, which are reusable packages of code that can be shared across multiple functions.
 - [Lambda PHP/Bref](https://github.com/localstack/localstack-pro-samples/tree/master/lambda-php-bref-cdk-app) shows how to use PHP/Bref with and without fpm, using the Serverless framework and AWS CDK.
 - [Lambda Container Images](https://github.com/localstack/localstack-pro-samples/tree/master/lambda-container-image) demonstrates how to use Lambda functions packaged as container images, which can be built using Docker and pushed to a local ECR registry.
-- [Lambda XRay Tracing](https://github.com/localstack/localstack-pro-samples/tree/master/lambda-xray) shows how to enable AWS X-Ray tracing for Lambda functions using the Serverless framework.
+- [Lambda X-Ray](https://github.com/localstack/localstack-pro-samples/tree/master/lambda-xray) shows how to instrument Lambda functions for X-Ray using Powertools and the X-Ray SDK.
 
 ## Troubleshooting
 

--- a/content/en/user-guide/aws/xray/index.md
+++ b/content/en/user-guide/aws/xray/index.md
@@ -1,15 +1,31 @@
 ---
-title: "XRay Tracing"
-linkTitle: "XRay Tracing"
+title: "X-Ray"
+linkTitle: "X-Ray"
 categories: ["LocalStack Pro"]
 description: >
-  Get started with XRay Tracing on LocalStack
+  Get started with X-Ray on LocalStack
 aliases:
   - /aws/xray-tracing/
 ---
 
-LocalStack Pro allows to instrument your applications using [XRay](https://aws.amazon.com/xray/) tracing. This helps in optimizing the interactions between service calls, and facilitates debugging of performance bottlenecks.
+## Introduction
 
+AWS X-Ray is a distributed tracing service that helps to understand cross-service interactions and facilitates
+debugging of performance bottlenecks.
+
+LocalStack supports X-Ray via the Pro/Team offering, allowing
+you to use the X-Ray APIs in your local environment.
+The supported APIs are available on our [API Coverage Page](https://docs.localstack.cloud/references/coverage/coverage_xray/),
+which provides information on the extent of X-Ray integration with LocalStack.
+
+## Getting started
+
+This guide is designed for users new to X-Ray and assumes basic
+knowledge of the AWS CLI and our `awslocal` wrapper script.
+
+// Provide a short tutorial to use the <Service Name> with AWS CLI/`awslocal`
+
+// TODO: describe short tutorial
 For example, a Python Lambda function can be instrumented as follows (based on the example [here](https://docs.aws.amazon.com/lambda/latest/dg/python-tracing.html)):
 
 ```python
@@ -28,8 +44,14 @@ def lambda_handler(event, context):
 
 Running this code in Lambda on LocalStack will result in two trace segments being created in XRay - one from the instrumented `boto3` client when running `create_bucket(..)`, and one for the custom subsegment denoted `'my_code'`. You can use the regular XRay API calls (e.g., [`GetTraceSummaries`](https://docs.aws.amazon.com/xray/latest/api/API_GetTraceSummaries.html), [`BatchGetTraces`](https://docs.aws.amazon.com/xray/latest/api/API_BatchGetTraces.html)) to retrieve the details (timestamps, IDs, etc) of these segments.
 
+## Examples
+
+// share any examples for this <Service Name> across Dev Hub, Pro Samples, etc
+
+// TODO: link to new pro sample
 You can also checkout another of our examples with Xray and Lambda, deployed via the Serverless framework, [`here`](https://github.com/localstack/localstack-pro-samples/tree/master/lambda-xray)
 
-{{< alert title="Note" >}}
-To use XRay in Lambdas, please note that you'll need to configure `LAMBDA_XRAY_INIT=1` - this will ensure that the XRay daemon process is fully initialized when spawning Lambda containers (may slightly increase startup times).
-{{< /alert >}}
+## Limitations
+
+LocalStack supports collecting trace segments but currently does not correlate multiple trace segments with the same
+`trace_id` into a single aggregated trace.

--- a/content/en/user-guide/aws/xray/index.md
+++ b/content/en/user-guide/aws/xray/index.md
@@ -1,37 +1,24 @@
 ---
 title: "X-Ray"
 linkTitle: "X-Ray"
-categories: ["LocalStack Pro"]
-description: >
-  Get started with X-Ray on LocalStack
+description: Get started with X-Ray on LocalStack
 aliases:
   - /aws/xray-tracing/
 ---
 
 ## Introduction
 
-[AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) is a distributed tracing service that
-helps to understand cross-service interactions and facilitates debugging of performance bottlenecks.
-
-Instrumented applications generate trace data by recording trace segments with information about the work tasks of an
-application, such as timestamps, tasks names, or metadata.
-AWS X-Rays supports different ways of [instrumenting your application](https://docs.aws.amazon.com/xray/latest/devguide/xray-instrumenting-your-app.html) including
+[X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) is a distributed tracing service that
+helps to understand cross-service interactions and facilitates debugging of performance bottlenecks. Instrumented applications generate trace data by recording trace segments with information about the work tasks of an
+application, such as timestamps, tasks names, or metadata. X-Ray supports different ways of [instrumenting your application](https://docs.aws.amazon.com/xray/latest/devguide/xray-instrumenting-your-app.html) including
 the [AWS X-Ray SDK](https://docs.aws.amazon.com/xray/latest/devguide/xray-instrumenting-your-app.html#xray-instrumenting-xray-sdk) and
 the [AWS Distro for OpenTelemetry (ADOT)](https://docs.aws.amazon.com/xray/latest/devguide/xray-instrumenting-your-app.html#xray-instrumenting-opentel).
-For AWS Lambda, the [Powertools for AWS](https://github.com/aws-powertools) provide an opinionated way to
-automatically configure ADOT for
-[Python](https://docs.powertools.aws.dev/lambda/python/latest/),
-[Java](https://docs.powertools.aws.dev/lambda/java/),
-[TypeScript](https://docs.powertools.aws.dev/lambda/typescript/latest/), and
-[.NET](https://docs.powertools.aws.dev/lambda/dotnet/).
-For example, the Python Powertools provide an `@tracer.capture_lambda_handler` annotation for automatically
-instrumenting Lambda handler functions.
-The [AWS X-Ray daemon](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html) is an application that gathers
+[X-Ray daemon](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html) is an application that gathers
 raw trace segment data from the X-Ray SDK and relays it to the AWS X-Ray API.
 The X-Ray API can then be used to retrieve traces originating from different application components.
 
 LocalStack supports X-Ray via the Pro/Team offering, allowing
-you to use the X-Ray APIs in your local environment.
+you to use the X-Ray APIs to send and retrieve trace segments in your local environment.
 The supported APIs are available on our [API Coverage Page](https://docs.localstack.cloud/references/coverage/coverage_xray/),
 which provides information on the extent of X-Ray integration with LocalStack.
 
@@ -40,22 +27,27 @@ which provides information on the extent of X-Ray integration with LocalStack.
 This guide is designed for users new to X-Ray and assumes basic
 knowledge of the AWS CLI and our `awslocal` wrapper script.
 
-Run the following Bash command to create a minimal [trace segment](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields)
-and manually send it to the X-Ray API using [PutTraceSegments](https://docs.aws.amazon.com/xray/latest/api/API_PutTraceSegments.html).
-Notice that this trace ingestion typically happens in the background, for example by the X-Ray SDK and X-Ray daemon.
+Start your LocalStack container using your preferred method. We will demonstrate how you can create a minimal [trace segment](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields)
+and manually send it to the X-Ray API. Notice that this trace ingestion typically happens in the background, for example by the X-Ray SDK and X-Ray daemon.
+
+ [PutTraceSegments](https://docs.aws.amazon.com/xray/latest/api/API_PutTraceSegments.html).
+
+### Sending trace segments
+
+You can generates a unique trace ID and constructs a JSON document with trace information. It then sends this trace segment to the AWS X-Ray API using the    [PutTraceSegments](https://docs.aws.amazon.com/xray/latest/api/API_PutTraceSegments.html) API. Run the following commands in your terminal:
 
 {{< command >}}
-START_TIME=$(date +%s)
-HEX_TIME=$(printf '%x\n' $START_TIME)
-GUID=$(dd if=/dev/random bs=12 count=1 2>/dev/null | od -An -tx1 | tr -d ' \t\n')
-TRACE_ID="1-$HEX_TIME-$GUID"
-END_TIME=$(($START_TIME+3))
-DOC=$(cat <<EOF
+$ START_TIME=$(date +%s)
+$ HEX_TIME=$(printf '%x\n' $START_TIME)
+$ GUID=$(dd if=/dev/random bs=12 count=1 2>/dev/null | od -An -tx1 | tr -d ' \t\n')
+$ TRACE_ID="1-$HEX_TIME-$GUID"
+$ END_TIME=$(($START_TIME+3))
+$ DOC=$(cat <<EOF
 {"trace_id": "$TRACE_ID", "id": "6226467e3f845502", "start_time": $START_TIME.37518, "end_time": $END_TIME.4042, "name": "test.elasticbeanstalk.com"}
 EOF
 )
-echo "Sending trace segment to X-Ray API: $DOC"
-awslocal xray put-trace-segments --trace-segment-documents "$DOC"
+$ echo "Sending trace segment to X-Ray API: $DOC"
+$ awslocal xray put-trace-segments --trace-segment-documents "$DOC"
 <disable-copy>
 Sending trace segment to X-Ray API: {"trace_id": "1-6501ee11-056ec85fafff21f648e2d3ae", "id": "6226467e3f845502", "start_time": 1694625297.37518, "end_time": 1694625300.4042, "name": "test.elasticbeanstalk.com"}
 {
@@ -64,11 +56,13 @@ Sending trace segment to X-Ray API: {"trace_id": "1-6501ee11-056ec85fafff21f648e
 </disable-copy>
 {{< /command >}}
 
-You can now retrieve the trace summaries from the last 10 minutes using:
+### Retrieve trace summaries
+
+You can now retrieve the trace summaries from the last 10 minutes using the [GetTraceSummaries](https://docs.aws.amazon.com/xray/latest/api/API_GetTraceSummaries.html) API. Run the following commands in your terminal:
 
 {{< command >}}
-EPOCH=$(date +%s)
-awslocal xray get-trace-summaries --start-time $(($EPOCH-600)) --end-time $(($EPOCH))
+$ EPOCH=$(date +%s)
+$ awslocal xray get-trace-summaries --start-time $(($EPOCH-600)) --end-time $(($EPOCH))
 <disable-copy>
 {
     "TraceSummaries": [
@@ -91,10 +85,12 @@ awslocal xray get-trace-summaries --start-time $(($EPOCH-600)) --end-time $(($EP
 </disable-copy>
 {{< /command >}}
 
-You can retrieve the full trace by providing the `TRACE_ID` (use the same terminal as for the first command): 
+### Retrieve full trace
+
+You can retrieve the full trace by providing the `TRACE_ID` using the [BatchGetTraces](https://docs.aws.amazon.com/xray/latest/api/API_BatchGetTraces.html) API. Run the following commands in your terminal (use the same terminal as for the first command):
 
 {{< command >}}
-awslocal xray batch-get-traces --trace-ids $TRACE_ID
+$ awslocal xray batch-get-traces --trace-ids $TRACE_ID
 <disable-copy>
 {
     "Traces": [


### PR DESCRIPTION
# Changes

* Update the X-Ray docs with the new template.
* Completely re-write the docs: Add a new generic X-Ray tutorial section instead of the Lambda-related snippet.
* Link to the new lambda-xray pro samples in https://github.com/localstack/localstack-pro-samples/pull/226

# Preview

https://localstack-docs-preview-pr-823.surge.sh/user-guide/aws/xray/

# TODO

- [x] Write short tutorial
- [x] Create new Pro sample. My messy example [in this PR](https://github.com/localstack/localstack-pro-samples/pull/225) based on the aws-lambda-developer-guide [blank-python](https://github.com/awsdocs/aws-lambda-developer-guide/tree/main/sample-apps/blank-python) sample needs quite some cleanup. Instead of using the X-Ray SDK, OpenTelemetry or PowerTools could be good instrumentation alternatives as mentioned in the AWS docs: https://docs.aws.amazon.com/lambda/latest/dg/python-tracing.html
- [x] Link to new Pro sample