### PR TITLE
Update index.md

### DIFF
--- a/content/en/user-guide/integrations/aws-cli/index.md
+++ b/content/en/user-guide/integrations/aws-cli/index.md
@@ -82,7 +82,7 @@ Alternatively, you can also set the `AWS_PROFILE=localstack` environment variabl
 Install the `awslocal` command using the following command:
 
 {{< command >}}
-$ pip install awscli-local[ver1]
+$ pip install "awscli-local[ver1]"
 {{< / command >}}
 
 {{< alert title="Note" >}}


### PR DESCRIPTION
I think you need to put quotes around the package name when there is an additional square brackets(`[]`) attached to it. 

Reference: https://pip.pypa.io/en/stable/user_guide/#installing-from-wheels

> To include optional dependencies provided in the provides_extras metadata in the wheel, you must add quotes around the install target name: