### PR TITLE
Unify terminology for features under development

### DIFF
--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -28,6 +28,9 @@ Disclaimer: Features under development (i.e., labelled as preview/beta, experime
 
 ## Official Releases
 
+LocalStack follows [Semantic Versioning](https://semver.org/) except for [AWS parity](https://localstack.cloud/blog/2022-08-04-parity-explained) fixes,
+which can be released as patch version because we are committed to make LocalStack behave the same way AWS does.
+
 | Version  | Release Date       | Release Notes                                                                                      |
 |----------|--------------------|----------------------------------------------------------------------------------------------------|
 | `v3.4.0` | April 25, 2024     | [v3.4.0](https://discuss.localstack.cloud/t/localstack-release-v3-4-0/871)                         |

--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -10,13 +10,16 @@ cascade:
 
 ## Introduction
 
-This page documents the release notes for official LocalStack major and minor releases since LocalStack v1.0.0.  If you're looking for information about nightly releases, beta features, or experimental features, pull the [latest Docker image]({{< ref "docker-images" >}}). The changelog is updated with every release. Updates that affect only LocalStack Web Application or features in beta or limited release may not be reflected.
+This page documents the release notes for official LocalStack major and minor releases since LocalStack v1.0.0.
+If you are looking for information about nightly releases, preview features, or experimental features, pull the [latest Docker image]({{< ref "docker-images" >}}).
+The changelog is updated with every release.
+Updates that affect only LocalStack Web Application or features in preview or limited release may not be reflected.
 
 ## Official Releases
 
 | Version  | Release Date       | Release Notes                                                                                      |
 |----------|--------------------|----------------------------------------------------------------------------------------------------|
-| `v3.4.0` | April 25, 2024        | [v3.4.0](https://discuss.localstack.cloud/t/localstack-release-v3-4-0/871)                         |
+| `v3.4.0` | April 25, 2024     | [v3.4.0](https://discuss.localstack.cloud/t/localstack-release-v3-4-0/871)                         |
 | `v3.3.0` | March 28, 2024     | [v3.3.0](https://discuss.localstack.cloud/t/localstack-release-v3-3-0/828)                         |
 | `v3.2.0` | February 29, 2024  | [v3.2.0](https://discuss.localstack.cloud/t/localstack-release-v3-2-0/782/)                        |
 | `v3.1.0` | January 25, 2024   | [v3.1.0](https://discuss.localstack.cloud/t/localstack-release-v3-1-0/713/)                        |

--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -15,6 +15,17 @@ If you are looking for information about nightly releases, preview features, or 
 The changelog is updated with every release.
 Updates that affect only LocalStack Web Application or features in preview or limited release may not be reflected.
 
+## Features under Development
+
+LocalStack uses the following terminology to communicate features under development:
+
+* **Preview** refers to a feature under development that usually evolves into becoming a stable feature.
+  We encourage you to try out these features and report [bugs](https://github.com/localstack/localstack/issues/new/choose), missing functionality, or general feedback.
+* **Experimental** refers to a feature prototype that demonstrates initial feasibility and usually comes with many limitations.
+  Please share your feedback to shape such features and express your interest to get them prioritized.
+
+Disclaimer: Features under development (i.e., labelled as preview/beta, experimental/alpha, or similar terms) are subject to changes (e.g., behavior, pricing tiers) or even complete removal.
+
 ## Official Releases
 
 | Version  | Release Date       | Release Notes                                                                                      |

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -322,7 +322,7 @@ To learn more about these configuration options, see [Persistence]({{< ref "pers
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `EVENT_RULE_ENGINE` (experimental) | `python` (default) \| `java` | Engine for [event pattern matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping. Set it `java` to use the AWS [event-ruler](https://github.com/aws/event-ruler) offering better parity. |
+| `EVENT_RULE_ENGINE` | `python` (default) \| `java` (preview) | Engine for [event pattern matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping. Set it `java` to use the AWS [event-ruler](https://github.com/aws/event-ruler) offering better parity. |
 | `SKIP_SSL_CERT_DOWNLOAD` | | Whether to skip downloading the SSL certificate for localhost.localstack.cloud |
 | `CUSTOM_SSL_CERT_PATH` | `/var/lib/localstack/custom/server.test.pem` | Defines the absolute path to a custom SSL certificate for localhost.localstack.cloud |
 | `IGNORE_ES_DOWNLOAD_ERRORS` | | Whether to ignore errors (e.g., network/SSL) when downloading Elasticsearch plugins |

--- a/content/en/user-guide/aws/events/index.md
+++ b/content/en/user-guide/aws/events/index.md
@@ -123,7 +123,8 @@ $ localstack logs
 ## Supported target types
 
 {{<alert title="Information">}}
-LocalStack now supports a new experimental event rule engine for [event pattern matching ](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html). You can configure the `EVENT_RULE_ENGINE=java` to use the AWS [event-ruler ](https://github.com/aws/event-ruler) that offers better parity.
+LocalStack now supports a new event rule engine for [EventBridge event patterns](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html).
+You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (preview) to use the AWS [event-ruler](https://github.com/aws/event-ruler), which offers better parity.
 {{< /alert >}}
 
 At this time LocalStack supports the following [target types](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html#eb-console-targets) for EventBridge rules:

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -110,7 +110,8 @@ The product of 10 and 10 is 100%
 ## Lambda Event Source Mappings
 
 {{<alert title="Information">}}
-LocalStack now supports a new experimental event rule engine for [event pattern matching ](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html). You can configure the `EVENT_RULE_ENGINE=java` to use the AWS [event-ruler ](https://github.com/aws/event-ruler) that offers better parity.
+LocalStack now supports a new event rule engine for [Lambda event filtering](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html).
+You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (preview) to use the AWS [event-ruler](https://github.com/aws/event-ruler), which offers better parity.
 {{< /alert >}}
 
 [Lambda event source mappings](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html) allows you to connect Lambda functions to other AWS services. The following event sources are supported in LocalStack:

--- a/content/en/user-guide/aws/pipes/index.md
+++ b/content/en/user-guide/aws/pipes/index.md
@@ -14,11 +14,13 @@ LocalStack allows you to use the Pipes APIs in your local environment to create 
 The supported APIs are available on our [API coverage page]({{< ref "coverage_pipes" >}}), which provides information on the extent of Pipe's integration with LocalStack. 
 
 {{< alert title="Note" color="info" >}}
-The implementation of EventBridge Pipes is currently in **preview** stage and under active development. If you would like support for more APIs or report bugs, please make an issue on [GitHub](https://github.com/localstack/localstack/issues/new/choose).
+The implementation of EventBridge Pipes is currently in **preview** stage and under active development.
+If you would like support for more APIs or report bugs, please make an issue on [GitHub](https://github.com/localstack/localstack/issues/new/choose).
 {{< /alert >}}
 
 {{<alert title="Information">}}
-LocalStack now supports a new experimental event rule engine for [event pattern matching ](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html). You can configure the `EVENT_RULE_ENGINE=java` to use the AWS [event-ruler ](https://github.com/aws/event-ruler) that offers better parity.
+LocalStack now supports a new event rule engine for [EventBridge event patterns](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html).
+You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (preview) to use the AWS [event-ruler](https://github.com/aws/event-ruler), which offers better parity.
 {{< /alert >}}
 
 ## Getting started

--- a/content/en/user-guide/ci/circle-ci/index.md
+++ b/content/en/user-guide/ci/circle-ci/index.md
@@ -354,7 +354,7 @@ workflows:
       ...
 ```
 
-#### Ephemeral Instance (Beta)
+#### Ephemeral Instance (Preview)
 Find out more about [Ephemeral Instances](/user-guide/cloud-sandbox/).
 
 ##### Same job 

--- a/content/en/user-guide/ci/codebuild/index.md
+++ b/content/en/user-guide/ci/codebuild/index.md
@@ -272,7 +272,7 @@ phases:
       ...
 ```
 
-#### Ephemeral Instances (Beta)
+#### Ephemeral Instances (Preview)
 ```yml
 ...
 phases:

--- a/content/en/user-guide/ci/github-actions/index.md
+++ b/content/en/user-guide/ci/github-actions/index.md
@@ -130,7 +130,7 @@ More information about state import and export [here](/user-guide/state-manageme
 
 Find more information about cloud pods [here](/user-guide/state-management/cloud-pods/).
 
-#### Ephemeral Instance (Beta)
+#### Ephemeral Instance (Preview)
 
 Our Github Action contains the prebuilt functionality to spin up an ephemeral instance.
 

--- a/content/en/user-guide/ci/gitlab-ci/index.md
+++ b/content/en/user-guide/ci/gitlab-ci/index.md
@@ -161,7 +161,7 @@ job:
 ```
 Find more information about cloud pods [here](/user-guide/state-management/cloud-pods/).
 
-#### Ephemeral Instance (Beta)
+#### Ephemeral Instance (Preview)
 
 ```yaml
 ...

--- a/content/en/user-guide/cloud-sandbox/_index.md
+++ b/content/en/user-guide/cloud-sandbox/_index.md
@@ -17,5 +17,6 @@ LocalStack Cloud Sandbox allow you to run an LocalStack instance in the cloud. L
 - Facilitate collaboration by allowing developers to test features on the same environment.
 
 {{< alert title="Note">}}
-Cloud Sandbox is currently in **private beta**. If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
+Cloud Sandbox is currently in **private preview**.
+If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
 {{< /alert >}}

--- a/content/en/user-guide/cloud-sandbox/application-previews/index.md
+++ b/content/en/user-guide/cloud-sandbox/application-previews/index.md
@@ -10,7 +10,8 @@ description: Create an Application Preview to deploy your application changes in
 Application Preview allows you to generate an preview environment from GitHub Pull Request (PR) builds. You can use Application Preview to temporarily deploy your AWS-powered application to a LocalStack Ephemeral Instance and preview your application changes. Currently, the Application Preview are only supported for GitHub repositories using GitHub Actions.
 
 {{< alert title="Note">}}
-Application Preview is currently in **private beta**. If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
+Application Preview is currently in **private preview**.
+If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
 {{< /alert >}}
 
 ## Getting started

--- a/content/en/user-guide/cloud-sandbox/ephemeral-instance/index.md
+++ b/content/en/user-guide/cloud-sandbox/ephemeral-instance/index.md
@@ -10,7 +10,8 @@ description: Create an Ephemeral Instance in the cloud using the LocalStack Web 
 LocalStack Ephemeral Instance allows you to run an LocalStack instance in the cloud. You can interact with these remote instances via the LocalStack Web Application, or by configuring your integrations and developer tools with the endpoint URL of the remote instance.
 
 {{< alert title="Note">}}
-Ephemeral Instance is currently in **private beta**. If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
+Ephemeral Instance is currently in **private preview**.
+If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
 {{< /alert >}}
 
 ## Getting started

--- a/content/en/user-guide/extensions/_index.md
+++ b/content/en/user-guide/extensions/_index.md
@@ -25,6 +25,6 @@ You can use LocalStack Extensions to:
 The officially supported [LocalStack Extensions]({{< ref "user-guide/extensions/official-extensions" >}}) can be discovered on our [Extension Library](https://app.localstack.cloud/extensions/library). To install and use extensions, you need an active LocalStack license.
 
 {{<alert title="Note">}}
-The feature and the API are currently experimental and may be subject to change.
+The feature and the API are currently in a preview stage and may be subject to change.
 Please report any issues or feature requests on [LocalStack Extension's GitHub repository](https://github.com/localstack/localstack-extensions).
 {{</alert>}}

--- a/content/en/user-guide/extensions/managing-extensions/index.md
+++ b/content/en/user-guide/extensions/managing-extensions/index.md
@@ -39,7 +39,7 @@ $ localstack extensions --help
 
 Usage: localstack extensions [OPTIONS] COMMAND [ARGS]...
 
-Manage LocalStack extensions (beta)
+Manage LocalStack extensions (preview)
 
 Options:
 -v, --verbose  Print more output

--- a/content/en/user-guide/state-management/export-import-state/index.md
+++ b/content/en/user-guide/state-management/export-import-state/index.md
@@ -20,7 +20,7 @@ $ localstack state --help
 <disable-copy>
 Usage: localstack state [OPTIONS] COMMAND [ARGS]...
 
-  (Beta) Manage and manipulate the localstack state.
+  (Preview) Manage and manipulate the localstack state.
 
   The state command group allows you to interact with LocalStack's state
   backend.

--- a/content/en/user-guide/state-management/pods-cli/index.md
+++ b/content/en/user-guide/state-management/pods-cli/index.md
@@ -317,7 +317,7 @@ The `state` group offers two commands to export and import the state of the Loca
 <disable-copy>
 Usage: state [OPTIONS] COMMAND [ARGS]...
 
-  (Beta) Manage and manipulate the localstack state.
+  (Preview) Manage and manipulate the localstack state.
 
   The state command group allows you to interact with LocalStack's state
   backend.

--- a/content/en/user-guide/web-application/ci-analytics/index.md
+++ b/content/en/user-guide/web-application/ci-analytics/index.md
@@ -21,7 +21,8 @@ CI Analytics is a feature of LocalStack Web Application that allows users to get
 CI Analytics integrates with all of the popular CI/CD tools, including GitHub Actions, GitLab CI, CircleCI, to gather pipeline metrics that track the performance and results of your cloud infrastructure deployments.
 
 {{< alert title="Note">}}
-CI Analytics is currently in **private beta**. If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
+CI Analytics is currently in **private preview**.
+If you'd like to try it out, please [contact us](https://www.localstack.cloud/demo) to request access.
 {{< /alert >}}
 
 ## Key Concepts


### PR DESCRIPTION
Migrate to the unified **preview** and **experimental** terminology following our internal decision doc "Communicate maturity levels of features under development".

## Changes

* Add terminology explanation "Features under Development" under the Changelog docs
* Add a comment about semver and AWS parity under the Changelog docs
* Migrate beta => preview
* Migrate alpha => experimental (didn't find any occurrences)
* Change the event ruler from experimental to preview stage. Given the thorough test coverage and positive customer feedback, we can consider this well-enough tested to advertise more broadly.