### PR TITLE
Add AWS_ENDPOINT_URL to pulumi docs

### DIFF
--- a/content/en/user-guide/integrations/pulumi/index.md
+++ b/content/en/user-guide/integrations/pulumi/index.md
@@ -453,8 +453,9 @@ You can configure the integration between pulumi-local and LocalStack by adding 
 | --------------------- | ------------- | ------------|
 | `PULUMI_CMD`          | pulumi        | The Pulumi command that is being delegated to |
 | `PULUMI_STACK_NAME`   | localstack    | The Pulumi stack name used for looking up the stack file (`Pulumi.<stack>.yaml`) |
-| `LOCALSTACK_HOSTNAME` | localhost     | The name of the host LocalStack is reachable at |
-| `EDGE_PORT`           | 4566          | The port LocalStack is reachable at |
+| `AWS_ENDPOINT_URL`    | -             |Hostname and port of the target LocalStack instance |
+| `LOCALSTACK_HOSTNAME` | localhost     | **(Deprecated)** The name of the host LocalStack is reachable at |
+| `EDGE_PORT`           | 4566          | **(Deprecated)** The port LocalStack is reachable at |
 | `USE_SSL`             | 0             | A truthy (`1`, `true`) string that indicates whether to use SSL when connecting to LocalStack |
 
 


### PR DESCRIPTION
# Motivation
Update Pulumi docs with new option in pulumi-local

# Changes
- Added new AWS_ENDPOINT_URL
- Marked LOCALSTACK_HOSTNAME and EDGE_PORT deprecated