### PR TITLE
V3.2 docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -209,7 +209,7 @@ enable = true
 
 [params.localstack]
 # LocalStack specific configuration values
-latest_version = "3.1.0"
+latest_version = "3.2.0"
 
 [params.localstack.cli_links]
 # Configure the different download links for the cli-binary-download shortcode

--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -16,6 +16,7 @@ This page documents the release notes for official LocalStack major and minor re
 
 | Version  | Release Date       | Release Notes                                                                                      |
 |----------|--------------------|----------------------------------------------------------------------------------------------------|
+| `v3.2.0` | February 29, 2024   | [v3.2.0](https://discuss.localstack.cloud/t/localstack-release-v3-2-0/782/)                       |
 | `v3.1.0` | January 25, 2024   | [v3.1.0](https://discuss.localstack.cloud/t/localstack-release-v3-1-0/713/)                       |
 | `v3.0.0` | November 16, 2023  | [v3.0.0](https://blog.localstack.cloud/2023-11-16-announcing-localstack-30-general-availability/)  |
 | `v2.3.0` | September 29, 2023 | [v2.3.0](https://discuss.localstack.cloud/t/localstack-release-v2-3-0/533)                         |

--- a/content/en/tutorials/lambda-ecr-container-images/index.md
+++ b/content/en/tutorials/lambda-ecr-container-images/index.md
@@ -77,7 +77,7 @@ COPY ./handler.py ./
 CMD [ "handler.handler" ]
 ```
 
-{{< alert title="Note" color="primary">}}
+{{< alert title="Note">}}
 If your Lambda function has additional dependencies, create a file named `requirements.txt` in the same directory as the Dockerfile. List the required libraries in this file. You can install these dependencies in the `Dockerfile` under the `${LAMBDA_TASK_ROOT}` directory.
 {{< /alert >}}
 
@@ -119,7 +119,7 @@ $ awslocal ecr create-repository --repository-name localstack-lambda-container-i
 }
 {{< / command >}}
 
-{{< alert title="Note" color="primary">}}
+{{< alert title="Note">}}
 To further customize the ECR repository, you can pass additional flags to the `create-repository` command. For more details on the available options, refer to the [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/reference/ecr/create-repository.html).
 {{< /alert >}}
 
@@ -158,7 +158,7 @@ By running this command, you can confirm that the image is now in the ECR reposi
 
 To deploy the container image as a Lambda function, we will create a new Lambda function using the `create-function` command. Run the following command to create the function:
 
-{{< alert title="Note" color="primary">}}
+{{< alert title="Note">}}
 Before creating the lambda function, please double check under which architecture you have built your image. If your image is built as arm64, you need to specify the lambda architecture when deploying or set `LAMBDA_IGNORE_ARCHTIECTURE=1` when starting LocalStack.
 More information can be found [in our documentation regarding ARM support.]({{< ref "arm64-support" >}})
 {{< /alert >}}

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -231,7 +231,7 @@ This behaviour can be controlled using the `EC2_DOWNLOAD_DEFAULT_IMAGES` configu
 
 {{< alert title="Note" >}}
 LocalStack will no longer provide the Ubuntu 20.04 Docker AMI by default in the next major release. It can still be manually added.
-{{< /alert >}
+{{< /alert >}}
 
 All LocalStack-managed Docker AMIs bear the resource tag `ec2_vm_manager:docker`.
 These AMIs can be listed using:

--- a/content/en/user-guide/aws/elastic-compute-cloud/index.md
+++ b/content/en/user-guide/aws/elastic-compute-cloud/index.md
@@ -229,6 +229,9 @@ This behaviour can be controlled using the `EC2_DOWNLOAD_DEFAULT_IMAGES` configu
 - Ubuntu 22.04 `ami-df5de72bdb3b`
 - Amazon Linux 2023 `ami-024f768332f0`
 
+{{< alert title="Note" >}}
+LocalStack will no longer provide the Ubuntu 20.04 Docker AMI by default in the next major release. It can still be manually added.
+{{< /alert >}
 
 All LocalStack-managed Docker AMIs bear the resource tag `ec2_vm_manager:docker`.
 These AMIs can be listed using:

--- a/content/en/user-guide/aws/mwaa/index.md
+++ b/content/en/user-guide/aws/mwaa/index.md
@@ -57,9 +57,9 @@ LocalStack will create the Airflow environment and print the Airflow UI URL and 
 
 LocalStack supports the following versions of Apache Airflow:
 
-- `1.10.12`
-- `2.0.2`
-- `2.2.2`
+- `1.10.12` (deprecated)
+- `2.0.2` (deprecated)
+- `2.2.2` (deprecated)
 - `2.4.3`
 - `2.5.1`
 - `2.6.3`

--- a/content/en/user-guide/aws/opensearch/index.md
+++ b/content/en/user-guide/aws/opensearch/index.md
@@ -7,7 +7,11 @@ description: >
 
 ## Introduction
 
-OpenSearch Service is an open-source search and analytics engine, offering developers and organizations advanced search capabilities, robust data analysis, and insightful visualizations. OpenSearch Service also offers log analytics, real-time application monitoring, and clickstream analysis. The following versions of OpenSearch Service are supported by LocalStack:
+OpenSearch Service is an open-source search and analytics engine, offering developers and organizations advanced search capabilities, robust data analysis, and insightful visualizations. OpenSearch Service also offers log analytics, real-time application monitoring, and clickstream analysis.
+
+LocalStack supports OpenSearch Service via the Community offering, allowing you to use the OpenSearch Service APIs in your local environment to create, manage, and operate the OpenSearch clusters. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_opensearch/), which provides information on the extent of OpenSearch's integration with LocalStack.
+
+The following versions of OpenSearch Service are supported by LocalStack:
 
 - 1.0
 - 1.1
@@ -15,9 +19,8 @@ OpenSearch Service is an open-source search and analytics engine, offering devel
 - 1.3
 - 2.3
 - 2.7
-- 2.9 (**default**)
-
-LocalStack supports OpenSearch Service via the Community offering, allowing you to use the OpenSearch Service APIs in your local environment to create, manage, and operate the OpenSearch clusters. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_opensearch/), which provides information on the extent of OpenSearch's integration with LocalStack. 
+- 2.9
+- 2.11 (**default**)
 
 OpenSearch is closely coupled with the [Elasticsearch Service](../elasticsearch). Clusters generated through the OpenSearch Service will be visible within the Elasticsearch Service interface, and vice versa. You can select an Elasticsearch version with the `--engine-version` parameter while creating an OpenSearch Service domain.
 

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -132,7 +132,7 @@ However, if the endpoint is not prefixed by `s3.`, LocalStack will not be able t
 You can either change the endpoint to an S3-specific one, or configure your SDK to use **Path style** requests instead.
 Check out our [SDK documentation](https://docs.localstack.cloud/user-guide/integrations/sdks/) to learn how you can configure language SDKs to access LocalStack and S3.
 
-{{< alert title="S3 Force Path Style" >}}
+{{< alert title="Note" >}}
 While using [AWS language SDKs](https://aws.amazon.com/developer/tools/#SDKs), you would need to configure the `ForcePathStyle` parameter to `true` in the S3 client configuration to use **Path style** requests. If you want to use virtual host addressing of buckets, you can remove `ForcePathStyle` from the configuration.
 The `ForcePathStyle` parameter name can vary between SDK and languages, please check our [SDK documentation](https://docs.localstack.cloud/user-guide/integrations/sdks/)
 {{< /alert >}}

--- a/content/en/user-guide/aws/sqs/index.md
+++ b/content/en/user-guide/aws/sqs/index.md
@@ -286,7 +286,7 @@ You can enable this behavior in LocalStack by setting the `SQS_ENABLE_MESSAGE_RE
 In AWS, valid values for message retention range from 60 (1 minute) to 1,209,600 (14 days).
 In LocalStack, we do not put constraints on the value which can be helpful for test scenarios.
 
-{{<alert>}}
+{{<alert title="Note">}}
 Note that, if you enable this option, [persistence]({{< ref "persistence" >}}) or [cloud pods]({{<ref "user-guide/state-management/cloud-pods" >}}) for SQS may not work as expected.
 The reason is that, LocalStack does not adjust timestamps when restoring a state, so time appears to pass between LocalStack runs.
 Consequently, when you restart LocalStack after a period that is longer than the message retention period, LocalStack will remove all those messages when SQS starts.


### PR DESCRIPTION
This PR:

- Adds note about the new OpenSearch version
- Adds note about deprecated EC2 AMI 
- Marks deprecated Airflow versions in MWAA