### PR TITLE
Fix typo in documentation, closes #1100

### DIFF
--- a/content/en/getting-started/auth-token/index.md
+++ b/content/en/getting-started/auth-token/index.md
@@ -19,7 +19,7 @@ The Auth Token remains unchanged unless manually rotated by the user, regardless
 
 ## Managing your License
 
-To use LocalStack, a license is required. You can get a license by registering on the [LocalStack Web Application](https://app.localstack.cloud/sign-up).Choose between a 14-day trial or explore additional features with our [paid offerring](https://app.localstack.cloud/pricing). During the trial period, you are welcome to use all the features of LocalStack.
+To use LocalStack, a license is required. You can get a license by registering on the [LocalStack Web Application](https://app.localstack.cloud/sign-up).Choose between a 14-day trial or explore additional features with our [paid offering](https://app.localstack.cloud/pricing). During the trial period, you are welcome to use all the features of LocalStack.
 
 After initiating your trial or acquiring a license, proceed to assign it to a user by following the steps outlined below:
 


### PR DESCRIPTION
In this page's "Managing your License" section: https://docs.localstack.cloud/getting-started/auth-token/, there was a typo in the word "offering," which included an extra 'r.' I have corrected this typo.