### PR TITLE
update metadata for generation of coverage docs

### DIFF
--- a/data/coverage/service_display_name.json
+++ b/data/coverage/service_display_name.json
@@ -169,6 +169,11 @@
       "short_name": "EMR",
       "api": "https://docs.aws.amazon.com/emr/latest/APIReference/Welcome.html"
     },
+    "emr-serverless": {
+      "long_name": "EMR Serverless",
+      "short_name": "EMR",
+      "api": "https://docs.aws.amazon.com/emr-serverless/latest/APIReference/Welcome.html"
+    },
     "es": {
       "long_name": "OpenSearch, legacy Elasticsearch",
       "short_name": "ES",
@@ -309,6 +314,12 @@
       "short_name": "QLDB Session",
       "api": "https://docs.aws.amazon.com/qldb/latest/developerguide/API_Types_Amazon_QLDB_Session.html"
     },
+    "ram": {
+      "long_name": "Resource Access Manager",
+      "short_name": "ram",
+      "api": "https://docs.aws.amazon.com/ram/latest/APIReference/Welcome.html"
+   
+    },
     "rds": {
       "long_name": "Relational Database Service",
       "short_name": "RDS",
@@ -400,6 +411,12 @@
       "short_name": "SNS",
       "api": "https://docs.aws.amazon.com/sns/latest/api/welcome.html"
     },
+    "scheduler": {
+      "long_name": "EventBridge Scheduler",
+      "short_name": "scheduler",
+      "api": "https://docs.aws.amazon.com/scheduler/latest/APIReference/Welcome.html"
+   
+    },
     "sqs": {
       "long_name": "Simple Queue Service",
       "short_name": "SQS",
@@ -409,6 +426,11 @@
       "long_name": "Web Services Systems Manager",
       "short_name": "SSM",
       "api": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/Welcome.html"
+    },
+    "sso-admin":{
+      "long_name": "IAM Identity Center (successor to Single Sign-On)",
+      "short_name": "sso-admin",
+      "api": "https://docs.aws.amazon.com/singlesignon/latest/APIReference/welcome.html"
     },
     "stepfunctions": {
       "long_name": "Step Functions",


### PR DESCRIPTION
Updates the content of `service_display_name.json` which is used for the coverage docs pages.

With the updated content the search will also include the long-service names, and we provide the link to the API reference along in the details page of the coverage service.

This will only be visible for the next docs-update, which runs with the scheduled workflow on Sundays.