### PR TITLE
Remove hover underline for headers

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -396,8 +396,10 @@ table tfoot {
     a {
         font-weight: bold
     }
-    a:hover {
-        text-decoration: underline
+    p {
+        a:hover {
+            text-decoration: underline
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR makes a tiny cosmetic fix to links. Earlier the link anchor on headers had an underline when hovered. This PR removes it.

### Before

![image](https://github.com/localstack/docs/assets/5170829/6cb194ef-e202-4bb9-b7ab-deb65954e35a)

### After

![image](https://github.com/localstack/docs/assets/5170829/7a01210b-d346-44c8-860e-17d19776bf76)
