### PR TITLE
Remove experimental warning for the ARM64 image

### DIFF
--- a/content/en/references/arm64-support/index.md
+++ b/content/en/references/arm64-support/index.md
@@ -8,13 +8,6 @@ description: >
 Since [version 0.13](https://github.com/localstack/localstack/releases/tag/v0.13.0), LocalStack officially publishes a [multi-architecture Docker manifest](https://hub.docker.com/r/localstack/localstack).
 This manifest contains links to a Linux AMD64 as well as a Linux ARM64 image.
 
-{{< alert title="Note">}}
-The ARM64 image of LocalStack is still experimental.
-Help us getting aware of current issues with the ARM64 image by [filing an issue](https://github.com/localstack/localstack/issues/new?assignees=&labels=bug,ARM64%2Cneeds-triaging&template=bug-report.yml&title=bug%3A+%3Ctitle%3E) if you experience any problems.
-
-Currently known limitations are collected in the GitHub issue [localstack/localstack#4921](https://github.com/localstack/localstack/issues/4921).
-{{< /alert >}}
-
 ## Pulling the LocalStack image
 
 With the multi-arch Docker manifest, your Docker client (and therefore the [LocalStack CLI]({{< ref "getting-started/#localstack-cli" >}})) now automatically selects the image according to your platform:
@@ -87,12 +80,13 @@ $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 When using Docker Compose, you can use the `platform` element [as described in the specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md#platform).
 
-### Apple Silicon / Apple M1
-If you are experiencing issues with the ARM64 image (and after you created an issue to make us aware of the problem 😉), you can try to use the AMD64 packages on your Apple Silicon device and use Apple Rosetta to emulate the AMD64 / x86_64 CPU architecture.
+### Emulating AMD64 in host mode on Apple Silicon
 
 {{< alert title="Warning" color="warning" >}}
 Please be aware that this workaround is not supported by LocalStack at all.
 {{< /alert >}}
+
+This advanced workaround is running the open source version of LocalStack in host mode (i.e., developer mode) using AMD64 emulation on an ARM64 machine.
 
 First, you should enable "Rosetta" on your preferred terminal.
 This way you'll be installing packages for `x86_64` platform.
@@ -118,16 +112,12 @@ jenv global 11
 # Install pyenv and follow instructions
 brew install pyenv
 
-# Install python 3.8.10 and enable it globally
-pyenv install 3.8.10
-pyenv global 3.8.10
+# Install python and enable it globally (check localstack/.python-version)
+pyenv install 3.11.9
+pyenv global 3.11.9
 ```
 
 Then clone LocalStack to your machine, run `make install` and then `make start`.
-
-{{< alert title="Note">}}
-You need to use the `local` lambda executor for JVM Lambda functions.
-{{< /alert >}}
 
 
 ### Raspberry Pi


### PR DESCRIPTION
The `experimental` warning is outdated because the ARM64 image is fully functional by now as communicated by Waldemar in the [#general](https://localstack-community.slack.com/archives/CLRFWBFC3/p1682006254442769?thread_ts=1682002541.693889&cid=CLRFWBFC3) community Slack channel.

## Changes

* Remove the warning
* Re-phrase instructions for emulating in host mode

## Discussion

We could consider removing the Apple Silicon host mode instructions entirely because they are not relevant anymore given the functional ARM image.