### PR TITLE
Fix mismatching Docker image tag

### DIFF
--- a/content/en/user-guide/aws/elastic-container-registry/index.md
+++ b/content/en/user-guide/aws/elastic-container-registry/index.md
@@ -110,7 +110,7 @@ To push the Docker image to the repository, you first need to tag the image with
 Run the following command to tag the image:
 
 {{< command >}}
-$ docker tag localstack-ecr-image localhost:4510/localstack-ecr-repository
+$ docker tag localstack-ecr-image localhost.localstack.cloud:4510/localstack-ecr-repository
 {{< / command >}}
 
 You can now push the image to the repository using the `docker` CLI:


### PR DESCRIPTION
Fixes https://github.com/localstack/docs/issues/844 and https://github.com/localstack/docs/issues/858

Change `localhost` to `localhost.localstack.cloud` matching the remainder of the docs.

Tested updated version locally ✅ 
