### PR TITLE
Fix lambda invoke commands with inline payload for AWS CLI v2

### DIFF
--- a/content/en/user-guide/tools/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/tools/lambda-tools/debugging/index.md
@@ -184,9 +184,23 @@ $ awslocal lambda create-function --function-name my-cool-local-function \
 
 We can quickly verify that it works by invoking it with a simple payload:
 
+{{< tabpane text=true persistLang=false >}}
+{{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
-$ awslocal lambda invoke --function-name my-cool-local-function --payload '{"message": "Hello from LocalStack!"}' output.txt
+$ awslocal lambda invoke --function-name my-cool-local-function \
+    --payload '{"message": "Hello from LocalStack!"}' \
+    output.txt
 {{< /command >}}
+{{% /tab %}}
+{{% tab header="AWS CLI v2" lang="shell" %}}
+{{< command >}}
+$ awslocal lambda invoke --function-name my-cool-local-function \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"message": "Hello from LocalStack!"}' \
+    output.txt
+{{< /command >}}
+{{% /tab %}}
+{{< /tabpane >}}
 
 ## Debugging JVM lambdas
 
@@ -380,9 +394,23 @@ Now to debug your lambda function, click on the `Debug` icon with
 `Attach to Remote Node.js` configuration selected, and then invoke your
 lambda function:
 
+{{< tabpane text=true persistLang=false >}}
+{{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
-$ awslocal lambda invoke --function-name func1 test.lambda.log --payload '{"hello":"world"}'
+$ awslocal lambda invoke --function-name func1 \
+    --payload '{"hello":"world"}' \
+    output.txt
 {{< /command >}}
+{{% /tab %}}
+{{% tab header="AWS CLI v2" lang="shell" %}}
+{{< command >}}
+$ awslocal lambda invoke --function-name func1 \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"hello":"world"}' \
+    output.txt
+{{< /command >}}
+{{% /tab %}}
+{{< /tabpane >}}
 
 
 ## Resources

--- a/content/en/user-guide/tools/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/tools/lambda-tools/hot-reloading/index.md
@@ -136,9 +136,23 @@ You can also check out some of our [Deployment Configuration Examples](#deployme
 
 We can also quickly make sure that it works by invoking it with a simple payload:
 
+{{< tabpane text=true persistLang=false >}}
+{{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
-$ awslocal lambda invoke --function-name my-cool-local-function --payload '{"action": "square", "number": 3}' output.txt
-{{< / command >}}
+$ awslocal lambda invoke --function-name my-cool-local-function \
+    --payload '{"action": "square", "number": 3}' \
+    output.txt
+{{< /command >}}
+{{% /tab %}}
+{{% tab header="AWS CLI v2" lang="shell" %}}
+{{< command >}}
+$ awslocal lambda invoke --function-name my-cool-local-function \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"action": "square", "number": 3}' \
+    output.txt
+{{< /command >}}
+{{% /tab %}}
+{{< /tabpane >}}
 
 The invocation returns itself returns:
 
@@ -297,11 +311,25 @@ awslocal lambda create-function \
 
 You can quickly make sure that it works by invoking it with a simple payload:
 
+{{< tabpane text=true persistLang=false >}}
+{{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
 $ awslocal lambda invoke \
     --function-name hello-world \
-    --payload '{"action": "test"}' output.txt
-{{< / command >}}
+    --payload '{"action": "test"}' \
+    output.txt
+{{< /command >}}
+{{% /tab %}}
+{{% tab header="AWS CLI v2" lang="shell" %}}
+{{< command >}}
+$ awslocal lambda invoke \
+    --function-name hello-world \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"action": "test"}' \
+    output.txt
+{{< /command >}}
+{{% /tab %}}
+{{< /tabpane >}}
 
 The invocation returns itself returns:
 


### PR DESCRIPTION
Addresses:
* https://github.com/localstack/docs/issues/785
* https://github.com/localstack/localstack-pro-samples/issues/224

## Motivation

The default Lambda invoke command with an inline payload such as `--payload '{"message": "Hello from LocalStack!"}'` works only for AWS CLI v1. The AWS CLI v2 needs an extra argument `--cli-binary-format raw-in-base64-out`, which is not available in the AWS CLI v1.
The Lambda documentation uses a tabpane to provide commands for both CLI versions: https://docs.localstack.cloud/user-guide/aws/lambda/#invoke-the-function


## Changes

This PR makes all Lambda invoke commands using an inline payload compatible with AWS CLI v2 by using a tabpane.

## Discussion

This tabpane approach seems quite cumbersome and we should try to avoid using inline payloads where possible to minimize using them.
