### PR TITLE
Fix CI broken link checks

### DIFF
--- a/content/en/user-guide/aws/iot/index.md
+++ b/content/en/user-guide/aws/iot/index.md
@@ -65,7 +65,7 @@ This message will be pushed to all subscribers of this topic, including the one 
 ## Authentication
 
 LocalStack IoT maintains its own root certificate authority which is regenerated at every run.
-The root CA certificate can be retrieved from <http://local.localstack.cloud:4566/_aws/iot/LocalStackIoTRootCA.pem>.
+The root CA certificate can be retrieved from <http://localhost.localstack.cloud:4566/_aws/iot/LocalStackIoTRootCA.pem>.
 
 {{< alert title="Note">}}
 AWS provides its root CA certificate at <https://www.amazontrust.com/repository/AmazonRootCA1.pem>.

--- a/content/en/user-guide/aws/neptune/index.md
+++ b/content/en/user-guide/aws/neptune/index.md
@@ -26,7 +26,7 @@ Start your LocalStack container using your preferred method. We will demonstrate
 
 ### Create a Neptune cluster
 
-To create a Neptune cluster you can use the [`CreateDBCluster`](https://docs.aws.amazon.com/neptune/latest/APIReference/API_CreateDBCluster.html) API. 
+To create a Neptune cluster you can use the [`CreateDBCluster`](https://docs.aws.amazon.com/neptune/latest/userguide/api-clusters.html#CreateDBCluster) API. 
 Run the following command to create a Neptune cluster:
 
 {{< command >}}
@@ -51,7 +51,7 @@ You should see the following output:
 
 ### Add an instance to the cluster
 
-To add an instance you can use the [`CreateDBInstance`](https://docs.aws.amazon.com/neptune/latest/APIReference/API_CreateDBInstance.html) API. 
+To add an instance you can use the [`CreateDBInstance`](https://docs.aws.amazon.com/neptune/latest/userguide/api-instances.html#CreateDBInstance) API. 
 Run the following command to create a Neptune instance:
 
 {{< command >}}


### PR DESCRIPTION
# Motivation

It seems merging #892 broke the broken link checker. This may be because the config file previously had an incorrect format, and was therefore invalid JSON, however it is confusing that the pipeline did not fail at any point.

Regardless, some broken links were found:

* the use of `local.localstack.cloud` (rather than `localhost.localstack.cloud`)
* links to removed neptune API reference

# Changes

This PR fixes the two points listed above, and fixes the broken link checker.
