### PR TITLE
update the windows volume path

### DIFF
--- a/content/en/references/filesystem.md
+++ b/content/en/references/filesystem.md
@@ -114,7 +114,7 @@ The defaults are:
 
 * Mac: `~/Library/Caches/localstack/volume`
 * Linux: `~/.cache/localstack/volume`
-* Windows: `%LOCALAPPDATA%/localstack/cache/volume`
+* Windows: `%LOCALAPPDATA%\cache\localstack\volume`
 
 ## Host mode
 


### PR DESCRIPTION
Change the location of the LocalStack CLI's volume folder in the `Using the CLI` for Windows.