### PR TITLE
Update Kafka version to 2.8.0

### DIFF
--- a/content/en/user-guide/aws/managed-streaming-for-kafka/index.md
+++ b/content/en/user-guide/aws/managed-streaming-for-kafka/index.md
@@ -41,7 +41,7 @@ Run the following command to create the cluster:
 $ awslocal kafka create-cluster \
     --cluster-name "EventsCluster" \
     --broker-node-group-info file://brokernodegroupinfo.json \
-    --kafka-version "2.2.1" \
+    --kafka-version "2.8.0" \
     --number-of-broker-nodes 3
 {{< / command >}}
 
@@ -97,11 +97,11 @@ To use LocalStack MSK, you can download and utilize the Kafka command line inter
 To download Apache Kafka, execute the following commands.
 
 {{< command >}}
-$ wget https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz
-$ tar -xzf kafka_2.12-2.2.1.tgz
+$ wget https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz
+$ tar -xzf kafka_2.12-2.8.0.tgz
 {{< / command >}}
 
-Navigate to the **kafka_2.12-2.2.1** directory. Execute the following command, replacing `ZookeeperConnectString` with the value you saved after running the [`DescribeCluster`](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#DescribeCluster) API:
+Navigate to the **kafka_2.12-2.8.0.tgz** directory. Execute the following command, replacing `ZookeeperConnectString` with the value you saved after running the [`DescribeCluster`](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#DescribeCluster) API:
 
 {{< command >}}
 $ bin/kafka-topics.sh \

--- a/content/en/user-guide/aws/managed-streaming-for-kafka/index.md
+++ b/content/en/user-guide/aws/managed-streaming-for-kafka/index.md
@@ -101,7 +101,7 @@ $ wget https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz
 $ tar -xzf kafka_2.12-2.8.0.tgz
 {{< / command >}}
 
-Navigate to the **kafka_2.12-2.8.0.tgz** directory. Execute the following command, replacing `ZookeeperConnectString` with the value you saved after running the [`DescribeCluster`](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#DescribeCluster) API:
+Navigate to the **kafka_2.12-2.8.0** directory. Execute the following command, replacing `ZookeeperConnectString` with the value you saved after running the [`DescribeCluster`](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#DescribeCluster) API:
 
 {{< command >}}
 $ bin/kafka-topics.sh \


### PR DESCRIPTION
This will address the issue of Kafka cluster interaction being broken due to the mismatch between the versions of Kafka in LocalStack and the version mentioned in the documentation.