### PR TITLE
Fix ambiguous ref in CI build

### DIFF
--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -39,7 +39,7 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 
 The API path for the AWS internal resources is `/_aws`. The following endpoints are available:
 
-[Lambda – Special Tools]({{< ref "user-guide/aws/lambda/#special-tools" >}})
+[Lambda – Special Tools]({{< ref "user-guide/aws/lambda#special-tools" >}})
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -39,7 +39,7 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 
 The API path for the AWS internal resources is `/_aws`. The following endpoints are available:
 
-L1: [Lambda]({{< ref "user-guide/aws/lambda" >}})
+[Lambda – Special Tools]({{< ref "user-guide/aws/lambda/#special-tools" >}})
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,7 +41,7 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "lambda" >}}) |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See TODO |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -40,7 +40,6 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 The API path for the AWS internal resources is `/_aws`. The following endpoints are available:
 
 L1: [Lambda]({{< ref "user-guide/aws/lambda" >}})
-L2: [Lambda]({{< ref "lambda" >}})
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,7 +41,7 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "lambda/#special-tools" >}}) |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "lambda#special-tools" >}}) |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,7 +41,7 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "user-guide/aws/lambda" >}}) |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "user-guide/aws/lambda#special-tools" >}}) |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,7 +41,7 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "lambda#special-tools" >}}) |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "user-guide/aws/lambda/#special-tools" >}}) |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -39,9 +39,12 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 
 The API path for the AWS internal resources is `/_aws`. The following endpoints are available:
 
+L1: [Lambda]({{< ref "user-guide/aws/lambda" >}})
+L2: [Lambda]({{< ref "lambda" >}})
+
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda]({{< ref "lambda" >}})  |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -39,11 +39,9 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 
 The API path for the AWS internal resources is `/_aws`. The following endpoints are available:
 
-[Lambda – Special Tools]({{< ref "user-guide/aws/lambda#special-tools" >}})
-
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "user-guide/aws/lambda" >}}) |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,7 +41,7 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "user-guide/aws/lambda/#special-tools" >}}) |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "lambda" >}}) |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -41,7 +41,7 @@ The API path for the AWS internal resources is `/_aws`. The following endpoints 
 
 | Endpoint                               | Description                                               |
 |----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See TODO |
+| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda]({{< ref "lambda" >}})  |
 | `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
 | `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
 | `/_aws/ses`                            | Access and delete all the sent SES emails                 |


### PR DESCRIPTION
https://github.com/localstack/docs/pull/1250 broke the CI build and this PR fixes it.

I cannot reproduce the issue locally. This might be caused by some outdated Hugo version behaving weirdly with presumably ambiguous references. See commit history of failing build in CI (which all success locally with Golang 1.22.2 and Hugo v0.124.1).

@HarshCasper The Golang ([1.17](https://go.dev/doc/devel/release#go1.17) was deprecated 2022-08-01) and Hugo version ([0.101.0](https://github.com/gohugoio/hugo/releases/tag/v0.101.0) is from Jun 16, 2022) of the docs CI are quite outdated. Consider updating to some more recent version for a better local dev experience because I'm getting more and more such weird issues and deprecation warnings.

## Preview

Now the Lambda direct link works using the full ref path without a trailing slash: https://localstack-docs-preview-pr-1251.surge.sh/references/internal-endpoints/
