### PR TITLE
Update docsy to support latest hugo versions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.101.0'
+          hugo-version: '0.125.6'
           extended: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - run: npm ci
       - run: hugo --gc --minify

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.101.0'
+          hugo-version: '0.125.6'
           extended: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - name: Install and Build
         run: |

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -29,6 +29,7 @@ body > header {
 
     & .td-navbar {
         background: linear-gradient(77.63deg, #12123E 23.04%, #12123E 23.05%, #3E3174 122.36%);
+        padding: 0.5rem 1rem;
 
         .td-navbar-nav-scroll {
             margin-top: 0 !important;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -224,6 +224,7 @@ footer.footer-localstack {
 }
 
 .taxonomy-terms-cloud {
+    display: none;
 
     .taxonomy-title {
         font-weight: 600;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -213,6 +213,9 @@ footer.footer-localstack {
             color: white;
         }
     }
+    & a {
+        color: $gray-500;
+    }
 
     & hr {
         margin-top: 0.5rem;

--- a/config.toml
+++ b/config.toml
@@ -128,8 +128,10 @@ github_branch= "main"
 # gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Algolia DocSearch
-[search]
-algolia = true
+[params.search.algolia]
+appId = "XBW1JU7CW5"
+apiKey = "6b0341e2f50196d328d088dbb5cd6166"
+indexName = "localstack"
 
 # Enable Lunr.js offline search
 offlineSearch = false

--- a/config.toml
+++ b/config.toml
@@ -62,10 +62,11 @@ id = "UA-101988473-1"
 [languages]
 [languages.en]
 title = "Docs"
-description = "LocalStack Documentation"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+[languages.en.params]
+description = "LocalStack Documentation"
 
 [markup]
   [markup.goldmark]
@@ -127,7 +128,8 @@ github_branch= "main"
 # gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Algolia DocSearch
-algolia_docsearch = true
+[search]
+algolia = true
 
 # Enable Lunr.js offline search
 offlineSearch = false

--- a/config.toml
+++ b/config.toml
@@ -127,17 +127,19 @@ github_branch= "main"
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "d72aa9b2712488cc3"
 
-# Enable Algolia DocSearch
-[params.search.algolia]
-appId = "XBW1JU7CW5"
-apiKey = "6b0341e2f50196d328d088dbb5cd6166"
-indexName = "localstack"
-
 # Enable Lunr.js offline search
 offlineSearch = false
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false
+
+disable_click2copy_chroma = true
+
+# Enable Algolia DocSearch
+[params.search.algolia]
+appId = "XBW1JU7CW5"
+apiKey = "6b0341e2f50196d328d088dbb5cd6166"
+indexName = "localstack"
 
 # User interface configuration
 [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -23,15 +23,9 @@ category = "categories"
 persistence = "persistence"
 
 [params.taxonomy]
-# set taxonomyCloud = [] to hide taxonomy clouds
-taxonomyCloud = [] 
-
-# If used, must have same length as taxonomyCloud
-taxonomyCloudTitle = ["Tag Cloud", "Categories"] 
-
-# set taxonomyPageHeader = [] to hide taxonomies on the page headers
-taxonomyPageHeader = ["tags", "persistence"]
-
+taxonomyCloud = [] # set taxonomyCloud = [] to hide taxonomy clouds
+taxonomyCloudTitle = [] # if used, must have same length as taxonomyCloud
+taxonomyPageHeader = ["tags", "categories", "persistence"] # set taxonomyPageHeader = [] to hide taxonomies on the page headers
 
 # Highlighting config
 pygmentsCodeFences = true

--- a/config.toml
+++ b/config.toml
@@ -240,7 +240,7 @@ latest_version = "3.4.0"
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.75.0"
+    min = "0.125.4"
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -238,7 +238,7 @@ If you want to manually manage your Docker container, it's usually a good idea t
 You can start LocalStack with [Docker Compose](https://docs.docker.com/compose/) by configuring a `docker-compose.yml` file.
 Currently, `docker-compose` version 1.9.0+ is supported.
 
-{{< tabpane >}}
+{{< tabpane lang="yml" >}}
 {{< tab header="Community" lang="yml" >}}
 version: "3.8"
 
@@ -328,7 +328,7 @@ If it does not report an error (but shows information on your Docker system), yo
 
 You can start the Docker container simply by executing the following `docker run` command:
 
-{{< tabpane >}}
+{{< tabpane lang="shell" >}}
 {{< tab header="Community" lang="shell" >}}
 docker run \
   --rm -it \

--- a/content/en/getting-started/quickstart/index.md
+++ b/content/en/getting-started/quickstart/index.md
@@ -186,7 +186,7 @@ $ awslocal lambda create-function-url-config \
 
 #### Build the Image Resizer Lambda
 
-{{< tabpane >}}
+{{< tabpane lang="shell" >}}
 {{< tab header="macOS" lang="shell" >}}
 cd lambdas/resize
 rm -rf libs lambda.zip

--- a/content/en/references/custom-tls-certificates.md
+++ b/content/en/references/custom-tls-certificates.md
@@ -60,7 +60,7 @@ If your certificate file ends with `.pem`, you can rename it to end in `.crt`.
 
 LocalStack now needs to be configured to use this custom image. The workflow is different depending on how you start localstack.
 
-{{< tabpane >}}
+{{< tabpane lang="bash">}}
 {{< tab header="CLI" lang="bash" >}}
 IMAGE_NAME=<image name> localstack start
 {{< /tab >}}

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -35,7 +35,7 @@ To enable access to the LocalStack instance, it's advisable to start LocalStack 
 This allows the code running inside the container to access the LocalStack instance using its hostname.
 For example:
 
-{{<tabpane>}}
+{{<tabpane lang="bash">}}
 {{<tab header="CLI" lang="bash">}}
 # create the network
 docker network create my-network
@@ -87,7 +87,7 @@ To configure your application container:
 * either determine your LocalStack container IP, or configure your LocalStack container to have a fixed known IP address;
 * set the DNS server of your application container to the IP address of the LocalStack container.
 
-{{% tabpane %}}
+{{% tabpane lang="bash" %}}
 {{< tab header="CLI" lang="bash" >}}
 # start localstack
 localstack start -d --network ls
@@ -162,7 +162,7 @@ To facilitate access to LocalStack from within the container, it's recommended t
 Doing so enables the containerized code to connect to the LocalStack instance using its hostname.
 For instance:
 
-{{<tabpane>}}
+{{<tabpane lang="bash">}}
 {{<tab header="CLI" lang="bash">}}
 # create the network
 docker network create my-network
@@ -214,7 +214,7 @@ Please update your LocalStack container and see the [instructions]({{< ref "#fro
 
 LocalStack must listen to the address of the host, or `0.0.0.0`.
 
-{{<tabpane>}}
+{{<tabpane lang="bash">}}
 {{<tab header="CLI" lang="bash">}}
 GATEWAY_LISTEN="0.0.0.0" localstack start
 {{</tab>}}

--- a/content/en/user-guide/aws/athena/index.md
+++ b/content/en/user-guide/aws/athena/index.md
@@ -209,7 +209,7 @@ s3://mybucket/prefix/temp/
 You can configure the Athena service in LocalStack with various clients, such as [PyAthena](https://github.com/laughingman7743/PyAthena/), [awswrangler](https://github.com/aws/aws-sdk-pandas), among others!
 Here are small snippets to get you started:
 
-{{< tabpane >}}
+{{< tabpane lang="python" >}}
 {{< tab header="PyAthena" lang="python" >}}
 from pyathena import connect
 

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -59,7 +59,7 @@ In the old Lambda provider, you could create a function with any arbitrary strin
 
 To invoke the Lambda function, you can use the [`Invoke` API](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html). Run the following command to invoke the function:
 
-{{< tabpane text=true persistLang=false >}}
+{{< tabpane text=true persist=false >}}
   {{% tab header="AWS CLI v1" lang="shell" %}}
   {{< command >}}
   $ awslocal lambda invoke --function-name localstack-lambda-url-example \
@@ -267,7 +267,7 @@ In the old Lambda provider, Lambda functions were executed within the LocalStack
 
 If you encounter the following error message, you may be using the local executor mode:
 
-{{< tabpane >}}
+{{< tabpane lang="bash" >}}
 {{< tab header="LocalStack Logs" lang="shell" >}}
 Lambda 'arn:aws:lambda:us-east-1:000000000000:function:my-function:$LATEST' changed to failed. Reason: Docker not available
 ...

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -227,7 +227,7 @@ $ docker pull localstack/localstack:s3-latest
 
 The S3 Docker image only supports the S3 APIs and does not include other services like Lambda, DynamoDB, etc. You can run the S3 Docker image using any of the following commands:
 
-{{< tabpane >}}
+{{< tabpane lang="shell" >}}
 {{< tab header="LocalStack CLI" lang="shell" >}}
 IMAGE_NAME=localstack/localstack:s3-latest localstack start
 {{< /tab >}}

--- a/content/en/user-guide/integrations/copilot/index.md
+++ b/content/en/user-guide/integrations/copilot/index.md
@@ -17,7 +17,7 @@ Using `copilotlocal` instead of `copilot` in your command line therefore ensures
 
 ### Download / Installation
 
-{{< tabpane >}}
+{{< tabpane lang="bash" >}}
 {{< tab header="Linux AMD64" lang="bash">}}
 curl -Lo copilotlocal https://github.com/localstack/copilot-cli/raw/localstack-builds/build/linux-amd64/copilotlocal && chmod +x copilotlocal
 # if you want to have copilotlocal in your $PATH, move the executable e.g. to /usr/local/bin/

--- a/content/en/user-guide/integrations/sdks/go/index.md
+++ b/content/en/user-guide/integrations/sdks/go/index.md
@@ -22,7 +22,7 @@ The Go SDK has two major versions, each with their own way of specifying the Loc
 Here is an example of how to create an S3 Client from a Session with the endpoint set to LocalStack.
 Full examples for both SDK versions can be found [in our samples repository](https://github.com/localstack/localstack-aws-sdk-examples/tree/main/go).
 
-{{< tabpane >}}
+{{< tabpane lang="golang" >}}
 {{< tab header="aws-go-sdk" lang="golang" >}}
 package main
 

--- a/content/en/user-guide/integrations/sdks/java/index.md
+++ b/content/en/user-guide/integrations/sdks/java/index.md
@@ -36,7 +36,7 @@ The client can be used to upload a file to an existing bucket and then retrieve 
 
 #### Configuring the S3 Client
 
-{{< tabpane >}}
+{{< tabpane lang="java" >}}
 {{< tab header="v1" lang="java" >}}
 
     // Credentials that can be replaced with real AWS values. (To be handled properly and not hardcoded.)
@@ -77,7 +77,7 @@ S3Client s3Client = S3Client.builder()
 
 #### Interacting with S3
 
-{{< tabpane >}}
+{{< tabpane lang="java" >}}
 {{< tab header="v1" lang="java" >}}
 
     // Existing bucket name.
@@ -153,7 +153,7 @@ cater to the application's needs. The full list of supported converters can be f
 
 #### Configuring the DynamoDB Client
 
-{{< tabpane >}}
+{{< tabpane lang="java" >}}
 {{< tab header="v1" lang="java">}}
 
     // Credentials that can be replaced with real AWS values. (To be handled properly and not hardcoded.)
@@ -207,7 +207,7 @@ DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
 
 #### Interacting with DynamoDB
 
-{{< tabpane >}}
+{{< tabpane lang="java" >}}
 
 {{< tab header="v1" lang="java">}}
 

--- a/content/en/user-guide/integrations/sdks/javascript/index.md
+++ b/content/en/user-guide/integrations/sdks/javascript/index.md
@@ -21,7 +21,7 @@ The JavaScript SDK has two major versions, each with their own way of specifying
 
 Here is an example of how to create a Lambda client and an S3 client with the endpoint set to LocalStack.
 
-{{< tabpane >}}
+{{< tabpane lang="javascript" >}}
 {{< tab header="aws-sdk-js" lang="javascript" >}}
 
 const AWS = require('aws-sdk');

--- a/content/en/user-guide/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/lambda-tools/debugging/index.md
@@ -184,7 +184,7 @@ $ awslocal lambda create-function --function-name my-cool-local-function \
 
 We can quickly verify that it works by invoking it with a simple payload:
 
-{{< tabpane text=true persistLang=false >}}
+{{< tabpane text=true persist=false >}}
 {{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
 $ awslocal lambda invoke --function-name my-cool-local-function \
@@ -394,7 +394,7 @@ Now to debug your lambda function, click on the `Debug` icon with
 `Attach to Remote Node.js` configuration selected, and then invoke your
 lambda function:
 
-{{< tabpane text=true persistLang=false >}}
+{{< tabpane text=true persist=false >}}
 {{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
 $ awslocal lambda invoke --function-name func1 \

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -121,7 +121,7 @@ You can also check out some of our [Deployment Configuration Examples](#deployme
 
 We can also quickly make sure that it works by invoking it with a simple payload:
 
-{{< tabpane text=true persistLang=false >}}
+{{< tabpane text=true persist=false >}}
 {{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
 $ awslocal lambda invoke --function-name my-cool-local-function \
@@ -308,7 +308,7 @@ $ awslocal lambda create-function \
 
 You can quickly make sure that it works by invoking it with a simple payload:
 
-{{< tabpane text=true persistLang=false >}}
+{{< tabpane text=true persist=false >}}
 {{% tab header="AWS CLI v1" lang="shell" %}}
 {{< command >}}
 $ awslocal lambda invoke \

--- a/content/en/user-guide/state-management/cloud-pods/index.md
+++ b/content/en/user-guide/state-management/cloud-pods/index.md
@@ -250,7 +250,7 @@ To automatically load a Cloud Pod at startup, utilize the `AUTO_LOAD_POD` [confi
 
 `AUTO_LOAD_POD` can accept multiple Cloud Pod names separated by commas. To autoload multiple Cloud Pods, such as `foo-pod` and `bar-pod`, use: `AUTO_LOAD_POD=foo-pod,bar-pod`. The order of Cloud Pods in `AUTO_LOAD_POD` dictates their loading sequence. When autoloading multiple Cloud Pods, later pods might overwrite the state of earlier ones if they share the same service, account, and region.
 
-{{< tabpane >}}
+{{< tabpane lang="bash" >}}
 {{< tab header="LocalStack CLI" lang="bash" >}}
 AUTO_LOAD_POD=foo-pod localstack start
 {{< /tab >}}

--- a/content/en/user-guide/state-management/persistence/index.md
+++ b/content/en/user-guide/state-management/persistence/index.md
@@ -17,7 +17,7 @@ LocalStack's Persistence mechanism enables the saving and restoration of the ent
 
 To start snapshot-based persistence, launch LocalStack with the configuration option `PERSISTENCE=1`. This setting instructs LocalStack to save all AWS resources and their respective application states into the LocalStack Volume Directory. Upon restarting LocalStack, you'll be able to resume your activities exactly where you left off.
 
-{{< tabpane >}}
+{{< tabpane lang="bash" >}}
 {{< tab header="LocalStack CLI" lang="bash" >}}
 LOCALSTACK_AUTH_TOKEN=... PERSISTENCE=1 localstack start
 {{< /tab >}}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/localstack/docs
 
 go 1.17
 
-require github.com/google/docsy v0.6.0 // indirect
+require (
+	github.com/google/docsy v0.10.0 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/localstack/docs
 
-go 1.17
+go 1.22
 
 require (
 	github.com/google/docsy v0.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/localstack/docs
 
-go 1.22
+go 1.21
 
 require (
 	github.com/google/docsy v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
-github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
-github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
-github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/layouts/academy/list.html
+++ b/layouts/academy/list.html
@@ -18,7 +18,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             <div class="page-content">
                 <h1 class="mt-2">{{ .Title }}</h1>

--- a/layouts/academy/single.html
+++ b/layouts/academy/single.html
@@ -18,7 +18,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <div class="page-content">

--- a/layouts/applications/list.html
+++ b/layouts/applications/list.html
@@ -16,7 +16,7 @@
           <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
             {{ partial "developer-hub/filters-sidebar.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <div class="td-content">

--- a/layouts/lessons/single.html
+++ b/layouts/lessons/single.html
@@ -18,7 +18,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <div class="td-content page-content">

--- a/layouts/partials/developer-hub/application.html
+++ b/layouts/partials/developer-hub/application.html
@@ -19,7 +19,7 @@
         </div>
         <div class="card-body">
             <h5 class="card-title d-flex align-items-center">
-                <a class="mr-2" href="{{ .url }}">
+                <a class="me-2" href="{{ .url }}">
                     {{ with .title }}{{ . }}{{end}}
                 </a>
             </h5>

--- a/layouts/partials/developer-hub/filters-sidebar.html
+++ b/layouts/partials/developer-hub/filters-sidebar.html
@@ -1,7 +1,7 @@
 <div class="toc-title d-flex align-items-center justify-content-between">
   <span>Filters</span>
   <a href="javascript:void(0)" class="clear-filters-btn clear-filters-container align-items-center" style="display: none;">
-    <i class="fas fa-circle-xmark mr-1"></i>
+    <i class="fas fa-circle-xmark me-1"></i>
     <span>Clear filters</span>
   </a>
 </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,7 +11,7 @@
         </div>
       </div>
       <div class="col">
-        <div class="text-right link-lists">
+        <div class="text-end link-lists">
           {{ with $links }}
           {{ with index . "user" }}
           {{ template "footer-links-block"  . }}
@@ -31,8 +31,8 @@
           <div class="col">
             {{ with .Site.Params.copyright }}<small>Copyright &copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
           </div>
-          <div class="col text-right">
-            {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+          <div class="col text-end">
+            {{ with .Site.Params.privacy_policy }}<small class="ms-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
             {{ if not .Site.Params.ui.footer_about_disable }}
               {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
             {{ end }}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,9 +1,2 @@
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
-<script type="text/javascript">docsearch({
-  container: '#docsearch',
-  appId: 'XBW1JU7CW5',
-  apiKey: '6b0341e2f50196d328d088dbb5cd6166',
-  indexName: 'localstack',
-});</script>
 <script src="{{ "js/global-script.js" | relURL }}"></script>
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -14,7 +14,7 @@
             <!-- disabled link menus (we currently only use this website for a single menu page: docs)
             {{ $p := . }}
             {{ range .Site.Menus.main }}
-            <li class="nav-item mr-4 mb-2 mb-lg-0">
+            <li class="nav-item me-4 mb-2 mb-lg-0">
                 {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
                 {{ with .Page }}
                 {{ $active = or $active ( $.IsDescendant .)  }}
@@ -28,12 +28,12 @@
             {{ end }}
             -->
             {{ if  .Site.Params.versions }}
-            <li class="nav-item dropdown mr-4 d-none d-lg-block">
+            <li class="nav-item dropdown me-4 d-none d-lg-block">
                 {{ partial "navbar-version-selector.html" . }}
             </li>
             {{ end }}
             {{ if  (gt (len .Site.Home.Translations) 0) }}
-            <li class="nav-item dropdown mr-4 d-none d-lg-block">
+            <li class="nav-item dropdown me-4 d-none d-lg-block">
                 {{ partial "navbar-lang-selector.html" . }}
             </li>
             {{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -9,7 +9,7 @@
         </a>
     </div>
 
-    <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
+    <div class="td-navbar-nav-scroll ms-md-auto" id="main_navbar">
         <ul class="navbar-nav mt-2 mt-md-0 display-flex align-items-center" style="gap: 0.5rem">
             <!-- disabled link menus (we currently only use this website for a single menu page: docs)
             {{ $p := . }}

--- a/layouts/tutorials/list.html
+++ b/layouts/tutorials/list.html
@@ -16,7 +16,7 @@
           <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
             {{ partial "developer-hub/filters-sidebar.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <div class="td-content">

--- a/layouts/tutorials/single.html
+++ b/layouts/tutorials/single.html
@@ -18,7 +18,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <div class="td-content">


### PR DESCRIPTION
## Motivation

Hugo > v125 does not seem to support our docsy theme anymore, due to no-found google analytics templates.
A solution is to upgrade docsy to the latest version, which supports hugo > 125.

However, this comes with several breaking changes, which I tried to make in this PR.

Beside some configuration changes, the most noticeable change is the upgrade to bootstrap v5, which requires some changes. It is very possible I forgot some migration steps, would be nice to get some eyes on it from people more knowledgeable than me in web design.

## Changes
* Upgrade to docsy 0.10
* Upgrade hugo versions to >=0.125.4
* Some migration to bootstrap v5
* Use algolia search directly (is already v3 with latest docsy) instead of manually importing and initializing it
* Fix the privacy notice link in the footer not being visible at all (not related to the upgrade, it is like this on current main as well)
* Update `lang` attribute to tabpane roots, so it uses the correct values for persistence
* Stop display everything with the taxonomy cloud class. This avoids the 'tags', 'persistence' and 'categories' sections on the right sidebar. For some reason, the official disabling of it does not work anymore. Maybe related to https://github.com/google/docsy/issues/704 , but I honestly do not know why it suddenly surfaces