### PR TITLE
prepare coverage docs creation for DMS

### DIFF
--- a/data/coverage/service_display_name.json
+++ b/data/coverage/service_display_name.json
@@ -119,6 +119,11 @@
       "short_name": "",
       "api": "https://docs.aws.amazon.com/config/latest/APIReference/Welcome.html"
     },
+    "dms": {
+      "long_name": "Database Migration Service",
+      "short_name": "DMS",
+      "api": "https://docs.aws.amazon.com/dms/latest/APIReference/Welcome.html"
+    },
     "docdb": {
       "long_name": "DocumentDB",
       "short_name": "",

--- a/scripts/create_data_coverage.py
+++ b/scripts/create_data_coverage.py
@@ -159,11 +159,6 @@ def main(
                 # we currently have "sqs" + "sqs-query" endpoints because of different protocols
                 # the resulting coverage should not care about this though
                 continue
-            if service_name == "dms":
-                # we don't officially support dms yet, so we shouldn't show it in the coverage either
-                # the generated docs is currently also wrong -> as we don't load the provider, we get 5xx errors, which is interpreted
-                # as the operations being implemented
-                continue
             service = impl_details.setdefault(service_name, {})
             service[row["operation"]] = {
                 "implemented": True if row["is_implemented"] == "True" else False,


### PR DESCRIPTION
* Remove skipping of DMS from the coverage creation script
* add DMS details to the `data/coverage/service_display_name.json`

Verified that DMS docs are created in https://github.com/localstack/docs/pull/1290 (running workflow against the branch)
* https://localstack-docs-preview-pr-1290.surge.sh/references/coverage/coverage_dms/

**The workflow will be re-run on main after the merge.**