### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,118 @@
+######################
+###  CODE OWNERS   ###
+######################
+
+# CODEOWNERS
+/CODEOWNERS @HarshCasper @alexrashed
+
+######################
+### SERVICE OWNERS ###
+######################
+
+# acm
+/content/en/user-guide/aws/acm/ @alexrashed
+
+# amplify
+/content/en/user-guide/aws/amplify/ @pinzon
+
+# apigateway
+/content/en/user-guide/aws/apigateway/ @calvernaz @bentsku
+
+# appconfig
+/content/en/user-guide/aws/appconfig/ @pandomic
+
+# appsync
+/content/en/user-guide/aws/appsync/ @simonrw @joe4dev
+
+# athena
+/content/en/user-guide/aws/athena/ @alexrashed
+
+# cloudformation
+/content/en/user-guide/aws/cloudformation/ @dominikschubert @pinzon @simonrw
+
+# cloudfront
+/content/en/user-guide/aws/cloudfront/ @giograno
+
+# cloudtrail
+/content/en/user-guide/aws/cloudtrail/ @steffyP
+
+# cloudwatch
+/content/en/user-guide/aws/cloudwatch/ @steffyP @silv-io
+
+# codecommit
+/content/en/user-guide/aws/codecommit/ @silv-io
+
+# dynamodb
+/content/en/user-guide/aws/dynamodb/ @viren-nadkarni @giograno
+
+# elasticache
+/content/en/user-guide/aws/elasticache/ @thrau @giograno
+
+# glue
+/content/en/user-guide/aws/glue/ @alexrashed
+
+# iam
+/content/en/user-guide/aws/iam/ @dfangl
+
+# iot
+/content/en/user-guide/aws/iot/ @viren-nadkarni
+
+# kms
+/content/en/user-guide/aws/kms/ @sannya-singal @silv-io
+
+# lambda
+/content/en/user-guide/aws/lambda/ @joe4dev @dominikschubert @dfangl
+
+# logs
+/content/en/user-guide/aws/logs/ @steffyP @silv-io
+
+# mq
+/content/en/user-guide/aws/mq/ @ackdav @giograno
+
+# mwaa
+/content/en/user-guide/aws/mwaa/ @viren-nadkarni
+
+# opensearch
+/content/en/user-guide/aws/opensearch/ @alexrashed @silv-io
+
+# qldb
+/content/en/user-guide/aws/qldb/ @simonrw
+
+# rds
+/content/en/user-guide/aws/rds/ @steffyP
+
+# route53
+/content/en/user-guide/aws/route53/ @giograno
+
+# s3
+/content/en/user-guide/aws/s3/ @bentsku @macnev2013
+
+# sagemaker
+/content/en/user-guide/aws/sagemaker/ @silv-io @lukqw
+
+# secretsmanager
+/content/en/user-guide/aws/secretsmanager/ @dominikschubert @MEPalma
+
+# servicediscovery
+/content/en/user-guide/aws/servicediscovery/ @dominikschubert
+
+# ses
+/content/en/user-guide/aws/ses/ @viren-nadkarni
+
+# sns
+/content/en/user-guide/aws/sns/ @bentsku @thrau
+
+# sqs
+/content/en/user-guide/aws/sqs/ @thrau @baermat
+
+# stepfunctions
+/content/en/user-guide/aws/stepfunctions/ @dominikschubert @MEPalma
+
+# timestream
+/content/en/user-guide/aws/timestream/ @ackdav
+
+# transcribe
+/content/en/user-guide/aws/transcribe/ @sannya-singal @ackdav
+
+# xray
+/content/en/user-guide/aws/xray/ @joe4dev


### PR DESCRIPTION
## Motivation
This PR adds an initial CODEOWNERS file.
This file defines a mapping from files to GitHub handles.
GitHub will then automatically assign these users as reviewers to PRs which touch these files.
The initial version only sets @HarshCasper and me as code owner for the CODEOWNERS file itself, and add our service owners as owners for the different service's docs pages.