### PR TITLE
add docs on wafv2 cfn provider

### DIFF
--- a/content/en/user-guide/aws/cloudformation/index.md
+++ b/content/en/user-guide/aws/cloudformation/index.md
@@ -403,3 +403,7 @@ When utilizing the Community image, any resources within the stack that are not 
 | AWS::SES::ReceiptRuleSet                        |      ✅ |      ✅ |      - |
 | AWS::SES::Template                              |      ✅ |      ✅ |      ✅ |
 | AWS::SecretsManager::SecretTargetAttachment     |      ✅ |      ✅ |      - |
+| AWS::WAFv2::IPSet                               |      ✅ |      ✅ |      - |
+| AWS::WAFv2::LoggingConfiguration                |     ✅ |      ✅ |      - |
+| AWS::WAFv2::WebACL                              |      ✅ |      ✅ |      - |
+| AWS::WAFv2::WebACLAssociation                   |      ✅ |      ✅ |      - |


### PR DESCRIPTION
This PR documents:

- Support for AWS::WAFv2::WebACL
- Support for AWS::WAFv2::WebACLAssociation
- Support for AWS::WAFv2::IPSet
- Support for AWS::WAFv2::LoggingConfiguration