### PR TITLE
Mount docker socket in installation example

### DIFF
--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -334,6 +334,7 @@ docker run \
   --rm -it \
   -p 4566:4566 \
   -p 4510-4559:4510-4559 \
+  -v /var/run/docker.sock:/var/run/docker.sock
   localstack/localstack
 {{< /tab >}}
 {{< tab header="Pro" lang="shell" >}}
@@ -342,6 +343,7 @@ docker run \
   -p 4566:4566 \
   -p 4510-4559:4510-4559 \
   -e LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} \
+  -v /var/run/docker.sock:/var/run/docker.sock
   localstack/localstack-pro{{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -294,7 +294,7 @@ $ docker-compose up
 
 - This command reuses the image if it's already on your machine, i.e. it will **not** pull the latest image automatically from Docker Hub.
 
-- Mounting the Docker socket `/var/run/docker.sock` as a volume is required for the Lambda service. Check out the [Lambda providers]({{< ref "user-guide/aws/lambda" >}}) documentation for more information.
+- Mounting the Docker socket `/var/run/docker.sock` as a volume is required for some services that use Docker to provide the emulation, such as AWS Lambda.
 
 - To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker.
   For instance, setting `LOCALSTACK_PERSISTENCE=1` is equivalent to `PERSISTENCE=1`.

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -295,6 +295,7 @@ $ docker-compose up
 - This command reuses the image if it's already on your machine, i.e. it will **not** pull the latest image automatically from Docker Hub.
 
 - Mounting the Docker socket `/var/run/docker.sock` as a volume is required for some services that use Docker to provide the emulation, such as AWS Lambda.
+  Check out the [Lambda providers]({{< ref "user-guide/aws/lambda" >}}) documentation for more information.
 
 - To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker.
   For instance, setting `LOCALSTACK_PERSISTENCE=1` is equivalent to `PERSISTENCE=1`.
@@ -358,6 +359,7 @@ docker run \
 - This command reuses the image if it's already on your machine, i.e. it will **not** pull the latest image automatically from Docker Hub.
 
 - Mounting the Docker socket `/var/run/docker.sock` as a volume is required for some services that use Docker to provide the emulation, such as AWS Lambda.
+  Check out the [Lambda providers]({{< ref "user-guide/aws/lambda" >}}) documentation for more information.
 
 - When using Docker to manually start LocalStack, you will have to configure the container on your own (see [docker-compose-pro.yml](https://github.com/localstack/localstack/blob/master/docker-compose-pro.yml) and [Configuration]({{< ref "configuration" >}})).
   This could be seen as the "expert mode" of starting LocalStack.

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -332,16 +332,17 @@ You can start the Docker container simply by executing the following `docker run
 {{< tab header="Community" lang="shell" >}}
 docker run \
   --rm -it \
-  -p 4566:4566 \
-  -p 4510-4559:4510-4559 \
+  -p 127.0.0.1:4566:4566 \
+  -p 127.0.0.1:4510-4559:4510-4559 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   localstack/localstack
 {{< /tab >}}
 {{< tab header="Pro" lang="shell" >}}
 docker run \
   --rm -it \
-  -p 4566:4566 \
-  -p 4510-4559:4510-4559 \
+  -p 127.0.0.1:4566:4566 \
+  -p 127.0.0.1:4510-4559:4510-4559 \
+  -p 127.0.0.1:443:443 \
   -e LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} \
   -v /var/run/docker.sock:/var/run/docker.sock \
   localstack/localstack-pro{{< /tab >}}

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -357,8 +357,9 @@ docker run \
 
 - This command reuses the image if it's already on your machine, i.e. it will **not** pull the latest image automatically from Docker Hub.
 
-- This command does not bind all ports that are potentially used by LocalStack, nor does it mount any volumes.
-  When using Docker to manually start LocalStack, you will have to configure the container on your own (see [docker-compose-pro.yml](https://github.com/localstack/localstack/blob/master/docker-compose-pro.yml) and [Configuration]({{< ref "configuration" >}})).
+- Mounting the Docker socket `/var/run/docker.sock` as a volume is required for some services that use Docker to provide the emulation, such as AWS Lambda.
+
+- When using Docker to manually start LocalStack, you will have to configure the container on your own (see [docker-compose-pro.yml](https://github.com/localstack/localstack/blob/master/docker-compose-pro.yml) and [Configuration]({{< ref "configuration" >}})).
   This could be seen as the "expert mode" of starting LocalStack.
   If you are looking for a simpler method of starting LocalStack, please use the [LocalStack CLI]({{< ref "#localstack-cli" >}}).
 

--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -334,7 +334,7 @@ docker run \
   --rm -it \
   -p 4566:4566 \
   -p 4510-4559:4510-4559 \
-  -v /var/run/docker.sock:/var/run/docker.sock
+  -v /var/run/docker.sock:/var/run/docker.sock \
   localstack/localstack
 {{< /tab >}}
 {{< tab header="Pro" lang="shell" >}}
@@ -343,7 +343,7 @@ docker run \
   -p 4566:4566 \
   -p 4510-4559:4510-4559 \
   -e LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} \
-  -v /var/run/docker.sock:/var/run/docker.sock
+  -v /var/run/docker.sock:/var/run/docker.sock \
   localstack/localstack-pro{{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -15,6 +15,9 @@ These options can be passed to LocalStack as environment variables like so:
 $ DEBUG=1 localstack start
 {{< / command >}}
 
+To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker.
+For instance, setting `LOCALSTACK_PERSISTENCE=1` is equivalent to `PERSISTENCE=1`.
+
 You can also use [Profiles](#profiles).
 
 Configurations marked as **Deprecated** will be removed in the next major version. You can find previously removed configuration variables under [Legacy](#legacy).


### PR DESCRIPTION
# Motivation

Our getting started example does not mount the Docker socket. If the user does this, they get lots of log messages regarding failed connections to the Docker socket (inside the container). This is off-putting for a new user.

# Changes

* Show mounting the Docker socket into the LocalStack container for the Docker installation section
* Expose ports on 127.0.0.1 by default
* Make more complete examples for Docker and Docker Compose
* Add info about `LOCALSTACK_` prefix for config variables in configuration reference
* Improve wording around why we mount the Docker socket