### PR TITLE
Add Lambda runtime internal endpoint

### DIFF
--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,9 +41,10 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "lambda/#special-tools" >}}) |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |
 | `/_aws/cloudwatch/metrics/raw`         | Access all the raw CloudWatch metrics                     |
-| `_aws/cognito-idp`                     | Access the local Cognito login form                       |
-| `/_aws/dynamodb/expired`               | Trigger the DynamoDB TTL worker at convenience                      |
+| `/_aws/cognito-idp`                    | Access the local Cognito login form                       |
+| `/_aws/dynamodb/expired`               | Trigger the DynamoDB TTL worker at convenience            |


### PR DESCRIPTION
Add missing internal Lambda endpoint.

PS: This list is hard to maintain moving forward. If we start using internal endpoints more extensively, we might need to consider auto-generating those in the future. They are all missing the HTTP verb (e.g., GET, POST)