### PR TITLE
add MA / MR pipeline docs for PRs coming from forks

### DIFF
--- a/content/en/contributing/multi-account-region-testing.md
+++ b/content/en/contributing/multi-account-region-testing.md
@@ -50,6 +50,7 @@ There is a [scheduled CircleCI workflow](https://github.com/localstack/localstac
 If you have permissions, this workflow can be manually triggered on CircleCI as follows:
 1. Go to the [LocalStack project on CircleCI](https://app.circleci.com/pipelines/github/localstack/localstack).
 1. Select a branch for which you want to trigger the workflow from the filters section.
+    - For PRs coming from forks, you can select the branch by using the PR number like this: `pull/<pr-number>`
 1. Click on the **Trigger Pipeline** button on the right and use the following values:
     1. Set **Parameter type** to `boolean`
     1. Set **Name** to `randomize-aws-credentials`


### PR DESCRIPTION
## Motivation
The branches of forks are not directly visible in CircleCI.
This can be confusing if you want to run the MA/MR pipeline for community contributions like https://github.com/localstack/localstack/pull/10625.
This PR adds a short explanation on how to trigger pipelines for PRs coming from forks.

## Changes
- Adds a very small section to explain that for PRs coming from community contributions (forked repositories), the PR number can be used.

## Testing
- [CircleCI Docs](https://support.circleci.com/hc/en-us/articles/360049841151-Trigger-Pipelines-on-Forked-Pull-Requests-with-CircleCI-API-v2)
- Tested in our community project's branch selection.