### PR TITLE
fix lambda layer documentation

### DIFF
--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -124,8 +124,7 @@ You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (previ
 
 ## Lambda Layers (Pro)
 
-[Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) lets you include additional code and dependencies in your Lambda functions. LocalStack Pro image allows you to deploy Lambda Layers locally to streamline your development and testing process.
-However, the layers are not applied when invoking a Lambda function.
+[Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) lets you include additional code and dependencies in your Lambda functions. LocalStack Pro image allows you to deploy Lambda Layers locally to streamline your development and testing process. You can use Lambda Layers in the Community image, though they are not applied when invoking a Lambda function.
 
 ### Creating and using a Lambda Layer Locally
 

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -124,7 +124,7 @@ You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (previ
 
 ## Lambda Layers (Pro)
 
-[Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) lets you include additional code and dependencies in your Lambda functions. LocalStack Pro image allows you to deploy Lambda Layers locally to streamline your development and testing process. You can use Lambda Layers in the Community image, though they are not applied when invoking a Lambda function.
+[Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) let you include additional code and dependencies in your Lambda functions. The LocalStack Pro image allows you to deploy Lambda Layers locally to streamline your development and testing process. The Community image also allows creating, updating, and deleting Lambda Layers, but they are not applied when invoking a Lambda function.
 
 ### Creating and using a Lambda Layer Locally
 


### PR DESCRIPTION
This PR updates the Lambda Layer documentation by:

- Clarifying that the feature is available and functional with the Pro image.
- Indicating that Layers can be referenced but are not used in the Community image.

This resolves a recent customer issue where there was confusion about Lambda Layer support in the Pro image. /cc: @komarkovich 