### PR TITLE
Add documentation for lambda hot reloading placeholders

### DIFF
--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -305,7 +305,7 @@ To create the Lambda function, you need to take care of two things:
 Create the Lambda Function using the `awslocal` CLI:
 
 {{< command >}}
-awslocal lambda create-function \
+$ awslocal lambda create-function \
     --function-name hello-world \
     --runtime "nodejs16.x" \
     --role arn:aws:iam::123456789012:role/lambda-ex \
@@ -365,9 +365,9 @@ Change the `Hello World!` message to `Hello LocalStack!` and run `npm run build`
 In this example, you can use our public [Webpack example](https://github.com/localstack-samples/localstack-pro-samples/tree/master/lambda-hot-reloading/lambda-typescript-webpack) to create a simple Lambda function using TypeScript and Webpack. To use the example, run the following commands:
 
 {{< command >}}
-cd /tmp
-git clone https://github.com/localstack-samples/localstack-pro-samples.git
-cd lambda-hot-reloading/lambda-typescript-webpack
+$ cd /tmp
+$ git clone https://github.com/localstack-samples/localstack-pro-samples.git
+$ cd lambda-hot-reloading/lambda-typescript-webpack
 {{< / command >}}
 
 ##### Setting up the build
@@ -603,6 +603,29 @@ resource "aws_lambda_function" "exampleFunctionOne" {
 $ terraform init && \
   terraform apply -var "STAGE=local" -var "LAMBDA_MOUNT_CWD=$(pwd)/build/hot"
 {{< / command >}}
+
+## Share deployment configuration between different machines
+
+The paths provided for hot reloading have to be absolute paths on the host running the LocalStack container.
+This, however makes sharing the same configuration between multiple machines difficult, whether using [Cloud Pods]({{< ref "user-guide/state-management/cloud-pods" >}}) or sharing IaC templates between different developers.
+
+In order to remove the need for manual adjustments for your hot-reloading paths specified in the `S3Key` field, you can use placeholders for environment variables inside the path.
+The placeholders use the same format as you would use for shell parameter expansion, namely `$ENV_VAR` or `${ENV_VAR}`.
+These used environment variables have to be set inside the LocalStack container.
+
+Please note that the final path, after substituting the placeholders for their values, has to be an absolute path.
+
+{{< callout >}}
+Please make sure the placeholder is not substituted by your shell before being sent to LocalStack.
+This is mostly relevant when using the AWS CLI to create a function.
+Please use string quotation marks which prevent parameter expansion in your shell.
+
+For bash, please use single quotes `'` instead of double quotes `"` to make sure the placeholder does not get expanded before being sent to LocalStack.
+{{< /callout >}}
+
+### Example
+
+
 
 ## Useful Links
 

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -625,7 +625,7 @@ For bash, please use single quotes `'` instead of double quotes `"` to make sure
 
 ### Example
 
-In order to make use of the environment variable placeholders, you can inject them into the LocalStack container, for example using the following docker-compose file.
+In order to make use of the environment variable placeholders, you can inject them into the LocalStack container, for example using the following `docker-compose.yml` file.
 
 ```yaml
 version: "3.8"
@@ -646,7 +646,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 ```
 
-This will set a `HOST_LAMBDA_DIR` environment variable to the current working directory when creating the docker compose stack.
+This will set a `HOST_LAMBDA_DIR` environment variable to the current working directory when creating the Docker Compose stack.
 Please note that this environment variable name is arbitrary - you can use any you want, but need to refer to that variable in your templates or commands to deploy your function correctly.
 You can then deploy a hot-reloading function with the following command:
 
@@ -663,7 +663,7 @@ Please note the single quotes `'` which prevent our shell to replace `$HOST_LAMB
 
 With the above example, you can make hot-reloading paths sharable between machines, as long as there is a point on the host to which the relative paths will stay the same.
 One example for this are checked out git repositories, where the code is located in the same structure - the absolute location of the checked out repository on the machine might however differ.
-If the choosen variable always points to the checked out directory, you can set the path using the placeholder in the checked out IaC template, or can share a CloudPod between machines.
+If the chosen variable always points to the checked out directory, you can set the path using the placeholder in the checked out IaC template, or can share a Cloud Pod between machines.
 
 ## Useful Links
 


### PR DESCRIPTION
## Motivation

With localstack/localstack#10857, we introduced an option to use placeholders for environment variables in hot reloading paths for lambda.

This allows the users to reuse their IaC templates or CloudPods between different machines, if there is a common point on the filesystem to there are relative paths to the code directories.

## Changes
* This PR adds documentation on that functionality, and an example how to use these placeholders.
