### PR TITLE
Document ECS_DISABLE_AWS_ENDPOINT_URL

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -119,6 +119,7 @@ This section covers configuration options that are specific to certain AWS servi
 | - | - | - |
 | `ECS_REMOVE_CONTAINERS` | `0`\|`1` (default) | Remove Docker containers associated with ECS tasks after execution. Disabling this and dumping container logs might help with troubleshooting failing ECS tasks. |
 | `ECS_DOCKER_FLAGS` | `--privileged`, `--dns 1.2.3.4` | Additional flags passed to Docker when creating ECS task containers. Same restrictions as `LAMBDA_DOCKER_FLAGS`. |
+| `ECS_DISABLE_AWS_ENDPOINT_URL` | `0` (default) \| `1` | Whether to disable injecting the environment variable `AWS_ENDPOINT_URL`, which automatically configures [supported AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html). |
 
 ### EC2
 


### PR DESCRIPTION
An upcoming feature of ECS is that we will inject `AWS_ENDPOINT_URL` into the users' container environment. This is a change to the defaults, so we must provide a configuration flag (`ECS_DISABLE_AWS_ENDPOINT_URL`) to restore the previous behaviour. 

This change documents that new flag, taking inspiration (i.e. copied from) the `LAMBDA_DISABLE_AWS_ENDPOINT_URL` variable.
