### PR TITLE
add a changelog page

### DIFF
--- a/content/en/getting-started/changelog.md
+++ b/content/en/getting-started/changelog.md
@@ -1,0 +1,29 @@
+---
+title: "Changelog"
+linkTitle: "Changelog"
+weight: 70
+description: >
+  This page lists new features, highlights, and bug fixes for official LocalStack releases.
+cascade:
+  type: docs
+---
+
+## Introduction
+
+This page documents the release notes for official LocalStack major and minor releases since LocalStack v1.0.0.  If you're looking for information about nightly releases, beta features, or experimental features, pull the [latest Docker image]({{< ref "docker-images" >}}). The changelog is updated with every release. Updates that affect only LocalStack Web Application or features in beta or limited release may not be reflected.
+
+## Official Releases
+
+| Version  | Release Date       | Release Notes                                                                                      |
+|----------|--------------------|----------------------------------------------------------------------------------------------------|
+| `v3.1.0` | January 25, 2024   | [v3.1.0](https://discuss.localstack.cloud/t/localstack-release-v3-1-0/713/2)                       |
+| `v3.0.0` | November 16, 2023  | [v3.0.0](https://blog.localstack.cloud/2023-11-16-announcing-localstack-30-general-availability/)  |
+| `v2.3.0` | September 29, 2023 | [v2.3.0](https://discuss.localstack.cloud/t/localstack-release-v2-3-0/533)                         |
+| `v2.2.0` | July 20, 2023      | [v2.2.0](https://discuss.localstack.cloud/t/localstack-release-v2-2-0/424)                         |
+| `v2.1.0` | May 25, 2023       | [v2.1.0](https://discuss.localstack.cloud/t/localstack-release-v2-1-0/357)                         |
+| `v2.0.0` | March 30, 2023     | [v2.0.0](https://blog.localstack.cloud/2023-03-29-announcing-localstack-2.0-general-availability/) |
+| `v1.4.0` | February 13, 2023  | [v1.4.0](https://discuss.localstack.cloud/t/localstack-release-v1-4-0/214/1)                       |
+| `v1.3.0` | December 1, 2022   | [v1.3.0](https://discuss.localstack.cloud/t/localstack-release-v1-3-0/170)                         |
+| `v1.2.0` | October 8, 2022    | [v1.2.0](https://discuss.localstack.cloud/t/localstack-release-v1-2-0/109)                         |
+| `v1.1.0` | September 3, 2022  | [v1.1.0](https://discuss.localstack.cloud/t/localstack-release-v1-1-0/89)                          |
+| `v1.0.0` | July 13, 2022      | [v1.0.0](https://blog.localstack.cloud/2022-07-13-announcing-localstack-v1-general-availability/)  |

--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -1,7 +1,7 @@
 ---
 title: "Changelog"
 linkTitle: "Changelog"
-weight: 70
+weight: 12
 description: >
   This page lists new features, highlights, and bug fixes for official LocalStack releases.
 cascade:

--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -16,7 +16,7 @@ This page documents the release notes for official LocalStack major and minor re
 
 | Version  | Release Date       | Release Notes                                                                                      |
 |----------|--------------------|----------------------------------------------------------------------------------------------------|
-| `v3.1.0` | January 25, 2024   | [v3.1.0](https://discuss.localstack.cloud/t/localstack-release-v3-1-0/713/2)                       |
+| `v3.1.0` | January 25, 2024   | [v3.1.0](https://discuss.localstack.cloud/t/localstack-release-v3-1-0/713/)                       |
 | `v3.0.0` | November 16, 2023  | [v3.0.0](https://blog.localstack.cloud/2023-11-16-announcing-localstack-30-general-availability/)  |
 | `v2.3.0` | September 29, 2023 | [v2.3.0](https://discuss.localstack.cloud/t/localstack-release-v2-3-0/533)                         |
 | `v2.2.0` | July 20, 2023      | [v2.2.0](https://discuss.localstack.cloud/t/localstack-release-v2-2-0/424)                         |


### PR DESCRIPTION
I was looking into docs analytics today and saw some folks have been looking for a Changelog on our docs. Currently, we have changelogs on Discuss for our minor releases. 

This PR:

- Adds a new changelog page
- Links it over the references section
- Documents every single major & minor release since 1.0