### PR TITLE
Split EKS commands and outputs for better copy and paste

### DIFF
--- a/content/en/user-guide/aws/elastic-kubernetes-service/index.md
+++ b/content/en/user-guide/aws/elastic-kubernetes-service/index.md
@@ -57,27 +57,20 @@ You can use the `docker` CLI to check that some containers have been created:
 
 {{< command >}}
 $ docker ps
-{{< / command >}}
-
-You can see an output similar to the following:
-
-```
+<disable-copy>
 CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS          PORTS                                           NAMES
 ...
 b335f7f089e4   rancher/k3d-proxy:5.0.1-rc.1   "/bin/sh -c nginx-pr…"   1 minute ago   Up 1 minute   0.0.0.0:8081->80/tcp, 0.0.0.0:44959->6443/tcp   k3d-cluster1-serverlb
 f05770ec8523   rancher/k3s:v1.21.5-k3s2       "/bin/k3s server --t…"   1 minute ago   Up 1 minute
 ...
-```
+</disable-copy>
+{{< / command >}}
 
 After successfully creating and initializing the cluster, we can easily find the server endpoint, using the [`DescribeCluster`](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html) API. Run the following command:
 
 {{< command >}}
 $ awslocal eks describe-cluster --name cluster1
-{{< / command >}}
-
-You should get a response similar to the following:
-
-```json
+<disable-copy>
 {
     "cluster": {
         "name": "cluster1",
@@ -98,7 +91,8 @@ You should get a response similar to the following:
         "clientRequestToken": "d188f578-b353-416b-b309-5d8c76ecc4e2"
     }
 }
-```
+</disable-copy>
+{{< / command >}}
 
 ### Utilizing ECR Images within EKS
 
