### PR TITLE
Update docs for upstream resolution patterns

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -309,8 +309,8 @@ To learn more about these configuration options, see [DNS Server]({{< ref "dns-s
 | `DNS_ADDRESS` | `0.0.0.0` (default) | Address the LocalStack should bind the DNS server on (port 53 tcp/udp). Value `0` to disable.
 | `DNS_SERVER` | Default upstream DNS or `8.8.8.8` (default) | Fallback DNS server for queries not handled by LocalStack.
 | `DNS_RESOLVE_IP` | `127.0.0.1` (default) | IP address the DNS server should return as A record for queries handled by LocalStack. If customized, this value will be returned in preference to the DNS server response.
-| `DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM` | | Skiplist of domain names that should *NOT* be resolved to the LocalStack container, as a comma-separated list of Python-flavored regex patterns.
-| `DNS_LOCAL_NAME_PATTERNS` | `.*(ecr\|lambda).*.amazonaws.com` (example) | **Deprecated since 3.0.0** Skiplist of domain names that should *NOT* be resolved to the LocalStack container, as a comma-separated list of Python-flavored regex patterns.
+| `DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM` | `.*(ecr\|lambda).*.amazonaws.com` (example) | List of domain names that should *NOT* be resolved to the LocalStack container, but instead always forwarded to the upstream resolver. Comma-separated list of Python-flavored regex patterns. See [the DNS server documentation]({{< ref "user-guide/tools/dns-server#skip-localstack-dns-resolution" >}}) for more details.
+| `DNS_LOCAL_NAME_PATTERNS` | `.*(ecr\|lambda).*.amazonaws.com` (example) | **Deprecated since 3.0.2** Skiplist of domain names that should *NOT* be resolved to the LocalStack container, as a comma-separated list of Python-flavored regex patterns. **Renamed to `DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM`**
 
 ## Transparent Endpoint Injection
 

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -309,7 +309,8 @@ To learn more about these configuration options, see [DNS Server]({{< ref "dns-s
 | `DNS_ADDRESS` | `0.0.0.0` (default) | Address the LocalStack should bind the DNS server on (port 53 tcp/udp). Value `0` to disable.
 | `DNS_SERVER` | Default upstream DNS or `8.8.8.8` (default) | Fallback DNS server for queries not handled by LocalStack.
 | `DNS_RESOLVE_IP` | `127.0.0.1` (default) | IP address the DNS server should return as A record for queries handled by LocalStack. If customized, this value will be returned in preference to the DNS server response.
-| `DNS_LOCAL_NAME_PATTERNS` | `.*(ecr\|lambda).*.amazonaws.com` (example) | Skiplist of hostnames that should *NOT* be resolved to the LocalStack container, as a comma-separated list of Python-flavored regex patterns.
+| `DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM` | | Skiplist of domain names that should *NOT* be resolved to the LocalStack container, as a comma-separated list of Python-flavored regex patterns.
+| `DNS_LOCAL_NAME_PATTERNS` | `.*(ecr\|lambda).*.amazonaws.com` (example) | **Deprecated since 3.0.0** Skiplist of domain names that should *NOT* be resolved to the LocalStack container, as a comma-separated list of Python-flavored regex patterns.
 
 ## Transparent Endpoint Injection
 

--- a/content/en/user-guide/tools/dns-server/_index.md
+++ b/content/en/user-guide/tools/dns-server/_index.md
@@ -30,7 +30,7 @@ unless your router has [DNS rebind protection]({{< ref "dns-server#dns-rebind-pr
 ### Fallback DNS server
 
 If you want to use another upstream DNS resolver than your default system DNS resolver or Google DNS (`8.8.8.8` fallback if detection fails),
-specify the fallback DNS server where all non-redirected queries (i.e., not matching `DNS_LOCAL_NAME_PATTERNS`) will be forwarded to:
+specify the fallback DNS server where all non-redirected queries (i.e., not matching `DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM`) will be forwarded to:
 
 ```bash
 DNS_SERVER=1.1.1.1
@@ -45,7 +45,7 @@ If you want to resolve certain AWS URLs to AWS instead of LocalStack,
 specify a comma-separated list of skip patterns using Python-flavored regex such as:
 
 ```bash
-DNS_LOCAL_NAME_PATTERNS='.*(ecr|lambda).*.amazonaws.com'
+DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM='.*(ecr|lambda).*.amazonaws.com'
 ```
 
 Using this configuration, the LocalStack DNS server resolves all AWS domains to LocalStack _except_ ECR and Lambda domains which will be resolved via the `DNS_SERVER` (i.e., the real DNS entry by default).


### PR DESCRIPTION
# Motivation

With https://github.com/localstack/localstack/pull/9692 we deprecated the use of `DNS_LOCAL_NAME_PATTERNS` since it had a confusing name. Instead of _adding_ domain name patterns to resolve to LocalStack, it added domain names to the skiplist of names that should always be resolved upstream. In particular, with transparent endpoint injection enabled, `s3.amazonaws.com` would resolve to LocalStack, and `DNS_LOCAL_NAME_PATTERNS` could force LocalStack to resolve the name from its upstream resolver.

# Changes

* Update all usages of `DNS_LOCAL_NAME_PATTERNS` to use the new `DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM` variable

# TODO

* [x] wait for https://github.com/localstack/localstack/pull/9692 to be merged
