### PR TITLE
Add fix on pulumi example

### DIFF
--- a/content/en/user-guide/integrations/pulumi/index.md
+++ b/content/en/user-guide/integrations/pulumi/index.md
@@ -72,7 +72,7 @@ Now edit your stack configuration `Pulumi.dev.yaml` as follows:
 config:
   aws:accessKey: test
   aws:secretKey: test
-  aws:s3ForcePathStyle: 'true'
+  aws:s3UsePathStyle: 'true'
   aws:skipCredentialsValidation: 'true'
   aws:skipRequestingAccountId: 'true'
   aws:endpoints:


### PR DESCRIPTION
# Motivation
Pulumi example contained wrong path style switch that throws an error with new package version.
I reported the issue to Pulumi too, which they have applied already.
https://github.com/pulumi/pulumi-aws/issues/3068

# Changes
- swap `s3ForcePathStyle` to `s3UsePathStyle`