### PR TITLE
Update 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -2,9 +2,8 @@
     <main id="main">
       <div>
        <h1 id="title">Not found</h1>
-       <p>Oops! This page doesn't exist. Try going back to our <a href="{{ "/" | relURL }}">home page</a>.</p>
 
-       <p>You can learn how to make a 404 page like this in <a href="https://gohugo.io/templates/404/">Custom 404 Pages</a>.</p>      
+       <p>This page does not exist. Try going back to our <a href="{{ "/" }}">home page</a>.</p>
       </div>
     </main>
 {{ end }}


### PR DESCRIPTION
This PR removes a Hugo help note from the 404 page.

### Before
![image](https://github.com/localstack/docs/assets/5170829/14d57bc1-255e-4a7e-9fa7-0cf7ece976fc)

---

### Now
![image](https://github.com/localstack/docs/assets/5170829/c976f9e9-1db1-4830-b1e2-0fa08783c2a7)
