### PR TITLE
add cross accounts and region testing in LS docs

### DIFF
--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -11,7 +11,7 @@ We regularly run the circleci test jobs of the LocalStack community repository t
 
 ## Manually trigger the workflow
 
-To manually trigger the scheduled workflow, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
+To manually trigger the scheduled workflow in case you have the permissions, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
 
 {{< alert title="Note">}}
 Make sure to change the value back to `false` after the tests are completed. 
@@ -19,7 +19,7 @@ Make sure to change the value back to `false` after the tests are completed.
 
 ## Test changes locally with non-default credentials
 
-In order to test your changes on your machine for multi-accounts and region compatibility, i.e. for non-default values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
+In order to test your changes on your machine for multi-accounts and region compatibility in case you have the permissions, i.e. for non-default values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
 
 - `TEST_AWS_ACCOUNT_ID=111111111111`
 - `TEST_AWS_ACCESS_KEY_ID=111111111111`

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -13,11 +13,11 @@ This document describes how to test your changes for compatibility with cross-ac
 In order to make your changes compatible with multi-account and multi-region, you should follow the below tips:
 
 - For cross-account, in inter-service-communication for many integrations, you can specify a role, with which permissions the source service makes a request to the target service, to access another service's resource. 
-This role should be in source account. 
+This role should be in the source account.
 When writing an AWS validated test case, you need to properly configure IAM roles.
 
     For example: 
