### PR TITLE
Exclude services from the persistence docs

### DIFF
--- a/content/en/user-guide/aws/sts/index.md
+++ b/content/en/user-guide/aws/sts/index.md
@@ -2,8 +2,10 @@
 title: "Security Token Service (STS)"
 linkTitle: "Security Token Service (STS)"
 aliases:
-- /user-guide/aws/security-token-service/ 
+- /user-guide/aws/security-token-service/
 description: Get started with Security Token Service on LocalStack
+persistence: supported
+
 ---
 
 ## Introduction

--- a/data/persistence/coverage.json
+++ b/data/persistence/coverage.json
@@ -146,13 +146,6 @@
     "test_suite": true,
     "limitations": ""
   },
-  "dms": {
-    "service": "dms",
-    "full_name": "dms",
-    "support": "not supported",
-    "test_suite": false,
-    "limitations": ""
-  },
   "docdb": {
     "service": "docdb",
     "full_name": "DocumentDB",
@@ -618,8 +611,8 @@
   "sts": {
     "service": "sts",
     "full_name": "STS (Security Token Service)",
-    "support": "not supported",
-    "test_suite": false,
+    "support": "supported",
+    "test_suite": true,
     "limitations": ""
   },
   "support": {
@@ -660,13 +653,6 @@
   "transfer": {
     "service": "transfer",
     "full_name": "Transfer",
-    "support": "unknown",
-    "test_suite": false,
-    "limitations": ""
-  },
-  "verifiedpermissions": {
-    "service": "verifiedpermissions",
-    "full_name": "verifiedpermissions",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""

--- a/scripts/persistence/create_persistence_docs.py
+++ b/scripts/persistence/create_persistence_docs.py
@@ -73,6 +73,9 @@ def collect_status() -> dict:
     catalog_db = PersistenceCatalog(notion_client=notion_client)
     statuses = {}
     for item in catalog_db:
+        # we do not want some services to be mentioned in the docs (for instance, not yet released)
+        if item.exclude:
+            continue
         service = item.name.replace('_', '-')
         status = item.status.lower()
         statuses[service] = {

--- a/scripts/persistence/notion/catalog.py
+++ b/scripts/persistence/notion/catalog.py
@@ -22,6 +22,7 @@ class PersistenceServiceItem(Page):
     primary_owner = PeopleProperty("Primary Owner")
     secondary_owner = PeopleProperty("Secondary Owner(s)")
     limitations = Text("Limitations (synced with docs)")
+    exclude = Checkbox("Exclude from docs")
 
 
 class PersistenceCatalog(Database[PersistenceServiceItem]):


### PR DESCRIPTION
As suggested by @HarshCasper, this PR introduces the possibility of excluding services from the automatic generation of the persistence docs.
There is now a checkbox field in Notion called "exclude from docs" that one can check.

This PR also rerun the generation script to the latest updates of the Notion catalog.