### PR TITLE
IoT: Fix incorrect port in example

### DIFF
--- a/content/en/user-guide/aws/iot/index.md
+++ b/content/en/user-guide/aws/iot/index.md
@@ -55,7 +55,7 @@ In another terminal, publish a message to this topic.
 {{< command >}}
 $ mqtt publish \
         --host localhost.localstack.cloud \
-        --port 4511 \
+        --port 4510 \
         --topic climate \
         -m "temperature=30°C;humidity=60%"
 {{< /command >}}


### PR DESCRIPTION
This PR makes all examples use the port returned by IoT:DescribeEndpoint