### PR TITLE
Update FAQ page on internet connectivity

### DIFF
--- a/content/en/getting-started/faq.md
+++ b/content/en/getting-started/faq.md
@@ -103,9 +103,18 @@ environment:
 
 You might be able to connect to the internet, but your Docker container can't connect. This can affect start of LocalStack.
 
-More details can be found on [official docker documentation](https://docs.docker.com/network/bridge/#enable-forwarding-from-docker-containers-to-the-outside-world).
+Please ensure that you are not using the `none` network driver when starting your docker container.
+More details about the default bridge network can be found on [official docker documentation](https://docs.docker.com/network/bridge).
 
-Solution for this is enabling the IP forwarding:
+Please also ensure that the docker container has an assigned IP address, by running:
+
+```bash
+docker inspect <container-name> | jq -r '.[0].NetworkSettings.Networks | to_entries | .[].value.IPAddress'
+```
+
+At least one IP address should be returned.
+
+If you are using Linux, ensure that you have enabled IP forwarding:
 
 ```bash
 sudo sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
# Motivation

The FAQ item for "Why is it that LocalStack is unable to connect to the internet" could do with expanding upon. It only suggests one thing, and links to outdated documentation.

# Changes

* Mention the `none` network driver, and ensure users are not using it
* Describe debugging the connectivity with `docker inspect ... ` and check for IP addresses
* Update the documentation to mention the bridge network specifically

# Limitations

Unfortunatley this is such a general question, and is not really in the scope of LocalStack, it is a docker networking problem. This means
* if we provide an FAQ item, we cannot cover all options
* perhaps this item should be removed, as it is not a LocalStack specific problem?
