### PR TITLE
Update Route53 Pro DNS server updating

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,12 @@
 # terraform
 /content/en/user-guide/integrations/terraform/ @lakkeger
 
+# network troubleshooting guide
+/content/en/references/network-troubleshooting @simonrw @joe4dev @dfangl
+
+# DNS server
+/content/en/user-guide/tools/dns-server @simonrw @joe4dev @dfangl
+
 ######################
 ### SERVICE OWNERS ###
 ######################

--- a/content/en/user-guide/aws/route53/index.md
+++ b/content/en/user-guide/aws/route53/index.md
@@ -19,12 +19,6 @@ This guide is designed for users new to Route53 and assumes basic knowledge of t
 
 Start your LocalStack container using your preferred method. We will demonstrate how to create a hosted zone and query the DNS record with the AWS CLI.
 
-{{< alert title="Note">}}
-When using the [LocalStack CLI]({{< ref "getting-started/installation#localstack-cli" >}}), the `DNS_ADDRESS` configuration variable can be used to configure the address the [LocalStack DNS server]({{< ref "user-guide/tools/dns-server/" >}}) binds to on the host.
-The default is `0.0.0.0`, but you use `127.0.0.1` to bind to `localhost` only.
-You can also set this variable to `0` to disable the DNS functionality, but we do not recommend this configuration as it disables internal functionality that relies on the DNS server being available within LocalStack.
-{{< /alert >}}
-
 ### Create a hosted zone
 
 You can created a hosted zone for `example.com` using the [`CreateHostedZone`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html) API. Run the following command:

--- a/content/en/user-guide/aws/route53/index.md
+++ b/content/en/user-guide/aws/route53/index.md
@@ -20,7 +20,9 @@ This guide is designed for users new to Route53 and assumes basic knowledge of t
 Start your LocalStack container using your preferred method. We will demonstrate how to create a hosted zone and query the DNS record with the AWS CLI.
 
 {{< alert title="Note">}}
-The built-in DNS capabilities requires privileged access for the LocalStack container. The `DNS_ADDRESS` configuration variable can be used to address the port the LocalStack should bind the DNS server on (port 53 tcp/udp). Default is `0.0.0.0` and you can add `0` to disable.
+When using the [LocalStack CLI]({{< ref "getting-started/installation#localstack-cli" >}}), the `DNS_ADDRESS` configuration variable can be used to configure the address the [LocalStack DNS server]({{< ref "user-guide/tools/dns-server/" >}}) binds to on the host.
+The default is `0.0.0.0`, but you use `127.0.0.1` to bind to `localhost` only.
+You can also set this variable to `0` to disable the DNS functionality, but we do not recommend this configuration as it disables internal functionality that relies on the DNS server being available within LocalStack.
 {{< /alert >}}
 
 ### Create a hosted zone

--- a/content/en/user-guide/aws/route53/index.md
+++ b/content/en/user-guide/aws/route53/index.md
@@ -8,7 +8,9 @@ description: Get started with Route 53 on LocalStack
 
 Route 53 is a highly scalable and reliable domain name system (DNS) web service provided by Amazon Web Services. Route 53 allows you to register domain names, and associate them with IP addresses or other resources. In addition to basic DNS functionality, Route 53 offers advanced features like health checks and DNS failover. Route 53 integrates seamlessly with other AWS services, such as route traffic to CloudFront distributions, S3 buckets configured for static website hosting, EC2 instances, and more.
 
-LocalStack supports Route53 via the Community offering, allowing you to use the Route53 APIs in your local environment to create hosted zones and to manage DNS entries which can then be queried via the built-in DNS server. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_route53/), which provides information on the extent of Route53's integration with LocalStack.
+LocalStack supports Route53 via the Community offering, allowing you to use the Route53 APIs in your local environment to create hosted zones and to manage DNS entries.
+Our Pro offering integrates with our DNS server to respond to DNS queries with these domains.
+The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_route53/), which provides information on the extent of Route53's integration with LocalStack.
 
 ## Getting started
 

--- a/content/en/user-guide/aws/route53/index.md
+++ b/content/en/user-guide/aws/route53/index.md
@@ -9,8 +9,9 @@ description: Get started with Route 53 on LocalStack
 Route 53 is a highly scalable and reliable domain name system (DNS) web service provided by Amazon Web Services. Route 53 allows you to register domain names, and associate them with IP addresses or other resources. In addition to basic DNS functionality, Route 53 offers advanced features like health checks and DNS failover. Route 53 integrates seamlessly with other AWS services, such as route traffic to CloudFront distributions, S3 buckets configured for static website hosting, EC2 instances, and more.
 
 LocalStack supports Route53 via the Community offering, allowing you to use the Route53 APIs in your local environment to create hosted zones and to manage DNS entries.
-Our Pro offering integrates with our DNS server to respond to DNS queries with these domains.
 The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_route53/), which provides information on the extent of Route53's integration with LocalStack.
+
+Our Pro offering integrates with our DNS server to respond to DNS queries with these domains.
 
 ## Getting started
 
@@ -61,7 +62,15 @@ The following output would be retrieved:
 }
 ```
 
-### Query DNS record
+## DNS resolution
+
+LocalStack Pro supports the ability to respond to DNS queries for your Route53 domain names, with our [integrated DNS server]({{< ref "user-guide/tools/dns-server/" >}}).
+
+{{< alert title="Note" >}}
+To follow the example below you must [configure your system DNS to use the LocalStack DNS server]({{< ref "user-guide/tools/dns-server/#system-dns-configuration" >}}).
+{{< / alert >}}
+
+### Query a DNS record
 
 You can query the DNS record using `dig` via the built-in DNS server by running the following command:
 
@@ -79,9 +88,11 @@ The following output would be retrieved:
 test.example.com.       300     IN      A       1.2.3.4
 ```
 
-## Customizing internal endpoint resolution
+### Customizing internal endpoint resolution
 
-The DNS name `localhost.localstack.cloud`, along with its subdomains like `mybucket.s3.localhost.localstack.cloud`, serves an internal routing purpose within LocalStack. It facilitates communication between a Lambda container and the LocalStack APIs.
+The DNS name `localhost.localstack.cloud`, along with its subdomains like `mybucket.s3.localhost.localstack.cloud`, serves an internal routing purpose within LocalStack.
+It facilitates communication between a LocalStack compute environment (such as a Lambda function) and the LocalStack APIs, as well as your containerised applications with the LocalStack APIs.
+For example configurations, see the [Network Troubleshooting guide]({{< ref "references/network-troubleshooting/endpoint-url/#from-your-container" >}}).
 
 For most use-cases, the default configuration of the internal LocalStack DNS name requires no modification. It functions seamlessly in typical scenarios. However, there are instances where adjusting the external resolution of this DNS name becomes necessary. For instance, this might be required when your LocalStack instance operates on a distinct Docker network compared to your application code or even on a separate machine.
 


### PR DESCRIPTION
# Motivation

A user in our [#help channel](https://localstack-community.slack.com/archives/CMAFN2KSP/p1701724951011449) was following the docs for Route53 and understandably thought that updating DNS records was in the Community version of LocalStack.

# Changes

* Update the documentation to describe that updating DNS records is a Pro feature.
* Reorganise the structure a bit to split the community (CRUD operations on hosted zones and record sets) from pro (dns resolution)
* Update codeowners for the network troubleshooting guide and DNS server pages
