### PR TITLE
re-enable edit link

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -43,9 +43,9 @@
     
     
   <div class="toc-title">Improve our documentation</div>
-  {{/*  <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
+  {{/*  <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>  */}}
   <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
-  <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>  */}}
+  {{/*  <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>  */}}
   <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
   {{ with $gh_project_repo -}}
     {{ $project_issueURL := printf "%s/issues/new" . -}}


### PR DESCRIPTION
## Motivation
In the past, we decided to remove the edit button from the docs pages.
But recently, we have seen that it might be useful to have a fast and easy way to propose changes to the docs.
This PR re-enables the edit button, which has been disabled in a rework of the sidebar in https://github.com/localstack/docs/pull/528 by @lukqw.
This should be used as the start of a discussion, and we can use the preview environment to play around with it.
I used the preview environment to create a short screencast of the feature used to create https://github.com/localstack/docs/pull/1031:
[Screencast.webm](https://github.com/localstack/docs/assets/2796604/a5ab8287-2588-4787-83ed-c8e054f3b040)

~~I explicitly made this a draft PR for now to make sure that we explicitly decide on re-enabling this feature.~~
Since there isn't really an argument against re-enabling the button, I'm changing the PR from draft to ready fro review.

## Changes
- Re-enables the "Edit this page" link on each page.