### PR TITLE
add docs for acm pca

### DIFF
--- a/content/en/user-guide/aws/acm/index.md
+++ b/content/en/user-guide/aws/acm/index.md
@@ -62,13 +62,17 @@ $ awslocal acm delete-certificate --certificate-arn arn:aws:acm:<region>:account
 
 ## ACM Private Certificate Authority
 
-AWS Private Certificate Authority (ACM PCA) is a managed private Certificate Authority (CA) service that manages the lifecycle of your private certificates. ACM PCA extends ACM's certificate management capabilities to private certificates, enabling you to manage public and private certificates centrally.
+AWS Private Certificate Authority (ACM PCA) is a managed private Certificate Authority (CA) service that manages the lifecycle of your private certificates. 
+ACM PCA extends ACM's certificate management capabilities to private certificates, enabling you to manage public and private certificates centrally.
 
-LocalStack supports ACM PCA via the Pro/Team offering, allowing you to use the ACM PCA API to create, list, and delete private certificates. You can creating, describing, tagging, and listing tags for a CA using ACM PCA. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_acm_pca/), which provides information on the extent of ACM PCA's integration with LocalStack.
+LocalStack supports ACM PCA via the Pro/Team offering, allowing you to use the ACM PCA API to create, list, and delete private certificates. 
+You can creating, describing, tagging, and listing tags for a CA using ACM PCA. 
+The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_acm_pca/), which provides information on the extent of ACM PCA's integration with LocalStack.
 
 ### Create a Certificate Authority (CA)
 
-Start by creating a new Certificate Authority with ACM PCA using the [`CreateCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_CreateCertificateAuthority.html) API. This command sets up a new CA with specified configurations for key algorithm, signing algorithm, and subject information.
+Start by creating a new Certificate Authority with ACM PCA using the [`CreateCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_CreateCertificateAuthority.html) API. 
+This command sets up a new CA with specified configurations for key algorithm, signing algorithm, and subject information.
 
 {{< command >}}
 $ awslocal acm-pca create-certificate-authority \
@@ -102,7 +106,8 @@ Note the `CertificateAuthorityArn` from the output as it will be needed for subs
 
 ### Describe the Certificate Authority
 
-To retrieve the detailed information about the created Certificate Authority, use the [`DescribeCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_DescribeCertificateAuthority.html) API. This command returns the detailed information about the CA, including the CA's ARN, status, and configuration.
+To retrieve the detailed information about the created Certificate Authority, use the [`DescribeCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_DescribeCertificateAuthority.html) API. 
+This command returns the detailed information about the CA, including the CA's ARN, status, and configuration.
 
 {{< command >}}
 $ awslocal acm-pca describe-certificate-authority \
@@ -139,11 +144,10 @@ $ awslocal acm-pca describe-certificate-authority \
 </disable-copy>
 {{< /command >}}
 
-This command provides detailed information about the Certificate Authority, including its type, status, and configuration details.
-
 ### Tag the Certificate Authority
 
-Tagging resources in AWS helps in managing and identifying them. Use the [`TagCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_TagCertificateAuthority.html) API to tag the created Certificate Authority. This command adds the specified tags to the specified CA.
+Tagging resources in AWS helps in managing and identifying them. Use the [`TagCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_TagCertificateAuthority.html) API to tag the created Certificate Authority. 
+This command adds the specified tags to the specified CA.
 
 {{< command >}}
 $ awslocal acm-pca tag-certificate-authority \
@@ -151,7 +155,8 @@ $ awslocal acm-pca tag-certificate-authority \
     --tags Key=Admin,Value=Alice
 {{< /command >}}
 
-After tagging your Certificate Authority, you may want to view these tags. You can use the [`ListTags`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_ListTags.html) API to list all the tags associated with the specified CA.
+After tagging your Certificate Authority, you may want to view these tags. 
+You can use the [`ListTags`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_ListTags.html) API to list all the tags associated with the specified CA.
 
 {{< command >}}
 $ awslocal acm-pca list-tags \

--- a/content/en/user-guide/aws/acm/index.md
+++ b/content/en/user-guide/aws/acm/index.md
@@ -67,11 +67,11 @@ ACM PCA extends ACM's certificate management capabilities to private certificate
 
 LocalStack supports ACM PCA via the Pro/Team offering, allowing you to use the ACM PCA API to create, list, and delete private certificates. 
 You can creating, describing, tagging, and listing tags for a CA using ACM PCA. 
-The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_acm_pca/), which provides information on the extent of ACM PCA's integration with LocalStack.
+The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_acm-pca/), which provides information on the extent of ACM PCA's integration with LocalStack.
 
 ### Create a Certificate Authority (CA)
 