@@ -126,11 +120,7 @@ You can create a new ECR repository using the [`CreateRepository`](https://docs.
 
 {{< command >}}
 $ awslocal ecr create-repository --repository-name "fancier-nginx"
-{{< / command >}}
-
-You should get a response similar to the following:
-
-```json
+<disable-copy>
 {
     "repository": {
         "repositoryArn": "arn:aws:ecr:us-east-1:000000000000:repository/fancier-nginx",
@@ -147,7 +137,8 @@ You should get a response similar to the following:
         }
     }
 }
-```
+</disable-copy>
+{{< / command >}}
 
 {{< alert title="Note">}}
 When creating an ECR repository, a port from the [external service port range]({{< ref "external-ports" >}}) is dynamically assigned. As a result, the port can differ from the static value `4510` used in the examples below.
@@ -180,17 +171,13 @@ Next, we can configure `kubectl` to use the EKS cluster, using the [`UpdateKubec
 {{< command >}}
 $ awslocal eks update-kubeconfig --name cluster1 && \
     kubectl config use-context arn:aws:eks:us-east-1:000000000000:cluster/cluster1
-{{< / command >}}
-
-
-You can see an output similar to the following:
-
-```
+<disable-copy>
 ...
 Added new context arn:aws:eks:us-east-1:000000000000:cluster/cluster1 to /home/localstack/.kube/config
 Switched to context "arn:aws:eks:us-east-1:000000000000:cluster/cluster1".
 ...
-```
+</disable-copy>
+{{< / command >}}
 
 You can now go ahead and add a deployment configuration for the `fancier-nginx` image. 
 
@@ -283,16 +270,13 @@ You will be able to send a request to `nginx` via the load balancer port `8081` 
 
 {{< command >}}
 $ curl http://localhost:8081/test123
-{{< / command >}}
-
-You should get a successful response with content similar to:
-
-```html
+<disable-copy>
 <html>
 ...
 <hr><center>nginx/1.21.6</center>
 ...
-```
+</disable-copy>
+{{< / command >}}
 
 {{< alert title="Note" >}}
 You can customize the Load Balancer port by configuring `EKS_LOADBALANCER_PORT` in your environment.
@@ -346,11 +330,7 @@ You can create an EKS Cluster configuration using the following command:
 
 {{< command >}}
 $ awslocal eks create-cluster --name cluster1 --role-arn arn:aws:iam::000000000000:role/eks-role --resources-vpc-config '{}'
-{{< / command >}}
-
-You should get a response similar to the following:
-
-```json
+<disable-copy>
 {
     "cluster": {
         "name": "cluster1",
@@ -361,21 +341,21 @@ You should get a response similar to the following:
         ...
     }
 }
-```
+</disable-copy>
+{{</ command >}}
+
+And check that it was created with:
 
 {{< command >}}
 $ awslocal eks list-clusters
-{{< / command >}}
-
-You should get a response similar to the following:
-
-```json
+<disable-copy>
 {
     "clusters": [
         "cluster1"
     ]
 }
-```
+</disable-copy>
+{{< / command >}}
 
 To interact with your Kubernetes cluster, configure your Kubernetes client (such as `kubectl` or other SDKs) to point to the `endpoint` provided in the `create-cluster` output mentioned earlier. However, depending on whether you're calling the Kubernetes API from your local machine or from within a Lambda function, you might need to use different endpoint URLs.
 
@@ -445,20 +425,14 @@ This approach enables us to access the two distinct services using the same path
 
 {{< command >}}
 $ curl http://eks-service-1.localhost.localstack.cloud:8081/v1
-{{< /command >}}
-
-```
+<disable-copy>
 ... [output of service 1]
-```
-
-{{< command >}}
+</disable-copy>
 $ curl http://eks-service-2.localhost.localstack.cloud:8081/v1
-{{< /command >}}
-
-```
+<disable-copy>
 ... [output of service 2]
-```
-
+</disable-copy>
+{{< /command >}}
 
 It is important to note that the host names `eks-service-1.localhost.localstack.cloud` and `eks-service-2.localhost.localstack.cloud` both resolve to `127.0.0.1` (localhost). Consequently, you can utilize them to communicate with your service endpoints and distinguish between different services within the Kubernetes load balancer.
 
@@ -480,11 +454,7 @@ $ awslocal eks create-cluster \
   --role-arn arn:aws:iam::000000000000:role/eks-role \
   --resources-vpc-config '{}' \
   --tags '{"_volume_mount_":"/path/on/host:/path/on/node"}'
-{{< / command >}}
-
-You should get a response similar to the following:
-
-```json
+<disable-copy>
 {
     "cluster": {
         "name": "cluster1",
@@ -498,7 +468,8 @@ You should get a response similar to the following:
         ...
     }
 }
-```
+</disable-copy>
+{{< / command >}}
 
 {{< alert title="Notes" >}}
 Note that the tag was previously referred to as `__k3d_volume_mount__`, but it has now been renamed to `_volume_mount_`. As a result, the tag name `__k3d_volume_mount__` is considered deprecated and will be removed in an upcoming release.

--- a/content/en/user-guide/aws/elastic-kubernetes-service/index.md
+++ b/content/en/user-guide/aws/elastic-kubernetes-service/index.md
@@ -57,17 +57,27 @@ You can use the `docker` CLI to check that some containers have been created:
 
 {{< command >}}
 $ docker ps
+{{< / command >}}
+
+You can see an output similar to the following:
+
+```
 CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS          PORTS                                           NAMES
 ...
 b335f7f089e4   rancher/k3d-proxy:5.0.1-rc.1   "/bin/sh -c nginx-pr…"   1 minute ago   Up 1 minute   0.0.0.0:8081->80/tcp, 0.0.0.0:44959->6443/tcp   k3d-cluster1-serverlb
 f05770ec8523   rancher/k3s:v1.21.5-k3s2       "/bin/k3s server --t…"   1 minute ago   Up 1 minute
 ...
-{{</ command >}}
+```
 
 After successfully creating and initializing the cluster, we can easily find the server endpoint, using the [`DescribeCluster`](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html) API. Run the following command:
 
 {{< command >}}
 $ awslocal eks describe-cluster --name cluster1
+{{< / command >}}
+
+You should get a response similar to the following:
+
+```json
 {
     "cluster": {
         "name": "cluster1",
@@ -88,7 +98,7 @@ $ awslocal eks describe-cluster --name cluster1
         "clientRequestToken": "d188f578-b353-416b-b309-5d8c76ecc4e2"
     }
 }
-{{</ command >}}
+```
 
 ### Utilizing ECR Images within EKS
 
@@ -116,6 +126,11 @@ You can create a new ECR repository using the [`CreateRepository`](https://docs.
 
 {{< command >}}
 $ awslocal ecr create-repository --repository-name "fancier-nginx"
+{{< / command >}}
+
+You should get a response similar to the following:
+
+```json
 {
     "repository": {
         "repositoryArn": "arn:aws:ecr:us-east-1:000000000000:repository/fancier-nginx",
@@ -132,7 +147,7 @@ $ awslocal ecr create-repository --repository-name "fancier-nginx"
         }
     }
 }
-{{< / command >}}
+```
 
 {{< alert title="Note">}}
 When creating an ECR repository, a port from the [external service port range]({{< ref "external-ports" >}}) is dynamically assigned. As a result, the port can differ from the static value `4510` used in the examples below.
@@ -163,13 +178,19 @@ Now, let us set up the EKS cluster using the image pushed to local ECR.
 Next, we can configure `kubectl` to use the EKS cluster, using the [`UpdateKubeconfig`](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateClusterConfig.html) API. Run the following command:
 
 {{< command >}}
-$ awslocal eks update-kubeconfig --name cluster1
-& kubectl config use-context arn:aws:eks:us-east-1:000000000000:cluster/cluster1
+$ awslocal eks update-kubeconfig --name cluster1 && \
+    kubectl config use-context arn:aws:eks:us-east-1:000000000000:cluster/cluster1
+{{< / command >}}
+
+
+You can see an output similar to the following:
+
+```
 ...
 Added new context arn:aws:eks:us-east-1:000000000000:cluster/cluster1 to /home/localstack/.kube/config
 Switched to context "arn:aws:eks:us-east-1:000000000000:cluster/cluster1".
 ...
-{{< / command >}}
+```
 
 You can now go ahead and add a deployment configuration for the `fancier-nginx` image. 
 
@@ -262,11 +283,16 @@ You will be able to send a request to `nginx` via the load balancer port `8081` 
 
 {{< command >}}
 $ curl http://localhost:8081/test123
+{{< / command >}}
+
+You should get a successful response with content similar to:
+
+```html
 <html>
 ...
 <hr><center>nginx/1.21.6</center>
 ...
-{{< / command >}}
+```
 
 {{< alert title="Note" >}}
 You can customize the Load Balancer port by configuring `EKS_LOADBALANCER_PORT` in your environment.
@@ -320,6 +346,11 @@ You can create an EKS Cluster configuration using the following command:
 
 {{< command >}}
 $ awslocal eks create-cluster --name cluster1 --role-arn arn:aws:iam::000000000000:role/eks-role --resources-vpc-config '{}'
+{{< / command >}}
+
+You should get a response similar to the following:
+
+```json
 {
     "cluster": {
         "name": "cluster1",
@@ -330,13 +361,21 @@ $ awslocal eks create-cluster --name cluster1 --role-arn arn:aws:iam::0000000000
         ...
     }
 }
+```
+
+{{< command >}}
 $ awslocal eks list-clusters
+{{< / command >}}
+
+You should get a response similar to the following:
+
+```json
 {
     "clusters": [
         "cluster1"
     ]
 }
-{{< / command >}}
+```
 
 To interact with your Kubernetes cluster, configure your Kubernetes client (such as `kubectl` or other SDKs) to point to the `endpoint` provided in the `create-cluster` output mentioned earlier. However, depending on whether you're calling the Kubernetes API from your local machine or from within a Lambda function, you might need to use different endpoint URLs.
 
@@ -406,10 +445,20 @@ This approach enables us to access the two distinct services using the same path
 
 {{< command >}}
 $ curl http://eks-service-1.localhost.localstack.cloud:8081/v1
-... [output of service 1]
-$ curl http://eks-service-2.localhost.localstack.cloud:8081/v1
-... [output of service 2]
 {{< /command >}}
+
+```
+... [output of service 1]
+```
+
+{{< command >}}
+$ curl http://eks-service-2.localhost.localstack.cloud:8081/v1
+{{< /command >}}
+
+```
+... [output of service 2]
+```
+
 
 It is important to note that the host names `eks-service-1.localhost.localstack.cloud` and `eks-service-2.localhost.localstack.cloud` both resolve to `127.0.0.1` (localhost). Consequently, you can utilize them to communicate with your service endpoints and distinguish between different services within the Kubernetes load balancer.
 
@@ -431,6 +480,11 @@ $ awslocal eks create-cluster \
   --role-arn arn:aws:iam::000000000000:role/eks-role \
   --resources-vpc-config '{}' \
   --tags '{"_volume_mount_":"/path/on/host:/path/on/node"}'
+{{< / command >}}
+
+You should get a response similar to the following:
+
+```json
 {
     "cluster": {
         "name": "cluster1",
@@ -444,7 +498,7 @@ $ awslocal eks create-cluster \
         ...
     }
 }
-{{< / command >}}
+```
 
 {{< alert title="Notes" >}}
 Note that the tag was previously referred to as `__k3d_volume_mount__`, but it has now been renamed to `_volume_mount_`. As a result, the tag name `__k3d_volume_mount__` is considered deprecated and will be removed in an upcoming release.

--- a/static/js/global-script.js
+++ b/static/js/global-script.js
@@ -9,7 +9,7 @@ function setupCodeBlockCopyButton() {
     const elem = $(this).closest('.code-container').find('code').clone();
     elem.find('.command-prefix').remove(); // removing prefix
     elem.find('.disable-copy').remove(); // removing text which shouldn't be copied
-    navigator.clipboard.writeText(elem.text());
+    navigator.clipboard.writeText(elem.text().trim());
     $(this).find('span').text('Copied!');
     setTimeout(() => {
       $(this).find('span').text('Copy');


### PR DESCRIPTION
# Motivation

When starting an EKS cluster, I was copying the commands from the docs but the output was copied along with the commands.

# Changes

* Split the command and output into separate code blocks
