### PR TITLE
avoid deprecated health endpoint

### DIFF
--- a/content/en/user-guide/ci/harness-ci/index.md
+++ b/content/en/user-guide/ci/harness-ci/index.md
@@ -52,7 +52,7 @@ stages:
                     connectorRef: docker_hub
                     image: curlimages/curl:7.83.1
                     shell: Sh
-                    command: until curl --fail --silent --max-time 1 http://localstack:4566/health; do sleep 2; done
+                    command: until curl --fail --silent --max-time 1 http://localstack:4566/_localstack/health; do sleep 2; done
 ```
 
 To run the pipeline, click **Save** and then **Run Pipeline**. You will be able to see LocalStack Service Dependency logs that verify that the LocalStack Container is healthy and running.


### PR DESCRIPTION
The `/health` endpoint has been deprecated for quite a while and will be removed with `3.0`.
This PR migrates to the new endpoint (`/localstack/health`).