### PR TITLE
Clarify installation page

### DIFF
--- a/content/en/getting-started/api-key.md
+++ b/content/en/getting-started/api-key.md
@@ -33,7 +33,7 @@ export LOCALSTACK_API_KEY=<YOUR_API_KEY>
 localstack start
 {{< /tab >}}
 {{< tab header="Windows" lang="powershell" >}}
-$env:LOCALSTACK_API_KEY="<YOUR_API_KEY>"; localstack start -d
+$env:LOCALSTACK_API_KEY="<YOUR_API_KEY>"; localstack start
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/getting-started/api-key.md
+++ b/content/en/getting-started/api-key.md
@@ -30,12 +30,14 @@ LocalStack expects your API key to be present in the environment variable `LOCAL
 {{< tabpane >}}
 {{< tab header="macOS/Linux" lang="shell" >}}
 export LOCALSTACK_API_KEY=<YOUR_API_KEY>
-localstack start -d
+localstack start
 {{< /tab >}}
 {{< tab header="Windows" lang="powershell" >}}
 $env:LOCALSTACK_API_KEY="<YOUR_API_KEY>"; localstack start -d
 {{< /tab >}}
 {{< /tabpane >}}
+
+You can optionally run your LocalStack container in background mode by adding the `-d` flag to the `localstack start` command.
 
 The `localstack` CLI will detect the API key and properly pass it to the LocalStack container.
 

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -26,7 +26,7 @@ $ brew install localstack/tap/localstack-cli
 <details>
 <summary>Alternative: Binary Download</summary>
 <p>
-Alternatively, you can just download the respective binary for your architecture directly:<br>
+Alternatively, you can download the respective binary for your architecture directly:<br>
 {{< cli-binary-download os="macos" >}}
 </p>
 <p>
@@ -61,7 +61,7 @@ If you have problems with permissions in MacOS X Sierra, install with `python3 -
 
 {{< tab header="Linux" >}}
 <p>
-You can just download the respective binary for your architecture directly:<br>
+You can download the respective binary for your architecture directly:<br>
 {{< cli-binary-download os="linux" >}}
 </p>
 <p>
@@ -101,7 +101,7 @@ Do not use `sudo` or the `root` user - LocalStack should be installed and starte
 
 
 {{< tab header="Windows" >}}
-You can just download the respective binary for your architecture directly: 
+You can download the respective binary for your architecture directly: 
 {{< cli-binary-download os="windows" >}}<br/>
 Then extract the archive and execute the binary using Powershell.
 
@@ -290,7 +290,7 @@ $ localstack config validate
 
 ### Docker
 
-You can also just directly start the LocalStack container using the Docker CLI instead of [Docker-Compose]({{< ref "#docker-compose" >}}).
+You can also directly start the LocalStack container using the Docker CLI instead of [Docker-Compose]({{< ref "#docker-compose" >}}).
 This method requires more manual steps and configuration, but it gives you more control over the container settings.
 
 #### Prerequisites

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -65,6 +65,23 @@ You can download the respective binary for your architecture directly:<br>
 {{< cli-binary-download os="linux" >}}
 </p>
 <p>
+or use this <code>curl</code> command:
+</p>
+<p>
+For <i>amd64</i>:
+{{< command >}}
+$ curl -Lo ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz \
+    https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz
+{{< / command >}}
+</p>
+<p>
+Or <i>arm64</i>:
+{{< command >}}
+$ curl -Lo ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz \
+    https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz
+{{< / command >}}
+</p>
+<p>
 Then extract the LocalStack CLI from the terminal:
 {{< command >}}
 $ sudo tar xvzf ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-*-onefile.tar.gz -C /usr/local/bin

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -30,9 +30,18 @@ Alternatively, you can download the respective binary for your architecture dire
 {{< cli-binary-download os="macos" >}}
 </p>
 <p>
+or use this <code>curl</code> command:
+</p>
+<p>
+{{< command >}}
+$ curl -Lo localstack-cli-{{< localstack-latest-version >}}-darwin-amd64-onefile.tar.gz \
+    https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-darwin-amd64-onefile.tar.gz
+{{< / command >}}
+</p>
+<p>
 Then extract the LocalStack CLI from the terminal:
 {{< command >}}
-$ sudo tar xvzf ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-darwin-*-onefile.tar.gz -C /usr/local/bin
+$ sudo tar xvzf localstack-cli-{{< localstack-latest-version >}}-darwin-*-onefile.tar.gz -C /usr/local/bin
 {{< / command >}}
 </p>
 </details>
@@ -68,23 +77,23 @@ You can download the respective binary for your architecture directly:<br>
 or use this <code>curl</code> command:
 </p>
 <p>
-For `x86-64`:
+For <code>x86-64</code>:
 {{< command >}}
-$ curl -Lo ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz \
+$ curl -Lo localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz \
     https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz
 {{< / command >}}
 </p>
 <p>
-Or `ARM64`:
+Or <code>ARM64</code>:
 {{< command >}}
-$ curl -Lo ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz \
+$ curl -Lo localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz \
     https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz
 {{< / command >}}
 </p>
 <p>
 Then extract the LocalStack CLI from the terminal:
 {{< command >}}
-$ sudo tar xvzf ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-*-onefile.tar.gz -C /usr/local/bin
+$ sudo tar xvzf localstack-cli-{{< localstack-latest-version >}}-linux-*-onefile.tar.gz -C /usr/local/bin
 {{< / command >}}
 </p>
 

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -14,6 +14,9 @@ cascade:
 The quickest way get started with LocalStack is by using the LocalStack CLI. It allows you to start LocalStack from your command line.
 Please make sure that you have a working [`docker` environment](https://docs.docker.com/get-docker/) on your machine before moving on.
 
+The CLI starts and manages the LocalStack docker container.
+For alternative methods of managing the LocalStack container, see our [alternative installation instructions]({{< ref "#alternatives" >}}).
+
 {{< tabpane text=true >}}
 {{< tab header="MacOS" >}}
 You can install the LocalStack CLI using Brew directly from our official LocalStack tap:

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -68,14 +68,14 @@ You can download the respective binary for your architecture directly:<br>
 or use this <code>curl</code> command:
 </p>
 <p>
-For <i>amd64</i>:
+For `x86-64`:
 {{< command >}}
 $ curl -Lo ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz \
     https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-linux-amd64-onefile.tar.gz
 {{< / command >}}
 </p>
 <p>
-Or <i>arm64</i>:
+Or `ARM64`:
 {{< command >}}
 $ curl -Lo ~/Downloads/localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz \
     https://github.com/localstack/localstack-cli/releases/download/v{{< localstack-latest-version >}}/localstack-cli-{{< localstack-latest-version >}}-linux-arm64-onefile.tar.gz


### PR DESCRIPTION
Add some clarity to the getting started page.

- Make getting started sections consistent community vs pro
- Include section on what the CLI does
- Remove the word "just"
- Add curl example commands
