### PR TITLE
switch term 'version' with 'image'

### DIFF
--- a/layouts/partials/coverage/coverage_table.html
+++ b/layouts/partials/coverage/coverage_table.html
@@ -10,7 +10,7 @@
             <tr>
             <th class="coverage-report-header-1">Operation</th>
             <th class="coverage-report-header-2">Implemented</th>
-            <th class="coverage-report-header-2">Edition</th>
+            <th class="coverage-report-header-2">Image</th>
             <th class="coverage-report-header-1">Internal Test Suite</th>
             {{ if not (eq "lambda" $service) }} 
             <th class="coverage-report-header-1">External Test Suite</th>

--- a/layouts/shortcodes/localstack_coverage_table.html
+++ b/layouts/shortcodes/localstack_coverage_table.html
@@ -8,14 +8,14 @@
 <!-- add links to api reference, and show display name for the service -->
 <a href="{{ $api }}">{{ $display_name }}{{ with $short_name := $service_details.short_name }} ({{ $short_name }}){{ end }}</a> 
  is supported by LocalStack 
-<!-- wording for the supported version -->
+<!-- wording for the supported image -->
 {{ if and ($data.pro_support) ($data.community_support) }}
-    in the <b>community version</b> with additional features available in the <b>pro version</b>.
+    in the <b>community image</b> with additional features available in the <b>pro image</b>.
 {{ else }}
     {{ if $data.pro_support }}
-        <b>only in the pro version</b>.
+        <b>only in the pro image</b>.
     {{ else }}
-       in the <b>community version</b>.
+       in the <b>community image</b>.
     {{ end }}
 {{ end }}
 </div>


### PR DESCRIPTION
For the coverage api we still need to adapt the terminology, as we currently use the wording `Edition` and `version` which both should be replaced with `image`. 

* This PR updates the templates we have that are used to create the individual pages
* The changes can be seen in the preview: https://localstack-docs-preview-pr-1159.surge.sh/references/coverage/