-Start by creating a new Certificate Authority with ACM PCA using the [`CreateCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_CreateCertificateAuthority.html) API. 
+Start by creating a new Certificate Authority with ACM PCA using the [`CreateCertificateAuthority`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html) API. 
 This command sets up a new CA with specified configurations for key algorithm, signing algorithm, and subject information.
 
 {{< command >}}
@@ -106,7 +106,7 @@ Note the `CertificateAuthorityArn` from the output as it will be needed for subs
 
 ### Describe the Certificate Authority
 
-To retrieve the detailed information about the created Certificate Authority, use the [`DescribeCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_DescribeCertificateAuthority.html) API. 
+To retrieve the detailed information about the created Certificate Authority, use the [`DescribeCertificateAuthority`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_DescribeCertificateAuthority.html) API. 
 This command returns the detailed information about the CA, including the CA's ARN, status, and configuration.
 
 {{< command >}}
@@ -146,7 +146,7 @@ $ awslocal acm-pca describe-certificate-authority \
 
 ### Tag the Certificate Authority
 
-Tagging resources in AWS helps in managing and identifying them. Use the [`TagCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_TagCertificateAuthority.html) API to tag the created Certificate Authority. 
+Tagging resources in AWS helps in managing and identifying them. Use the [`TagCertificateAuthority`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_TagCertificateAuthority.html) API to tag the created Certificate Authority. 
 This command adds the specified tags to the specified CA.
 
 {{< command >}}
@@ -156,7 +156,7 @@ $ awslocal acm-pca tag-certificate-authority \
 {{< /command >}}
 
 After tagging your Certificate Authority, you may want to view these tags. 
-You can use the [`ListTags`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_ListTags.html) API to list all the tags associated with the specified CA.
+You can use the [`ListTags`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_ListTags.html) API to list all the tags associated with the specified CA.
 
 {{< command >}}
 $ awslocal acm-pca list-tags \

--- a/content/en/user-guide/aws/acm/index.md
+++ b/content/en/user-guide/aws/acm/index.md
@@ -1,14 +1,7 @@
 ---
 title: "AWS Certificate Manager (ACM)"
-linkTitle: "AWS Certificate Manager"
-categories: ["LocalStack Community"]
-tags:
-- aws-certificate-manager
-- acm
-description: >
-  Get started with AWS Certificate Manager (ACM) on LocalStack
-aliases:
-  - /aws/acm/
+linkTitle: "AWS Certificate Manager (ACM)"
+description: Get started with AWS Certificate Manager (ACM) on LocalStack
 ---
 
 ## Introduction
@@ -22,6 +15,8 @@ LocalStack supports ACM via the Community offering, allowing you to use the ACM 
 ## Getting started
 
 This guide is designed for users who are new to ACM and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+
+### Request a public certificate
 
 Start your LocalStack container using your preferred method, then use the [RequestCertificate API](https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html) to request a new public ACM certificate. Specify the domain name you want to request the certificate for, and any additional options you need. Here's an example command:
 
@@ -41,11 +36,15 @@ This command will return the Amazon Resource Name (ARN) of the new certificate, 
 }
 ```
 
+### List the certificates
+
 Use the [`ListCertificates` API](https://docs.aws.amazon.com/acm/latest/APIReference/API_ListCertificates.html) to list all the certificates. This command returns a list of the ARNs of all the certificates that have been requested or imported into ACM. Here's an example command:
 
 {{< command >}}
 $ awslocal acm list-certificates --max-items 10
 {{< /command >}}
+
+### Describe the certificate
 
 Use the [`DescribeCertificate` API](https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html) to view the details of a specific certificate. Provide the ARN of the certificate you want to view, and this command will return information about the certificate's status, domain name, and other attributes. Here's an example command:
 
@@ -53,13 +52,126 @@ Use the [`DescribeCertificate` API](https://docs.aws.amazon.com/acm/latest/APIRe
 $ awslocal acm describe-certificate --certificate-arn arn:aws:acm:<region>:account:certificate/<certificate_ID>
 {{< /command >}}
 
+### Delete the certificate
+
 Finally you can use the [`DeleteCertificate` API](https://docs.aws.amazon.com/acm/latest/APIReference/API_DeleteCertificate.html) to delete a certificate from ACM, by passing the ARN of the certificate you want to delete. Here's an example command:
 
 {{< command >}}
 $ awslocal acm delete-certificate --certificate-arn arn:aws:acm:<region>:account:certificate/<certificate_ID>
 {{< /command >}}
 
-For more comprehensive information on ACM, refer to the [AWS Certificate Manager](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) documentation. You can use the `awslocal` CLI or any [integration](https://docs.localstack.cloud/user-guide/integrations/) to interact with ACM in LocalStack.
+## ACM Private Certificate Authority
+
+AWS Private Certificate Authority (ACM PCA) is a managed private Certificate Authority (CA) service that manages the lifecycle of your private certificates. ACM PCA extends ACM's certificate management capabilities to private certificates, enabling you to manage public and private certificates centrally.
+
+LocalStack supports ACM PCA via the Pro/Team offering, allowing you to use the ACM PCA API to create, list, and delete private certificates. You can creating, describing, tagging, and listing tags for a CA using ACM PCA. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_acm_pca/), which provides information on the extent of ACM PCA's integration with LocalStack.
+
+### Create a Certificate Authority (CA)
+
+Start by creating a new Certificate Authority with ACM PCA using the [`CreateCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_CreateCertificateAuthority.html) API. This command sets up a new CA with specified configurations for key algorithm, signing algorithm, and subject information.
+
+{{< command >}}
+$ awslocal acm-pca create-certificate-authority \
+     --certificate-authority-configuration '{
+        "KeyAlgorithm":"RSA_2048",
+        "SigningAlgorithm":"SHA256WITHRSA",
+        "Subject":{
+            "Country":"US",
+            "Organization":"Example Corp",
+            "OrganizationalUnit":"Sales",
+            "State":"WA",
+            "Locality":"Seattle",
+            "CommonName":"www.example.com"
+        }
+     }' \
+     --revocation-configuration '{
+        "OcspConfiguration":{
+            "Enabled":true
+        }
+     }' \
+     --certificate-authority-type "ROOT" \
+     --tags  Key=Name,Value=MyPCA
+<disable-copy>
+{
+    "CertificateAuthorityArn": "arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600"
+}
+</disable-copy>
+{{< /command >}}
+
+Note the `CertificateAuthorityArn` from the output as it will be needed for subsequent commands.
+
+### Describe the Certificate Authority
+
+To retrieve the detailed information about the created Certificate Authority, use the [`DescribeCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_DescribeCertificateAuthority.html) API. This command returns the detailed information about the CA, including the CA's ARN, status, and configuration.
+
+{{< command >}}
+$ awslocal acm-pca describe-certificate-authority \
+    --certificate-authority-arn arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600
+<disable-copy>
+{
+    "CertificateAuthority": {
+        "Arn": "arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600",
+        "OwnerAccount": "000000000000",
+        "CreatedAt": "2023-12-23T20:52:20.917796+05:30",
+        "Type": "ROOT",
+        "Status": "PENDING_CERTIFICATE",
+        "CertificateAuthorityConfiguration": {
+            "KeyAlgorithm": "RSA_2048",
+            "SigningAlgorithm": "SHA256WITHRSA",
+            "Subject": {
+                "Country": "US",
+                "Organization": "Example Corp",
+                "OrganizationalUnit": "Sales",
+                "State": "WA",
+                "CommonName": "www.example.com",
+                "Locality": "Seattle"
+            }
+        },
+        "RevocationConfiguration": {
+            "OcspConfiguration": {
+                "Enabled": true
+            }
+        },
+        "KeyStorageSecurityStandard": "FIPS_140_2_LEVEL_3_OR_HIGHER",
+        "UsageMode": "SHORT_LIVED_CERTIFICATE"
+    }
+}
+</disable-copy>
+{{< /command >}}
+
+This command provides detailed information about the Certificate Authority, including its type, status, and configuration details.
+
+### Tag the Certificate Authority
+
+Tagging resources in AWS helps in managing and identifying them. Use the [`TagCertificateAuthority`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_TagCertificateAuthority.html) API to tag the created Certificate Authority. This command adds the specified tags to the specified CA.
+
+{{< command >}}
+$ awslocal acm-pca tag-certificate-authority \
+    --certificate-authority-arn arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600 \
+    --tags Key=Admin,Value=Alice
+{{< /command >}}
+
+After tagging your Certificate Authority, you may want to view these tags. You can use the [`ListTags`](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_ListTags.html) API to list all the tags associated with the specified CA.
+
+{{< command >}}
+$ awslocal acm-pca list-tags \
+    --certificate-authority-arn arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600 \
+    --max-results 10
+<disable-copy>
+{
+    "Tags": [
+        {
+            "Key": "Name",
+            "Value": "MyPCA"
+        },
+        {
+            "Key": "Admin",
+            "Value": "Alice"
+        }
+    ]
+}
+</disable-copy>
+{{< /command >}}
 
 ## Examples
 


### PR DESCRIPTION
This PR adds docs for `acm-pca` service that is shipped out in the `localstack/localstack-pro:latest` image this week 