### PR TITLE
Major: rename default container name to localstack-main

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -38,7 +38,7 @@
         },
         {
             "pattern": "https://localhost:4566/(.*)"
-        }
+        },
         {
             "pattern": "https://localhost:45139/"
         }

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -34,6 +34,9 @@
             "pattern": "http://localstack_main:4566"
         },
         {
+            "pattern": "http://localstack-main:4566"
+        },
+        {
             "pattern": "(.*)localhost.localstack.cloud(.*)"
         },
         {

--- a/content/en/getting-started/faq.md
+++ b/content/en/getting-started/faq.md
@@ -83,10 +83,10 @@ ports:
        …
 ```
 
-Furthermore, use either the default name `localstack_main` for the container, or alternatively configure the environment variable `MAIN_CONTAINER_NAME` to point to the correct name.
+Furthermore, use either the default name `localstack-main` for the container, or alternatively configure the environment variable `MAIN_CONTAINER_NAME` to point to the correct name.
 
 ```yaml
-container_name: localstack_main
+container_name: localstack-main
 ```
 
 Ensure that `127.0.0.1` is configured as the target DNS server for the `bigdata` container:

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -244,7 +244,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
@@ -261,7 +261,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro  # required for Pro
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -29,7 +29,7 @@ Options that affect the core LocalStack system.
 | `LOCALSTACK_HOST`| `localhost.localstack.cloud:4566` (default) | This is interpolated into URLs and addresses that are returned by LocalStack. It has the form `<hostname>:<port>`. |
 | `LEGACY_DIRECTORIES` | `0` (default) | Use legacy method of managing internal filesystem layout. See [Filesystem Layout]({{< ref "filesystem" >}}). |
 | `PERSISTENCE` | `0` (default) | Enable persistence. See [Persistence Mechanism]({{< ref "persistence-mechanism" >}}) and [Filesystem Layout]({{< ref "filesystem" >}}). |
-| `MAIN_CONTAINER_NAME` | `localstack_main` (default) | Specify the main docker container name |
+| `MAIN_CONTAINER_NAME` | `localstack-main` (default) | Specify the main docker container name |
 | `LS_LOG` | `trace`, `trace-internal`, `debug`, `info`, `warn`, `error`, `warning`| Specify the log level. Currently overrides the `DEBUG` configuration. `trace` for detailed request/response, `trace-internal` for internal calls, too. |
 | `EXTERNAL_SERVICE_PORTS_START` | `4510` (default) | Start of the [External Service Port Range]({{< ref "external-ports" >}}) (inclusive). |
 | `EXTERNAL_SERVICE_PORTS_END` | `4560` (default) | End of the [External Service Port Range]({{< ref "external-ports" >}}) (exclusive). |

--- a/content/en/references/docker-images.md
+++ b/content/en/references/docker-images.md
@@ -36,7 +36,7 @@ To use the LocalStack Pro image, you must configure an environment variable name
 You can use the Pro image to start your LocalStack container using various [installation methods](https://docs.localstack.cloud/getting-started/installation/). While configuring to run LocalStack with Docker or Docker Compose, run the `localstack/localstack-pro` image with the appropriate tag you have pulled (if not `latest`).
 
 {{< alert title="Notes" >}}
-Earlier, we maintained `localstack/localstack-light` and `localstack/localstack-full` images. They have been deprecated and are removed with the LocalStack 2.0 release. The [BigData image](https://hub.docker.com/r/localstack/bigdata/tags), which started as a `bigdata_container` container, has also been deprecated in favor of a BigData Mono container which installs dependencies directly into the LocalStack (`localstack_main`) container.
+Earlier, we maintained `localstack/localstack-light` and `localstack/localstack-full` images. They have been deprecated and are removed with the LocalStack 2.0 release. The [BigData image](https://hub.docker.com/r/localstack/bigdata/tags), which started as a `bigdata_container` container, has also been deprecated in favor of a BigData Mono container which installs dependencies directly into the LocalStack (`localstack-main`) container.
 {{< /alert >}}
 
 ## Image tags

--- a/content/en/references/external-ports.md
+++ b/content/en/references/external-ports.md
@@ -40,9 +40,9 @@ If you wish to run multiple instances of LocalStack simultaneously, it is essent
 Here's how you can achieve this using the LocalStack CLI:
 
 {{< command >}}
-$ GATEWAY_LISTEN=0.0.0.0:4566 EXTERNAL_SERVICE_PORTS_START=4510 EXTERNAL_SERVICE_PORTS_END=4559 MAIN_CONTAINER_NAME=localstack-main_1 localstack start
-$ GATEWAY_LISTEN=0.0.0.0:4666 EXTERNAL_SERVICE_PORTS_START=4610 EXTERNAL_SERVICE_PORTS_END=4659 MAIN_CONTAINER_NAME=localstack-main_2 localstack start
-$ GATEWAY_LISTEN=0.0.0.0:4766 EXTERNAL_SERVICE_PORTS_START=4710 EXTERNAL_SERVICE_PORTS_END=4759 MAIN_CONTAINER_NAME=localstack-main_3 localstack start
+$ GATEWAY_LISTEN=0.0.0.0:4566 EXTERNAL_SERVICE_PORTS_START=4510 EXTERNAL_SERVICE_PORTS_END=4559 MAIN_CONTAINER_NAME=localstack-main-1 localstack start
+$ GATEWAY_LISTEN=0.0.0.0:4666 EXTERNAL_SERVICE_PORTS_START=4610 EXTERNAL_SERVICE_PORTS_END=4659 MAIN_CONTAINER_NAME=localstack-main-2 localstack start
+$ GATEWAY_LISTEN=0.0.0.0:4766 EXTERNAL_SERVICE_PORTS_START=4710 EXTERNAL_SERVICE_PORTS_END=4759 MAIN_CONTAINER_NAME=localstack-main-3 localstack start
 {{< /command >}}
 
 By customizing the `GATEWAY_LISTEN` and `EXTERNAL_SERVICE_PORTS_START`/`EXTERNAL_SERVICE_PORTS_END` values for each instance, you can ensure that they operate on distinct port ranges, preventing any conflicts and enabling smooth execution of multiple LocalStack instances.

--- a/content/en/references/external-ports.md
+++ b/content/en/references/external-ports.md
@@ -40,9 +40,9 @@ If you wish to run multiple instances of LocalStack simultaneously, it is essent
 Here's how you can achieve this using the LocalStack CLI:
 
 {{< command >}}
-$ GATEWAY_LISTEN=0.0.0.0:4566 EXTERNAL_SERVICE_PORTS_START=4510 EXTERNAL_SERVICE_PORTS_END=4559 MAIN_CONTAINER_NAME=localstack_main_1 localstack start
-$ GATEWAY_LISTEN=0.0.0.0:4666 EXTERNAL_SERVICE_PORTS_START=4610 EXTERNAL_SERVICE_PORTS_END=4659 MAIN_CONTAINER_NAME=localstack_main_2 localstack start
-$ GATEWAY_LISTEN=0.0.0.0:4766 EXTERNAL_SERVICE_PORTS_START=4710 EXTERNAL_SERVICE_PORTS_END=4759 MAIN_CONTAINER_NAME=localstack_main_3 localstack start
+$ GATEWAY_LISTEN=0.0.0.0:4566 EXTERNAL_SERVICE_PORTS_START=4510 EXTERNAL_SERVICE_PORTS_END=4559 MAIN_CONTAINER_NAME=localstack-main_1 localstack start
+$ GATEWAY_LISTEN=0.0.0.0:4666 EXTERNAL_SERVICE_PORTS_START=4610 EXTERNAL_SERVICE_PORTS_END=4659 MAIN_CONTAINER_NAME=localstack-main_2 localstack start
+$ GATEWAY_LISTEN=0.0.0.0:4766 EXTERNAL_SERVICE_PORTS_START=4710 EXTERNAL_SERVICE_PORTS_END=4759 MAIN_CONTAINER_NAME=localstack-main_3 localstack start
 {{< /command >}}
 
 By customizing the `GATEWAY_LISTEN` and `EXTERNAL_SERVICE_PORTS_START`/`EXTERNAL_SERVICE_PORTS_END` values for each instance, you can ensure that they operate on distinct port ranges, preventing any conflicts and enabling smooth execution of multiple LocalStack instances.

--- a/content/en/references/external-ports.md
+++ b/content/en/references/external-ports.md
@@ -57,6 +57,7 @@ services:
       - "4566:4566"            # LocalStack Gateway
       - "4510-4559:4510-4559"  # external services port range
     environment:
+      - GATEWAY_LISTEN=0.0.0.0:4566
       - EXTERNAL_SERVICE_PORTS_START=4510
       - EXTERNAL_SERVICE_PORTS_END=4559
       - MAIN_CONTAINER_NAME=localstack-main-1
@@ -72,6 +73,7 @@ services:
       - "4666:4666"            # LocalStack Gateway
       - "4610-4659:4610-4659"  # external services port range
     environment:
+      - GATEWAY_LISTEN=0.0.0.0:4666
       - EXTERNAL_SERVICE_PORTS_START=4610
       - EXTERNAL_SERVICE_PORTS_END=4659
       - MAIN_CONTAINER_NAME=localstack-main-2
@@ -87,6 +89,7 @@ services:
       - "4766:4766"            # LocalStack Gateway
       - "4710-4759:4710-4759"  # external services port range
     environment:
+      - GATEWAY_LISTEN=0.0.0.0:4766
       - EXTERNAL_SERVICE_PORTS_START=4710
       - EXTERNAL_SERVICE_PORTS_END=4759
       - MAIN_CONTAINER_NAME=localstack-main-3

--- a/content/en/references/external-ports.md
+++ b/content/en/references/external-ports.md
@@ -37,13 +37,65 @@ By adjusting these environment variables, you can customize the port range accor
 ## Running multiple LocalStack containers with Custom Port Mapping
 
 If you wish to run multiple instances of LocalStack simultaneously, it is essential to ensure that the edge port (default: `4566`) and external service ports are mapped to non-overlapping ranges.
-Here's how you can achieve this using the LocalStack CLI:
 
-{{< command >}}
+Here's how you can achieve this using when either using the CLI or docker-compose to start your LocalStack instances:
+
+{{< tabpane >}}
+{{< tab header="LocalStack CLI" lang="shell" >}}
 $ GATEWAY_LISTEN=0.0.0.0:4566 EXTERNAL_SERVICE_PORTS_START=4510 EXTERNAL_SERVICE_PORTS_END=4559 MAIN_CONTAINER_NAME=localstack-main-1 localstack start
 $ GATEWAY_LISTEN=0.0.0.0:4666 EXTERNAL_SERVICE_PORTS_START=4610 EXTERNAL_SERVICE_PORTS_END=4659 MAIN_CONTAINER_NAME=localstack-main-2 localstack start
 $ GATEWAY_LISTEN=0.0.0.0:4766 EXTERNAL_SERVICE_PORTS_START=4710 EXTERNAL_SERVICE_PORTS_END=4759 MAIN_CONTAINER_NAME=localstack-main-3 localstack start
-{{< /command >}}
+{{< /tab >}}
+{{< tab header="docker-compose" lang="yml" >}}
+version: "3.8"
+
+services:
+  localstack-main-1:
+    container_name: localstack-main-1
+    image: localstack/localstack
+    ports:
+      - "4566:4566"            # LocalStack Gateway
+      - "4510-4559:4510-4559"  # external services port range
+    environment:
+      - EXTERNAL_SERVICE_PORTS_START=4510
+      - EXTERNAL_SERVICE_PORTS_END=4559
+      - MAIN_CONTAINER_NAME=localstack-main-1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  localstack-main-2:
+    container_name: localstack-main-2
+    image: localstack/localstack
+    ports:
+      - "4666:4666"            # LocalStack Gateway
+      - "4610-4659:4610-4659"  # external services port range
+    environment:
+      - EXTERNAL_SERVICE_PORTS_START=4610
+      - EXTERNAL_SERVICE_PORTS_END=4659
+      - MAIN_CONTAINER_NAME=localstack-main-2
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  localstack-main-3:
+    container_name: localstack-main-3
+    image: localstack/localstack
+    ports:
+      - "4766:4766"            # LocalStack Gateway
+      - "4710-4759:4710-4759"  # external services port range
+    environment:
+      - EXTERNAL_SERVICE_PORTS_START=4710
+      - EXTERNAL_SERVICE_PORTS_END=4759
+      - MAIN_CONTAINER_NAME=localstack-main-3
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+{{< /tab >}}
+{{< /tabpane >}}
 
 By customizing the `GATEWAY_LISTEN` and `EXTERNAL_SERVICE_PORTS_START`/`EXTERNAL_SERVICE_PORTS_END` values for each instance, you can ensure that they operate on distinct port ranges, preventing any conflicts and enabling smooth execution of multiple LocalStack instances.
 Please make sure to set `MAIN_CONTAINER_NAME` for following usages of the LocalStack CLI to specify which instance of LocalStack you want to address with the specific CLI command.

--- a/content/en/references/init-hooks.md
+++ b/content/en/references/init-hooks.md
@@ -129,7 +129,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4566:4566"

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -41,16 +41,16 @@ For example:
 docker network create my-network
 # launch localstack
 MAIN_DOCKER_NETWORK=my-network DOCKER_FLAGS="--network my-network" localstack start
-# then your code can access localstack at its container name (by default: localstack_main)
-aws --endpoint-url http://localstack_main:4566 s3api list-buckets
+# then your code can access localstack at its container name (by default: localstack-main)
+aws --endpoint-url http://localstack-main:4566 s3api list-buckets
 {{</tab>}}
 {{<tab header="Docker" lang="bash">}}
 # create the network
 docker network create my-network
 # launch localstack
 docker run --rm -it --network my-network -e MAIN_DOCKER_NETWORK=my-network <other flags> localstack/localstack[-pro]
-# then your code can access localstack at its container name (by default: localstack_main)
-aws --endpoint-url http://localstack_main:4566 s3api list-buckets
+# then your code can access localstack at its container name (by default: localstack-main)
+aws --endpoint-url http://localstack-main:4566 s3api list-buckets
 {{</tab>}}
 {{<tab header="docker-compose.yml" lang="yml">}}
 services:
@@ -94,7 +94,7 @@ localstack start -d --network ls
 localstack wait
 
 # get the ip address of the LocalStack container
-docker inspect localstack_main | \
+docker inspect localstack-main | \
 	jq -r '.[0].NetworkSettings.Networks | to_entries | .[].value.IPAddress'
 # prints 172.27.0.2
 
@@ -104,10 +104,10 @@ docker run --rm -it --dns 172.27.0.2 --network ls <arguments> <image name>
 {{< tab header="Docker" lang="bash" >}}
 # start localstack
 docker network create ls
-docker run --rm -it --network ls --name localstack_main <other flags> localstack/localstack[-pro]
+docker run --rm -it --network ls --name localstack-main <other flags> localstack/localstack[-pro]
 
 # get the ip address of the LocalStack container
-docker inspect localstack_main | \
+docker inspect localstack-main | \
 	jq -r '.[0].NetworkSettings.Networks | to_entries | .[].value.IPAddress'
 # prints 172.27.0.2
 
@@ -119,7 +119,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       # Now only required if you need to access LocalStack from the host
@@ -171,7 +171,7 @@ docker network create my-network
 DOCKER_FLAGS="--network my-network" localstack start
 # launch your container
 docker run --rm it --network my-network <image name>
-# then your code can access localstack at its container name (by default: localstack_main)
+# then your code can access localstack at its container name (by default: localstack-main)
 {{</tab>}}
 {{<tab header="Docker" lang="bash">}}
 # create the network
@@ -180,7 +180,7 @@ docker network create my-network
 docker run --rm -it --network my-network <other flags> localstack/localstack[-pro]
 # launch your container
 docker run --rm it --network my-network <image name>
-# then your code can access localstack at its container name (by default: localstack_main)
+# then your code can access localstack at its container name (by default: localstack-main)
 {{</tab>}}
 {{<tab header="docker-compose.yml" lang="yml">}}
 services:

--- a/content/en/user-guide/aws/opensearch/index.md
+++ b/content/en/user-guide/aws/opensearch/index.md
@@ -233,7 +233,7 @@ services:
       - data01:/usr/share/opensearch/data
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "4566:4566"

--- a/content/en/user-guide/extensions/managing-extensions/index.md
+++ b/content/en/user-guide/extensions/managing-extensions/index.md
@@ -92,7 +92,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "localstack_main"
+    container_name: "localstack-main"
     image: localstack/localstack-pro
     ports:
       - "127.0.0.1:4566:4566"

--- a/content/en/user-guide/tools/transparent-endpoint-injection/dns-server.md
+++ b/content/en/user-guide/tools/transparent-endpoint-injection/dns-server.md
@@ -172,7 +172,7 @@ Also, it configures the DNS route to exclusively (and only) route the following 
 If you want to perform this action manually, please do the following steps:
 
 1. Find out the bridge interface and container IP of your LocalStack container.
-    Use `docker inspect localstack_main` to get the IP address and network, then `docker inspect network` to get the interface name.
+    Use `docker inspect localstack-main` to get the IP address and network, then `docker inspect network` to get the interface name.
     If the interface name is not mentioned, it is usually the first 12 characters of the network ID prefixed with `br-`, like `br-0ae393d3345e`.
     If you use the default bridge network, it is usually `docker0`.
 


### PR DESCRIPTION
# Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for boto3 which refuses to connect.

# Changes

This PR updates usages of `localstack_main` to `localstack-main`.
