### PR TITLE
update S3 endpoint docs

### DIFF
--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -111,16 +111,31 @@ You will see a generated pre-signed URL for your S3 object. You can use [`cURL`]
 
 ## Path-Style and Virtual Hosted-Style Requests
 
-Similar to AWS, LocalStack categorizes requests as either [Path-Style or Virtual Hosted-Style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) based on the Host header of the request. The following example illustrates this distinction:
+Similar to AWS, LocalStack categorizes requests as either [Path style or Virtual-Hosted style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) based on the Host header of the request.
+The following example illustrates this distinction:
 
 ```bash
 http://<bucket-name>.s3.<region>.localhost.localstack.cloud:4566/<key-name> # host-style request
+http://<bucket-name>.s3.localhost.localstack.cloud:4566/<key-name> # host-style request, region is not mandatory in LocalStack
 http://s3.<region>.localhost.localstack.cloud:4566/<bucket-name>/<key-name> # path-style request
+http://localhost:4566/<bucket-name>/<key-name> # path-style request
 ```
 
-As a special case in LocalStack, leaving out `<region>` also works for the `s3.localhost.localstack.cloud` domain. `<bucket-name>.s3.localhost.localstack.cloud` is also a host-style request.
+A `Virtual-Hosted style` request will have the `bucket` as part of the `Host` header of your request.
+In order for LocalStack to be able to parse the bucket name from your request, your endpoint needs to be prefixed with `s3.`, like `s3.localhost.localstack.cloud`.
 
-All other requests are treated as path-style requests. Using the `s3.localhost.localstack.cloud` endpoint URL is recommended for all requests aimed at S3.
+
+If your endpoint cannot be prefixed with `s3.`, you should configure your SDK to use `Path style` request instead, and make the bucket part of the path. 
+
+
+By default, most SDKs will try to use `Virtual-Hosted style` requests and prepend your endpoint with the bucket name.
+However, if the endpoint is not prefixed by `s3.`, LocalStack will not be able to understand the request and it will most likely result in an error.
+You can either change the endpoint to an S3-specific one, or configure your SDK to use `Path style` requests instead.
+[See our SDKs page to configure them to access LocalStack and S3](https://docs.localstack.cloud/user-guide/integrations/sdks/).
+
+
+If your endpoint is not prefixed with `s3.`, all requests are treated as `Path style` requests.
+Using the `s3.localhost.localstack.cloud` endpoint URL is recommended for all requests aimed at S3.
 
 ## Configuring Cross-Origin Resource Sharing on S3
 

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -121,20 +121,20 @@ http://s3.<region>.localhost.localstack.cloud:4566/<bucket-name>/<key-name> # pa
 http://localhost:4566/<bucket-name>/<key-name> # path-style request
 ```
 
-A `Virtual-Hosted style` request will have the `bucket` as part of the `Host` header of your request.
+A **Virtual-Hosted style** request will have the `bucket` as part of the `Host` header of your request.
 In order for LocalStack to be able to parse the bucket name from your request, your endpoint needs to be prefixed with `s3.`, like `s3.localhost.localstack.cloud`.
 
 
-If your endpoint cannot be prefixed with `s3.`, you should configure your SDK to use `Path style` request instead, and make the bucket part of the path. 
+If your endpoint cannot be prefixed with `s3.`, you should configure your SDK to use **Path style** request instead, and make the bucket part of the path. 
 
 
-By default, most SDKs will try to use `Virtual-Hosted style` requests and prepend your endpoint with the bucket name.
+By default, most SDKs will try to use **Virtual-Hosted style** requests and prepend your endpoint with the bucket name.
 However, if the endpoint is not prefixed by `s3.`, LocalStack will not be able to understand the request and it will most likely result in an error.
-You can either change the endpoint to an S3-specific one, or configure your SDK to use `Path style` requests instead.
+You can either change the endpoint to an S3-specific one, or configure your SDK to use **Path style** requests instead.
 [See our SDKs page to configure them to access LocalStack and S3](https://docs.localstack.cloud/user-guide/integrations/sdks/).
 
 
-If your endpoint is not prefixed with `s3.`, all requests are treated as `Path style` requests.
+If your endpoint is not prefixed with `s3.`, all requests are treated as **Path style** requests.
 Using the `s3.localhost.localstack.cloud` endpoint URL is recommended for all requests aimed at S3.
 
 ## Configuring Cross-Origin Resource Sharing on S3

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -124,15 +124,13 @@ http://localhost:4566/<bucket-name>/<key-name> # path-style request
 A **Virtual-Hosted style** request will have the `bucket` as part of the `Host` header of your request.
 In order for LocalStack to be able to parse the bucket name from your request, your endpoint needs to be prefixed with `s3.`, like `s3.localhost.localstack.cloud`.
 
-
 If your endpoint cannot be prefixed with `s3.`, you should configure your SDK to use **Path style** request instead, and make the bucket part of the path. 
-
 
 By default, most SDKs will try to use **Virtual-Hosted style** requests and prepend your endpoint with the bucket name.
 However, if the endpoint is not prefixed by `s3.`, LocalStack will not be able to understand the request and it will most likely result in an error.
-You can either change the endpoint to an S3-specific one, or configure your SDK to use **Path style** requests instead.
-[See our SDKs page to configure them to access LocalStack and S3](https://docs.localstack.cloud/user-guide/integrations/sdks/).
 
+You can either change the endpoint to an S3-specific one, or configure your SDK to use **Path style** requests instead.
+Check out our [SDK documentation](https://docs.localstack.cloud/user-guide/integrations/sdks/) to learn how you can configure language SDKs to access LocalStack and S3.
 
 If your endpoint is not prefixed with `s3.`, all requests are treated as **Path style** requests.
 Using the `s3.localhost.localstack.cloud` endpoint URL is recommended for all requests aimed at S3.


### PR DESCRIPTION
S3 endpoints are a source of confusion for our users ( we must have had at least 4 GH issues in the past regarding this issue, + community slack), as most SDKs will now use virtual hosted requests to access LocalStack. However, trying to access a bucket with `bucket.localhost.localstack.cloud` or `bucket.localhost` won't work in most cases. Added a bit more explanation in the documentation about the configuration, and put a link to the SDKs where most of them have the S3 specific case and endpoint explained. 

preview page: https://localstack-docs-preview-pr-834.surge.sh/user-guide/aws/s3/#path-style-and-virtual-hosted-style-requests