### PR TITLE
add example for DLQ redrive testing

### DIFF
--- a/content/en/user-guide/aws/sqs/index.md
+++ b/content/en/user-guide/aws/sqs/index.md
@@ -110,7 +110,7 @@ $ awslocal sqs purge-queue --queue-url http://sqs.us-east-1.localhost.localstack
 ## Dead-letter queue testing
 
 LocalStack's SQS implementation supports both regular [dead-letter queues (DLQ)](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) and [DLQ redrive](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-dead-letter-queue-redrive.html) via move message tasks.
-Here's an end-to-end example of how to use message move tasks to test DQL redrive.
+Here's an end-to-end example of how to use message move tasks to test DLQ redrive.
 
 First, create three queues. One will serve as original input queue, one as DLQ, and the third as target for DLQ redrive.
 {{< command >}}

--- a/content/en/user-guide/aws/sqs/index.md
+++ b/content/en/user-guide/aws/sqs/index.md
@@ -112,7 +112,7 @@ $ awslocal sqs purge-queue --queue-url http://sqs.us-east-1.localhost.localstack
 LocalStack's SQS implementation supports both regular [dead-letter queues (DLQ)](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) and [DLQ redrive](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-dead-letter-queue-redrive.html) via move message tasks.
 Here's an end-to-end example of how to use message move tasks to test DQL redrive.
 
-First, create three queues. One will serve as original input queue, one as DLQ, and the third as target for DQL redrive.
+First, create three queues. One will serve as original input queue, one as DLQ, and the third as target for DLQ redrive.
 {{< command >}}
 $ awslocal sqs create-queue --queue-name input-queue
 $ awslocal sqs create-queue --queue-name dead-letter-queue


### PR DESCRIPTION
Adds documentation for https://github.com/localstack/localstack/pull/9988. I added a complete end-to-end example on DLQ testing.

I did feel this is somewhat of a slippery slope towards replicating the AWS docs, but I think having the full example helps showcase how sophisticated the implementation is :+1: 