### PR TITLE
Add info on cross-account/region VPC peering

### DIFF
--- a/content/en/references/cross-account-access.md
+++ b/content/en/references/cross-account-access.md
@@ -23,8 +23,8 @@ Resources that can be accessed across multiple accounts are always identified by
 The full list of resources and operations that allow cross-account access are listed below.
 
 {{< alert title="Note">}}
-IAM currently does not enforce cross-account access.
-Any ACLs, identity-based or resource-based policy attached to these operations or resources will be ignored.
+LocalStack does not enforce IAM for cross-account access by default.
+Use the `ENFORCE_IAM` [configuration]({{< ref "configuration#iam" >}}) option to enable it.
 {{< /alert >}}
 
 ### EC2 VPCs

--- a/content/en/references/cross-account-access.md
+++ b/content/en/references/cross-account-access.md
@@ -27,6 +27,32 @@ IAM currently does not enforce cross-account access.
 Any ACLs, identity-based or resource-based policy attached to these operations or resources will be ignored.
 {{< /alert >}}
 
+### EC2 VPCs
+
+It is possible to peer VPCs that are in a different region or account than the requester.
+Ensure that the `PeerRegion` and `PeerOwnerId` arguments are correctly set when creating VPC peering connections.
+
+### KMS keys
+
+- `CreateGrant`
+- `Decrypt`
+- `DescribeKey`
+- `Encrypt`
+- `GenerateDataKey`
+- `GenerateDataKeyPair`
+- `GenerateDataKeyPairWithoutPlaintext`
+- `GenerateDataKeyWithoutPlaintext`
+- `GenerateMac`
+- `GetKeyRotationStatus`
+- `GetPublicKey`
+- `ListGrants`
+- `RetireGrant`
+- `RevokeGrant`
+- `Sign`
+- `Verify`
+- `VerifyMac`
+<!--    - ReEncrypt (NOT IMPLEMENTED IN LOCALSTACK) -->
+
 ### Lambda functions and layers
 
 - `AddLayerVersionPermission`
@@ -55,32 +81,15 @@ Any ACLs, identity-based or resource-based policy attached to these operations o
 - `UpdateAlias`
 - `UpdateFunctionCode`
 
-### SQS queues
+### S3 buckets
 
-On AWS, all operations except `AddPermission`, `CreateQueue`, `DeleteQueue`, `ListQueues`, `ListQueueTags`, `RemovePermission`, `SetQueueAttributes`, `TagQueue` and `UntagQueue` allow cross-account access.
+Like AWS, LocalStack S3 has a bucket namespace which is shared by all accounts.
+This means that the bucket name has to be globally unique.
 
-On LocalStack, all operations allow cross-account access.
+- `GetObject`
+- `ListObjects`
+- `PutObject`
 
-### KMS keys
-
-- `CreateGrant`
-- `Decrypt`
-- `DescribeKey`
-- `Encrypt`
-- `GenerateDataKey`
-- `GenerateDataKeyPair`
-- `GenerateDataKeyPairWithoutPlaintext`
-- `GenerateDataKeyWithoutPlaintext`
-- `GenerateMac`
-- `GetKeyRotationStatus`
-- `GetPublicKey`
-- `ListGrants`
-- `RetireGrant`
-- `RevokeGrant`
-- `Sign`
-- `Verify`
-- `VerifyMac`
-<!--    - ReEncrypt (NOT IMPLEMENTED IN LOCALSTACK) -->
 
 ### SNS topics
 
@@ -93,14 +102,11 @@ On LocalStack, all operations allow cross-account access.
 - `SetTopicAttributes`
 - `Subscribe`
 
-### S3 buckets
+### SQS queues
 
-Like AWS, LocalStack S3 has a bucket namespace which is shared by all accounts.
-This means that the bucket name has to be globally unique.
+On AWS, all operations except `AddPermission`, `CreateQueue`, `DeleteQueue`, `ListQueues`, `ListQueueTags`, `RemovePermission`, `SetQueueAttributes`, `TagQueue` and `UntagQueue` allow cross-account access.
 
-- `GetObject`
-- `ListObjects`
-- `PutObject`
+On LocalStack, all operations allow cross-account access.
 
 ## Cross-Region
 

--- a/content/en/references/cross-account-access.md
+++ b/content/en/references/cross-account-access.md
@@ -27,10 +27,10 @@ LocalStack does not enforce IAM for cross-account access by default.
 Use the `ENFORCE_IAM` [configuration]({{< ref "configuration#iam" >}}) option to enable it.
 {{< /alert >}}
 
-### EC2 VPCs
+### EC2 Peering
 
-It is possible to peer VPCs that are in a different region or account than the requester.
-Ensure that the `PeerRegion` and `PeerOwnerId` arguments are correctly set when creating VPC peering connections.
+It is possible to create peered VPCs and transit gateway peering attachments that are in a different region or account than the requester.
+Ensure that the `PeerRegion` and `PeerOwnerId` arguments are correctly set when creating these resources.
 
 ### KMS keys
 


### PR DESCRIPTION
Adds info on cross-account/region VPC peering.

Also sorts section alphabetically.

Related to https://github.com/localstack/localstack/issues/8550