### PR TITLE
update the CLI version and links to 3.0.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -209,7 +209,7 @@ enable = true
 
 [params.localstack]
 # LocalStack specific configuration values
-latest_version = "3.0.0"
+latest_version = "3.0.1"
 
 [params.localstack.cli_links]
 # Configure the different download links for the cli-binary-download shortcode


### PR DESCRIPTION
Version 3.0.1 has been released.
This PR updates the CLI version output, as well as the links in the instructions to point towards the new release.