### PR TITLE
fix: typos in supported services list for persistence page

### DIFF
--- a/content/en/user-guide/state-management/persistence/index.md
+++ b/content/en/user-guide/state-management/persistence/index.md
@@ -116,7 +116,7 @@ Persistence for services that are _not_ listed here _may_ work correctly, but ar
 * AppSync
 * CloudWatch
 * Cognito
-* DynamodDB
+* DynamoDB
 * IAM
 * Kinesis
 * KMS
@@ -124,7 +124,7 @@ Persistence for services that are _not_ listed here _may_ work correctly, but ar
 * RDS: Postgres, MariaDB, MySQL
 * Route53
 * S3
-* SecresManager
+* SecretsManager
 * SNS
 * SQS
 * SSM


### PR DESCRIPTION
Found some minor typos in supported services list for persistence