-    In the test case `test_api_gateway_kinesis_integration` we have specified a [role](https://github.com/localstack/localstack/blob/ae31f63bb6d8254edc0c85a66e3c36cd0c7dc7b0/tests/aws/services/apigateway/test_apigateway_basic.py#L2017-L2022) in the apigateway which has permissions to access the target kinesis account.
+    In the test case [`test_api_gateway_kinesis_integration`](https://github.com/localstack/localstack/blob/0c2d8a103a9a06ade4ef1c18eacf5888d2b8adcf/tests/aws/services/apigateway/test_apigateway_basic.py#L2047) we have specified a [role](https://github.com/localstack/localstack/blob/ae31f63bb6d8254edc0c85a66e3c36cd0c7dc7b0/tests/aws/services/apigateway/test_apigateway_basic.py#L2017-L2022) which has permissions to access the target kinesis account.
     ```python
     result = self.connect_api_gateway_to_kinesis(
             client,
@@ -54,18 +54,17 @@ When writing an AWS validated test case, you need to properly configure IAM role
 
 ## Test changes in CI with non-default credentials
 
-We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross-account against the changes. 
-To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credentials every night at 1:00am UTC.
+We regularly run the CircleCI test jobs of the LocalStack repository to check the compatibility of cross-account against the changes. 
+To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomized account and region credentials every night at 1:00am UTC.
 
-To manually trigger the scheduled workflow through circleci UI(in case you have the permissions), in order to test your changes with randomised account and region credentials, you can perform the following steps: 
-- Go to the [localStack](https://app.circleci.com/pipelines/github/localstack/localstack) project repository on circleci UI.
-- Select a branch for which you want to trigger the scheduled workflow from the filters section.
+To manually trigger the workflow through the webinterface of CircleCI (in case you have the permissions), in order to test your changes with randomized account and region credentials, you can perform the following steps: 
+- Go to the [localStack](https://app.circleci.com/pipelines/github/localstack/localstack) project repository on CircleCI.
+- Select a branch for which you want to trigger the workflow from the filters section.
 - Now click on the `Trigger pipeline` button on the right and add the following variables:
     1. Parameter type to `string`
     2. Name to `randomize-aws-credentials`
     3. Value to `true`
-
-and press the `Trigger pipeline` button to trigger the workflow.
+- Press the `Trigger pipeline` button to trigger the workflow.
 
 ## Test changes locally with non-default credentials
 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -21,7 +21,7 @@ Make sure to change the value back to `false` after the tests are completed.
 
 ## Test changes locally with non-default credentials
 
-In order to test your changes on your machine for multi-accounts and region compatibility, i.e. for values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
+In order to test your changes on your machine for multi-accounts and region compatibility, i.e. for non-default values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
 
 - `TEST_AWS_ACCOUNT_ID=111111111111`
 - `TEST_AWS_ACCESS_KEY_ID=111111111111`

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -31,5 +31,5 @@ In order to test your changes on your machine for multi-accounts and region comp
 We can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes.
 
 {{< alert title="Note">}}
-Make sure to revert these chnages after the tests are completed. 
+Make sure to revert these changes after the tests are completed. 
 {{< /alert >}}

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -1,0 +1,26 @@
+---
+title: "Multiple account and region Testing"
+weight: 7
+description: >
+  How to test multi-account and multi-region compatibility.
+aliases:
+  - /developer-guide/multi-account-region-testing/
+---
+
+We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
+
+## Manually trigger the scheduled workflow
+
+To manually trigger the scheduled workflow, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
+
+
+## Test changes locally with non-default credentials
+
+In order to test your changes on your machine for multi-accounts and region compatibility, i.e. for values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
+
+- `TEST_AWS_ACCOUNT_ID=111111111111`
+- `TEST_AWS_ACCESS_KEY_ID=111111111111`
+- `TEST_AWS_REGION=us-west-1`
+- `TEST_AWS_SECRET_ACCESS_KEY=test1`
+
+We can additionally prefer to create a commit eg:[da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials.

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -7,6 +7,8 @@ aliases:
   - /developer-guide/multi-account-region-testing/
 ---
 
+LocalStack community supports multiple accounts and regions compatibity. This document describes how to test your changes against cross accounts and regions.
+
 We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
 
 ## Manually trigger the scheduled workflow

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -1,5 +1,5 @@
 ---
-title: "Multi account and region testing"
+title: "Multi-account and Multi-region Testing"
 weight: 8
 description: >
   How to test multi-account and multi-region compatibility.
@@ -10,13 +10,52 @@ This document describes how to test your changes against cross accounts and regi
 
 We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credentials every night at 1:00am UTC.
 
+
+## Tips to make your changes compatible with multi-accounts and regions
+
+In order to make your changes compatible with multi-accounts and regions, you should follow the below tips:
+
+- For cross accounts, in inter service communication for many integrations, you can specify a role, with which permissions the source service makes a request to the target service, to access other services resource. This role should be in source account. When writing an AWS validated test case, you need to properly configure IAM roles. 
+
+    For example: 
+    In the test case `test_api_gateway_kinesis_integration` we have specified a [role](https://github.com/localstack/localstack/blob/ae31f63bb6d8254edc0c85a66e3c36cd0c7dc7b0/tests/aws/services/apigateway/test_apigateway_basic.py#L2017-L2022) in the apigateway which has permissions to access the target kinesis account.
+    ```python
+    result = self.connect_api_gateway_to_kinesis(
+            client,
+            api_name,
+            stream_name,
+            region_name,
+            role_arn,
+        )
+    ```
+
+- While having an inter service communication in cross-accounts, you can create the client using `with_assumed_role(…)`:
+
+    For example:
+    ```python
+    result = self.connect_api_gateway_to_kinesis(
+            client,
+            api_name,
+            stream_name,
+            region_name,
+            role_arn,
+        )
+    ```
+    
+- When there is no role specified, you should use the source arn conceptually if cross-account is allowed. 
+
+    For example:
+    This can be seen in a case where we [added](https://github.com/localstack/localstack/blob/ae31f63bb6d8254edc0c85a66e3c36cd0c7dc7b0/localstack/utils/aws/message_forwarding.py#L42) `account_id` to [send events to the target](https://github.com/localstack/localstack/blob/ae31f63bb6d8254edc0c85a66e3c36cd0c7dc7b0/localstack/utils/aws/message_forwarding.py#L31) service like sqs, sns, lambda, etc. 
+
+- You should always refer the official AWS API docs and check how the the application is communicating to each other. 
+    
+    For example: 
+    Firehose to s3 refer to [Offical AWS Docs](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#cross-account-delivery-s3).
+
+
 ## Manually trigger the workflow
 
 To manually trigger the scheduled workflow in case you have the permissions, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
-
-{{< alert title="Note">}}
-Make sure to change the value back to `false` after the tests are completed. 
-{{< /alert >}}
 
 ## Test changes locally with non-default credentials
 
@@ -27,7 +66,7 @@ In order to test your changes on your machine for multi-accounts and region comp
 - `TEST_AWS_REGION=us-west-1`
 - `TEST_AWS_SECRET_ACCESS_KEY=test1`
 
-You can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes.
+You can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes. Note that within the tests we must use `account_id`, `secondary_account_id`, `region_name`, `secondary_region_name` fixtures and avoid importing `localstack.constants.TEST_*` values. 
 
 {{< alert title="Note">}}
 Make sure to revert these changes after the tests are completed. 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -1,13 +1,11 @@
 ---
-title: "Multiple account and region Testing"
+title: "Multi account and region testing"
 weight: 7
 description: >
   How to test multi-account and multi-region compatibility.
-aliases:
-  - /developer-guide/multi-account-region-testing/
 ---
 
-LocalStack community supports multiple accounts and regions compatibility. This document describes how to test your changes against cross accounts and regions.
+LocalStack community supports multi accounts and regions compatibility. This document describes how to test your changes against cross accounts and regions.
 
 We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
 
@@ -28,7 +26,7 @@ In order to test your changes on your machine for multi-accounts and region comp
 - `TEST_AWS_REGION=us-west-1`
 - `TEST_AWS_SECRET_ACCESS_KEY=test1`
 
-We can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes.
+You can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes.
 
 {{< alert title="Note">}}
 Make sure to revert these changes after the tests are completed. 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -60,10 +60,10 @@ To achieve that, we have a [scheduled workflow](https://github.com/localstack/lo
 To manually trigger the scheduled workflow through circleci UI(in case you have the permissions), in order to test your changes with randomised account and region credentials, you can perform the following steps: 
 - Go to the [localStack](https://app.circleci.com/pipelines/github/localstack/localstack) project repository on circleci UI.
 - Select a branch for which you want to trigger the scheduled workflow from the filters section.
-- Now click on the `Trigger pipeline` button on the right and add the following parameter:
-    1. `Parameter type`: `string`
-    2. `Name`: `randomize-aws-credentials`
-    3. `Value`: `true`
+- Now click on the `Trigger pipeline` button on the right and add the following variables:
+    1. Parameter type to `string`
+    2. Name to `randomize-aws-credentials`
+    3. Value to `true`
 
 and press the `Trigger pipeline` button to trigger the workflow.
 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -62,7 +62,7 @@ To manually trigger the scheduled workflow through circleci UI(in case you have 
 - Select a branch for which you want to trigger the scheduled workflow from the filters section.
 - Now click on the `Trigger pipeline` button on the right and add the following parameter:
     1. `Parameter type`: `string`
-    2.  `Name`: `randomize-aws-credentials`
+    2. `Name`: `randomize-aws-credentials`
     3. `Value`: `true`
 
 and press the `Trigger pipeline` button to trigger the workflow.

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -15,7 +15,6 @@ We regularly run the circleci test jobs of the LocalStack community repository t
 
 To manually trigger the scheduled workflow, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
 
-
 ## Test changes locally with non-default credentials
 
 In order to test your changes on your machine for multi-accounts and region compatibility, i.e. for values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -5,7 +5,7 @@ description: >
   How to test multi-account and multi-region compatibility.
 ---
 
-LocalStack community supports multi accounts and regions compatibility. This document describes how to test your changes against cross accounts and regions.
+LocalStack supports multi accounts and regions compatibility. This document describes how to test your changes against cross accounts and regions.
 
 We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -5,17 +5,16 @@ description: >
   How to test multi-account and multi-region compatibility.
 ---
 
-LocalStack supports multi accounts and regions compatibility. 
-This document describes how to test your changes against cross accounts and regions.
+LocalStack supports multi-account and multi-region compatibility. 
+This document describes how to test your changes for compatibility with cross-account and cross-region requests.
 
-We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credentials every night at 1:00am UTC.
+## Tips to make your changes compatible with multi-account and multi-region
 
+In order to make your changes compatible with multi-account and multi-region, you should follow the below tips:
 
-## Tips to make your changes compatible with multi-accounts and regions
-
-In order to make your changes compatible with multi-accounts and regions, you should follow the below tips:
-
-- For cross accounts, in inter service communication for many integrations, you can specify a role, with which permissions the source service makes a request to the target service, to access other services resource. This role should be in source account. When writing an AWS validated test case, you need to properly configure IAM roles. 
+- For cross-account, in inter-service-communication for many integrations, you can specify a role, with which permissions the source service makes a request to the target service, to access another service's resource. 
+This role should be in source account. 
+When writing an AWS validated test case, you need to properly configure IAM roles.
 
     For example: 
     In the test case `test_api_gateway_kinesis_integration` we have specified a [role](https://github.com/localstack/localstack/blob/ae31f63bb6d8254edc0c85a66e3c36cd0c7dc7b0/tests/aws/services/apigateway/test_apigateway_basic.py#L2017-L2022) in the apigateway which has permissions to access the target kinesis account.
@@ -29,7 +28,7 @@ In order to make your changes compatible with multi-accounts and regions, you sh
         )
     ```
 
-- While having an inter service communication in cross-accounts, you can create the client using `with_assumed_role(…)`:
+- While having an inter service communication in cross-account, you can create the client using `with_assumed_role(…)`:
 
     For example:
     ```python
@@ -53,20 +52,32 @@ In order to make your changes compatible with multi-accounts and regions, you sh
     Firehose to s3 refer to [Offical AWS Docs](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#cross-account-delivery-s3).
 
 
-## Manually trigger the workflow
+## Test changes in CI with non-default credentials
 
-To manually trigger the scheduled workflow in case you have the permissions, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
+We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross-account against the changes. 
+To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credentials every night at 1:00am UTC.
+
+To manually trigger the scheduled workflow through circleci UI(in case you have the permissions), in order to test your changes with randomised account and region credentials, you can perform the following steps: 
+- Go to the [localStack](https://app.circleci.com/pipelines/github/localstack/localstack) project repository on circleci UI.
+- Select a branch for which you want to trigger the scheduled workflow from the filters section.
+- Now click on the `Trigger pipeline` button on the right and add the following parameter:
+    1. `Parameter type`: `string`
+    2.  `Name`: `randomize-aws-credentials`
+    3. `Value`: `true`
+
+and press the `Trigger pipeline` button to trigger the workflow.
 
 ## Test changes locally with non-default credentials
 
-In order to test your changes on your machine for multi-accounts and region compatibility in case you have the permissions, i.e. for non-default values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
+In order to test your changes on your machine for multi-account and multi-region compatibility in case you have the permissions, i.e. for non-default values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
 
 - `TEST_AWS_ACCOUNT_ID=111111111111`
 - `TEST_AWS_ACCESS_KEY_ID=111111111111`
 - `TEST_AWS_REGION=us-west-1`
 - `TEST_AWS_SECRET_ACCESS_KEY=test1`
 
-You can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes. Note that within the tests we must use `account_id`, `secondary_account_id`, `region_name`, `secondary_region_name` fixtures and avoid importing `localstack.constants.TEST_*` values. 
+You can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes. 
+Note that within the tests we must use `account_id`, `secondary_account_id`, `region_name`, `secondary_region_name` fixtures and avoid importing `localstack.constants.TEST_*` values. 
 
 {{< alert title="Note">}}
 Make sure to revert these changes after the tests are completed. 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -11,7 +11,7 @@ LocalStack community supports multiple accounts and regions compatibity. This do
 
 We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
 
-## Manually trigger the scheduled workflow
+## Manually trigger the workflow
 
 To manually trigger the scheduled workflow, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -7,7 +7,7 @@ aliases:
   - /developer-guide/multi-account-region-testing/
 ---
 
-LocalStack community supports multiple accounts and regions compatibity. This document describes how to test your changes against cross accounts and regions.
+LocalStack community supports multiple accounts and regions compatibility. This document describes how to test your changes against cross accounts and regions.
 
 We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -25,4 +25,4 @@ In order to test your changes on your machine for multi-accounts and region comp
 - `TEST_AWS_REGION=us-west-1`
 - `TEST_AWS_SECRET_ACCESS_KEY=test1`
 
-We can additionally prefer to create a commit eg:[da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials.
+We can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes.

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -1,13 +1,14 @@
 ---
 title: "Multi account and region testing"
-weight: 7
+weight: 8
 description: >
   How to test multi-account and multi-region compatibility.
 ---
 
-LocalStack supports multi accounts and regions compatibility. This document describes how to test your changes against cross accounts and regions.
+LocalStack supports multi accounts and regions compatibility. 
+This document describes how to test your changes against cross accounts and regions.
 
-We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credenitals every night at 1:00am UTC.
+We regularly run the circleci test jobs of the LocalStack community repository to check the compatibility of cross accounts against the changes. To achieve that, we have a [scheduled workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml) on [LocalStack](https://github.com/localstack/localstack), which executes the tests with randomised account and region credentials every night at 1:00am UTC.
 
 ## Manually trigger the workflow
 

--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -15,6 +15,10 @@ We regularly run the circleci test jobs of the LocalStack community repository t
 
 To manually trigger the scheduled workflow, you can change set the value of `randomize-aws-credentials` to `true` in the [workflow](https://github.com/localstack/localstack/blob/master/.circleci/config.yml#L13). This will trigger the tests with randomised account and region credentials.
 
+{{< alert title="Note">}}
+Make sure to change the value back to `false` after the tests are completed. 
+{{< /alert >}}
+
 ## Test changes locally with non-default credentials
 
 In order to test your changes on your machine for multi-accounts and region compatibility, i.e. for values other than `000000000000` for account ID or `us-east-1` for region, set the following environment variables to any random non-default values, for example:  
@@ -25,3 +29,7 @@ In order to test your changes on your machine for multi-accounts and region comp
 - `TEST_AWS_SECRET_ACCESS_KEY=test1`
 
 We can additionally prefer to create a commit eg: [da3f8d5](https://github.com/localstack/localstack/pull/9751/commits/da3f8d5f2328adb7c5c025722994fea4433c08ba) to test the pipeline for non-default credentials against your changes.
+
+{{< alert title="Note">}}
+Make sure to revert these chnages after the tests are completed. 
+{{< /alert >}}


### PR DESCRIPTION
Localstack now supports multiple accounts and regions compatibility. This document guides the contributors to test their changes against cross accounts and region. 