### PR TITLE
fix parity docs action after github actions upgrade

### DIFF
--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-ext
-          ARTIFACT_ID: parity-metric-ext-raw 
+          ARTIFACT_ID: parity-metric-ext-raw-*
           WORKFLOW: "Build, Test, Push" 
           PREFIX_ARTIFACT: pro-integration-test
       

--- a/scripts/get_latest_github_metrics.sh
+++ b/scripts/get_latest_github_metrics.sh
@@ -51,7 +51,7 @@ fi
 echo "Trying to download file with runid $RUN_ID..."
 
 # we do not want to exit if this command fails -> using or true
-gh run download $RUN_ID --repo $REPOSITORY_OWNER/$REPOSITORY_NAME -n $ARTIFACT_ID -D $TMP_FOLDER || true
+gh run download $RUN_ID --repo $REPOSITORY_OWNER/$REPOSITORY_NAME -p "$ARTIFACT_ID" -D $TMP_FOLDER || true
 
 # count the files with the pattern (we do not know the exact name) to check if we downloaded something
 if [ 0 -lt $(ls $TMP_FOLDER 2>/dev/null | wc -w) ]; then
@@ -91,10 +91,10 @@ echo "Moving artifact to $TARGET_FOLDER"
 mkdir -p $TARGET_FOLDER
 if [[ -z "${PREFIX_ARTIFACT}" ]]; then
     # pro implementation_coverage artifact download has a subfolder "pro"
-    cp -R $TMP_FOLDER/* $TARGET_FOLDER
+    cp -R $TMP_FOLDER/**/* $TARGET_FOLDER
 else
     # metrics-raw-data artifacts -> we are only want to keept the csv and rename it
-    for file in $TMP_FOLDER/*.csv; do
+    for file in $TMP_FOLDER/**/*.csv; do
       org_file_name=$(echo $file | sed "s/.*\///")
       mv -- "$file" "$TARGET_FOLDER/$PREFIX_ARTIFACT-$org_file_name"
     done


### PR DESCRIPTION
## Motivation
Previously, we used the same artifact ID for the parallel metrics collection in our internal test suite on GitHub. This means both jobs executed in parallel would use the same ID (the first one to finish creating the artifact, the second one to append to it).
But we recently upgraded to the latest major version of `actions/upload-artifact` in our internal test pipelines, and this major version enforces that every artifact is immutable (which forced us to use multiple artifact IDs for the metrics).

## Changes
This PR adjusts the scripts and GitHub workflow to update the Partiy Docs such that they use a pattern when downloading the artifacts from GitHub instead. 

When using the pattern, a subfolder for each artifact is created, which is why the glob patterns for the file movements are also slightly changed. 

## Testing
### Manual Testing
I tested the script locally, here's the output for:
- _capture-notimplemented-pro_
  ```
  Searching for Artifact: capture-notimplemented-pro in workflow 'Build, Test, Push' on branch master in repo localstack/xxxxxx.
  searching last workflow with 'conclusion=success'
  Trying to download file with runid xxxxxx...
  ...downloaded capture-notimplemented-pro successfully.
  target/tmp_download
  └── capture-notimplemented-pro
      └── pro
          ├── implementation_coverage_aggregated.csv
          └── implementation_coverage_full.csv
  
  2 directories, 2 files
  Moving artifact to target/metrics-implementation-details
  content of target/metrics-implementation-details:
  target/metrics-implementation-details
  └── pro
      ├── implementation_coverage_aggregated.csv
      └── implementation_coverage_full.csv
  
  1 directory, 2 files
  Done.
  ```
- _parity-metric-ext-raw-*_
  ```
  Searching for Artifact: parity-metric-ext-raw-* in workflow 'Build, Test, Push' on branch master in repo localstack/localstack-ext.
  searching last workflow with 'conclusion=success'
  Trying to download file with runid 7427419271...
  ...downloaded parity-metric-ext-raw-* successfully.
  target/tmp_download
  ├── parity-metric-ext-raw-1
  │   └── metric-report-raw-data-2024-01-05__22_50_52-pytest-junit-main-amd64-1.csv
  └── parity-metric-ext-raw-2
      └── metric-report-raw-data-2024-01-05__22_52_44-pytest-junit-main-amd64-2.csv
  
  2 directories, 2 files
  Moving artifact to target/metrics-raw
  content of target/metrics-raw:
  target/metrics-raw
  ├── pro-integration-test-metric-report-raw-data-2024-01-05__22_50_52-pytest-junit-main-amd64-1.csv
  └── pro-integration-test-metric-report-raw-data-2024-01-05__22_52_44-pytest-junit-main-amd64-2.csv
  
  0 directories, 2 files
  Done.
  ```

The final output for these two test cases looks the same as the final output in the last successful run of the action:
https://github.com/localstack/docs/actions/runs/7375052319/job/20066182679

### GitHub Actions
I also triggered the action from this PR's branch, which was successful and is looking good (to me?):
https://github.com/localstack/docs/actions/runs/7444837936/job/20251973267
The action execution resulted in this PR: https://github.com/localstack/docs/pull/1006
However, I closed the PR because it proposed the changes based on / targeting this branch (instead of `main`).