### PR TITLE
add chaos engineering samples

### DIFF
--- a/data/developerhub/applications.json
+++ b/data/developerhub/applications.json
@@ -272,6 +272,32 @@
       "complexity": ["intermediate"],
       "pro": false,
       "cloudpods": false
+    },
+    {
+      "title": "Route53 Failover with FIS",
+      "description": "LocalStack's integration of Fault Injection Simulator (FIS) with Route53 enables automatic user diversion to a secondary zone during primary region failures, enhancing system resilience and ensuring uninterrupted service.",
+      "url": "https://github.com/localstack-samples/samples-chaos-engineering/tree/main/route53-failover",
+      "teaser": "https://raw.githubusercontent.com/localstack-samples/samples-chaos-engineering/main/route53-failover/images/route53-product-stack.png",
+      "services": ["ddb", "lmb", "agw", "r53", "fis"],
+      "deployment": ["awscli"],
+      "platform": ["java","python"],
+      "tags": ["chaos-engineering", "dns-failover", "fault-injection"],
+      "complexity": ["advanced"],
+      "pro": true,
+      "cloudpods": false
+    },
+    {
+      "title": "Building resilient systems with API Gateway, Lambda, DynamoDB and FIS",
+      "description": "Using AWS Fault Injection Simulator (FIS) for controlled DynamoDB outages, this test demonstrates software resilience by implementing queuing strategies to handle database downtime and maintain system operations.",
+      "url": "https://github.com/localstack-samples/samples-chaos-engineering/tree/main/FIS-experiments",
+      "teaser": "https://github.com/localstack-samples/samples-chaos-engineering/blob/main/FIS-experiments/images/dark-fis-after-sqs.png?raw=true",
+      "services": ["ddb", "lmb", "agw", "fis"],
+      "deployment": ["awscli"],
+      "platform": ["java"],
+      "tags": ["chaos-engineering", "fault-injection"],
+      "complexity": ["advanced"],
+      "pro": true,
+      "cloudpods": false
     }
   ]
 }

--- a/data/developerhub/platforms.json
+++ b/data/developerhub/platforms.json
@@ -5,5 +5,6 @@
   "typescript": "Typescript",
   "go": "Golang",
   "docker": "Docker",
-  "html": "HTML"
+  "html": "HTML",
+  "dotnet": ".NET"
 }

--- a/data/developerhub/services.json
+++ b/data/developerhub/services.json
@@ -53,5 +53,8 @@
   "mwaa": "Managed Apache Airflow",
   "qldb": "QLDB",
   "trc": "Transcribe",
-  "msk": "MSK"
+  "msk": "MSK",
+  "r53": "Route53",
+  "fis": "Fault Injection Simulator",
+  "farg": "Fargate"
 }


### PR DESCRIPTION
Add Route53 failover with FIS & Building resilient systems with FIS experiments, for now.
I excluded the extension for now, as it uses the Pet/Food Store sample, and it's not a standalone example.