### PR TITLE
standardize limitations heading for collecting known issues

### DIFF
--- a/content/en/references/iam-coverage.md
+++ b/content/en/references/iam-coverage.md
@@ -150,6 +150,6 @@ In principle, LocalStack supports all operations. However, not all services and 
 |                | Supported condition keys:                                                            |
 |                | - aws:SourceArn                                                                      |
 
-## Limitations
+## Current Limitations
 
 - CloudFormation stack permissions do not work as expected.

--- a/content/en/references/iam-coverage.md
+++ b/content/en/references/iam-coverage.md
@@ -150,6 +150,6 @@ In principle, LocalStack supports all operations. However, not all services and 
 |                | Supported condition keys:                                                            |
 |                | - aws:SourceArn                                                                      |
 
-## Known Issues
+## Limitations
 
 - CloudFormation stack permissions do not work as expected.

--- a/content/en/user-guide/aws/batch/index.md
+++ b/content/en/user-guide/aws/batch/index.md
@@ -166,6 +166,6 @@ You should see the following output:
 }
 ```
 
-## Limitations 
+## Current Limitations 
 
 As mentioned in the example above, the creation of a compute environment does not entail the provisioning of EC2 or Fargate instances. Rather, it executes Batch jobs on the local Docker daemon, operating alongside LocalStack.

--- a/content/en/user-guide/aws/ce/index.md
+++ b/content/en/user-guide/aws/ce/index.md
@@ -160,6 +160,6 @@ The Resource Browser allows you to perform the following actions:
 - **View Cost Category definition**: View the details of a Cost Category definition by clicking on the Cost Category definition.
 - **Delete Cost Category definition**: Delete a Cost Category definition by selecting on the Cost Categorty definition, and then clicking on the **Actions** button followed by **Remove Selected**.
 
-## Limitations
+## Current Limitations
 
 LocalStack's Cost Explorer implementation cannot programmatically query your cost and usage data, or provide aggregated data such as total monthly costs or total daily usage. However, you can use the integrations to mock the Cost Explorer APIs and test your workflow locally.

--- a/content/en/user-guide/aws/ce/index.md
+++ b/content/en/user-guide/aws/ce/index.md
@@ -12,10 +12,6 @@ Cost Explorer is a service provided by Amazon Web Services (AWS) that enables yo
 
 LocalStack allows you to use the Cost Explorer APIs in your local environment to create and manage cost category definition, cost anomaly monitors & subscriptions. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_ce/), which provides information on the extent of Cost Explorer's integration with LocalStack.
 
-{{< callout >}}
-LocalStack's Cost Explorer implementation cannot programmatically query your cost and usage data, or provide aggregated data such as total monthly costs or total daily usage. However, you can use the integrations to mock the Cost Explorer APIs and test your workflow locally.
-{{< /callout >}}
-
 ## Getting started
 
 This guide is designed for users new to Cost Explorer and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
@@ -163,3 +159,7 @@ The Resource Browser allows you to perform the following actions:
 - **Create Cost Category definition**: Create a new Cost Category definition by clicking on the **Create** button and providing the required details.
 - **View Cost Category definition**: View the details of a Cost Category definition by clicking on the Cost Category definition.
 - **Delete Cost Category definition**: Delete a Cost Category definition by selecting on the Cost Categorty definition, and then clicking on the **Actions** button followed by **Remove Selected**.
+
+## Limitations
+
+LocalStack's Cost Explorer implementation cannot programmatically query your cost and usage data, or provide aggregated data such as total monthly costs or total daily usage. However, you can use the integrations to mock the Cost Explorer APIs and test your workflow locally.

--- a/content/en/user-guide/aws/cognito/index.md
+++ b/content/en/user-guide/aws/cognito/index.md
@@ -13,10 +13,6 @@ Cognito is a managed identity service provided by AWS that is used for securing 
 
 LocalStack allows you to use the Cognito APIs in your local environment to manage authentication and access control for your local application and resources. The supported APIs are available on our [Cognito Identity coverage page](https://docs.localstack.cloud/references/coverage/coverage_cognito-identity/) and [Cognito User Pools coverage page](https://docs.localstack.cloud/references/coverage/coverage_cognito-idp/), which provides information on the extent of Cognito's integration with LocalStack.
 
-{{< callout >}}
-By default, LocalStack's Cognito does not send actual email messages. However, if you wish to enable this feature, you will need to provide an email address and configure the corresponding SMTP settings. The instructions on configuring the connection parameters of your SMTP server can be found in the [Configuration]({{< ref "configuration#emails" >}}) guide to allow your local Cognito environment to send email notifications.
-{{< /callout >}}
-
 ## Getting started
 
 This guide is designed for users new to Cognito and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
@@ -316,3 +312,7 @@ The following code snippets and sample applications provide practical examples o
 - [Running Cognito authentication and user pools locally](https://github.com/localstack/localstack-pro-samples/tree/master/cognito-jwt)
 - [Serverless Container-based APIs with ECS & API Gateway](https://github.com/localstack/serverless-api-ecs-apigateway-sample)
 - [Step-up Authentication using Cognito](https://github.com/localstack/step-up-auth-sample)
+
+## Limitations
+
+By default, LocalStack's Cognito does not send actual email messages. However, if you wish to enable this feature, you will need to provide an email address and configure the corresponding SMTP settings. The instructions on configuring the connection parameters of your SMTP server can be found in the [Configuration]({{< ref "configuration#emails" >}}) guide to allow your local Cognito environment to send email notifications.

--- a/content/en/user-guide/aws/cognito/index.md
+++ b/content/en/user-guide/aws/cognito/index.md
@@ -313,6 +313,6 @@ The following code snippets and sample applications provide practical examples o
 - [Serverless Container-based APIs with ECS & API Gateway](https://github.com/localstack/serverless-api-ecs-apigateway-sample)
 - [Step-up Authentication using Cognito](https://github.com/localstack/step-up-auth-sample)
 
-## Limitations
+## Current Limitations
 
 By default, LocalStack's Cognito does not send actual email messages. However, if you wish to enable this feature, you will need to provide an email address and configure the corresponding SMTP settings. The instructions on configuring the connection parameters of your SMTP server can be found in the [Configuration]({{< ref "configuration#emails" >}}) guide to allow your local Cognito environment to send email notifications.

--- a/content/en/user-guide/aws/config/index.md
+++ b/content/en/user-guide/aws/config/index.md
@@ -98,7 +98,7 @@ $ awslocal configservice describe-delivery-channels
 $ awslocal configservice describe-configuration-recorder-status
 {{< /command >}}
 
-## Limitations
+## Current Limitations
 
 AWS Config is currently mocked in LocalStack.
 You can create, read, update, and delete AWS Config resources (like delivery channels or configuration recorders),

--- a/content/en/user-guide/aws/dms/index.md
+++ b/content/en/user-guide/aws/dms/index.md
@@ -122,7 +122,7 @@ DMS is in a preview state on LocalStack and only supports some selected use case
 | RDS MySQL          | Kinesis     | full-load, cdc  |
 
 
-## Limitations
+## Current Limitations
 
 For RDS MariaDB and RDS MySQL it is not yet possible to set custom db-parameters. 
 In order to make those databases work with `cdc` migration for DMS, some default db-parameters are changed upon start if the `ENABLE_DMS=1` flag is set:

--- a/content/en/user-guide/aws/docdb/index.md
+++ b/content/en/user-guide/aws/docdb/index.md
@@ -12,16 +12,6 @@ DocumentDB is a fully managed, non-relational database service that supports Mon
 
 LocalStack allows you to use the DocumentDB APIs to create and manage DocumentDB clusters and instances. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_docdb/), which provides information on the extent of DocumentDB's integration with LocalStack.
 
-{{< callout >}}
-Under the hood, LocalStack starts a MongoDB server, to handle DocumentDB storage, in a separate Docker container and adds port-mapping so that it can be accessed from `localhost`. When defining a port to access the container, an available port on the host machine will be selected, that means there is no pre-defined port range by default.
-
-Because LocalStack utilizes a MongoDB container to provide DocumentDB storage, LocalStack may not
-have exact feature parity with Amazon DocumentDB. The database engine may support additional
-features that DocumentDB does not and vice versa.
-
-DocumentDB currently uses the default configuration of the latest [MongoDB Docker image](https://hub.docker.com/_/mongo). When the `MasterUsername` and `MasterUserPassword` are set for the creation for the DocumentDB cluster or instance, the container will be started with the corresponding ENVs `MONGO_INITDB_ROOT_USERNAME` respectively `MONGO_INITDB_ROOT_PASSWORD`. 
-{{< /callout >}}
-
 ## Getting started
 
 To create a new DocumentDB cluster we use the `create-db-cluster` command as follows:
@@ -410,3 +400,11 @@ The Resource Browser allows you to perform the following actions:
 - **View Instance & Cluster**: View an existing DocumentDB instance or cluster by clicking the instance/cluster name.
 - **Edit Instance & Cluster**: Edit an existing DocumentDB instance or cluster by clicking the instance/cluster name and clicking the **Edit Instance** or **Edit Cluster** button.
 - **Remove Instance & Cluster**: Remove an existing DocumentDB instance or cluster by clicking the instance/cluster name and clicking the **Actions** followed by **Remove Selected** button.
+
+## Limitations
+
+Under the hood, LocalStack starts a MongoDB server, to handle DocumentDB storage, in a separate Docker container and adds port-mapping so that it can be accessed from `localhost`. When defining a port to access the container, an available port on the host machine will be selected, that means there is no pre-defined port range by default.
+
+Because LocalStack utilizes a MongoDB container to provide DocumentDB storage, LocalStack may not have exact feature parity with Amazon DocumentDB. The database engine may support additional features that DocumentDB does not and vice versa.
+
+DocumentDB currently uses the default configuration of the latest [MongoDB Docker image](https://hub.docker.com/_/mongo). When the `MasterUsername` and `MasterUserPassword` are set for the creation for the DocumentDB cluster or instance, the container will be started with the corresponding ENVs `MONGO_INITDB_ROOT_USERNAME` respectively `MONGO_INITDB_ROOT_PASSWORD`. 

--- a/content/en/user-guide/aws/docdb/index.md
+++ b/content/en/user-guide/aws/docdb/index.md
@@ -401,7 +401,7 @@ The Resource Browser allows you to perform the following actions:
 - **Edit Instance & Cluster**: Edit an existing DocumentDB instance or cluster by clicking the instance/cluster name and clicking the **Edit Instance** or **Edit Cluster** button.
 - **Remove Instance & Cluster**: Remove an existing DocumentDB instance or cluster by clicking the instance/cluster name and clicking the **Actions** followed by **Remove Selected** button.
 
-## Limitations
+## Current Limitations
 
 Under the hood, LocalStack starts a MongoDB server, to handle DocumentDB storage, in a separate Docker container and adds port-mapping so that it can be accessed from `localhost`. When defining a port to access the container, an available port on the host machine will be selected, that means there is no pre-defined port range by default.
 

--- a/content/en/user-guide/aws/dynamodb/index.md
+++ b/content/en/user-guide/aws/dynamodb/index.md
@@ -13,10 +13,6 @@ DynamoDB provides a fast and scalable key-value datastore with support for repli
 LocalStack allows you to use the DynamoDB APIs in your local environment to manage key-value and document data models.
 The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_dynamodb/), which provides information on the extent of DynamoDB's integration with LocalStack.
 
-{{< callout >}}
-DynamoDB on LocalStack is powered by [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html).
-{{< /callout >}}
-
 ## Getting started
 
 This guide is designed for users new to DynamoDB and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.

--- a/content/en/user-guide/aws/dynamodb/index.md
+++ b/content/en/user-guide/aws/dynamodb/index.md
@@ -202,7 +202,7 @@ The following code snippets and sample applications provide practical examples o
 -   [Loan Broker application with AWS Step Functions, DynamoDB, Lambda, SQS, and SNS](https://github.com/localstack/loan-broker-stepfunctions-lambda-app)
 -   [Messaging Processing application with SQS, DynamoDB, and Fargate](https://github.com/localstack/sqs-fargate-ddb-cdk-go)
 
-## Limitations
+## Current Limitations
 
 ### Global tables
 

--- a/content/en/user-guide/aws/efs/index.md
+++ b/content/en/user-guide/aws/efs/index.md
@@ -100,6 +100,6 @@ The following output would be retrieved:
 }
 ```
 
-## Limitations
+## Current Limitations
 
 LocalStack's EFS implementation is limited and lacks support for functionalities like creating mount targets, configuring access points, and generating tags. LocalStack uses Moto to emulate the EFS APIs, and efforts are underway to incorporate support for these features in upcoming updates.

--- a/content/en/user-guide/aws/efs/index.md
+++ b/content/en/user-guide/aws/efs/index.md
@@ -12,10 +12,6 @@ Elastic File System (EFS) is a fully managed file storage service provided by Am
 
 LocalStack allows you to use the EFS APIs in your local environment to create local file systems, lifecycle configurations, and file system policies. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_efs/), which provides information on the extent of EFS's integration with LocalStack.
 
-{{< callout "note" >}}
-LocalStack's EFS implementation is limited and lacks support for functionalities like creating mount targets, configuring access points, and generating tags. LocalStack uses Moto to emulate the EFS APIs, and efforts are underway to incorporate support for these features in upcoming updates.
-{{< /callout >}}
-
 ## Getting started
 
 This guide is designed for users new to Elastic File System and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
@@ -103,3 +99,7 @@ The following output would be retrieved:
     ]
 }
 ```
+
+## Limitations
+
+LocalStack's EFS implementation is limited and lacks support for functionalities like creating mount targets, configuring access points, and generating tags. LocalStack uses Moto to emulate the EFS APIs, and efforts are underway to incorporate support for these features in upcoming updates.

--- a/content/en/user-guide/aws/elasticache/index.md
+++ b/content/en/user-guide/aws/elasticache/index.md
@@ -18,7 +18,7 @@ It supports popular open-source caching engines like Redis and Memcached (LocalS
 providing a means to efficiently store and retrieve frequently accessed data with minimal latency.
 
 LocalStack supports ElastiCache via the Pro offering, allowing you to use the ElastiCache APIs in your local environment.
-The supported APIs are available on our API Coverage Page,
+The supported APIs are available on our [API Coverage Page]{{< ref "coverage_elasticache" >}},
 which provides information on the extent of ElastiCache integration with LocalStack.
 
 
@@ -139,5 +139,3 @@ Moreover, LocalStack emulation support for ElastiCache is mostly centered around
 Resources necessary to operate a cluster, like parameter groups, security groups, subnets groups, etc. are mocked, but have no effect on the functioning of the Redis servers.
 
 LocalStack currently doesn't support ElastiCache snapshots, failovers, users/passwords, service updates, replication scaling, SSL, migrations, service integration (like CloudWatch/Kinesis log delivery, SNS notifications) or tests.
-
-You can find a detailed list of covered API methods on the [ElastiCache coverage page]({{< ref "coverage_elasticache" >}}).

--- a/content/en/user-guide/aws/elasticache/index.md
+++ b/content/en/user-guide/aws/elasticache/index.md
@@ -131,7 +131,7 @@ In the ElastiCache resource browser you can:
   {{< img src="elasticache-resource-browser-create.png" alt="Create a ElastiCache cluster in the resource browser" >}}
 
 
-## Limitations
+## Current Limitations
 
 LocalStack currently supports Redis single-node and cluster mode, but not memcached.
 Moreover, LocalStack emulation support for ElastiCache is mostly centered around starting/stopping Redis servers.

--- a/content/en/user-guide/aws/elasticbeanstalk/index.md
+++ b/content/en/user-guide/aws/elasticbeanstalk/index.md
@@ -12,10 +12,6 @@ Elastic Beanstalk (EB) is a managed platform-as-a-service (PaaS) provided by Ama
 
 LocalStack allows you to use the Elastic Beanstalk APIs in your local environment to create and manage applications, environments and versions. The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_elasticbeanstalk/), which provides information on the extent of Elastic Beanstalk's integration with LocalStack.
 
-{{< callout >}}
-LocalStack's Elastic Beanstalk implementation is limited and lacks support for installing application and running it in a local Elastic Beanstalk environment. LocalStack also does not support the [`eb`](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) CLI tool. However, you can use other integrations, such as AWS CLI & Terraform, to mock the Elastic Beanstalk APIs and test your workflow locally.
-{{< /callout >}}
-
 ## Getting started
 
 This guide is designed for users new to Elastic Beanstalk and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
@@ -108,3 +104,7 @@ You can also use the [`DescribeApplicationVersions`](https://docs.aws.amazon.com
 $ awslocal elasticbeanstalk describe-application-versions \
     --application-name my-app
 {{< /command >}}
+
+## Limitations
+
+LocalStack's Elastic Beanstalk implementation is limited and lacks support for installing application and running it in a local Elastic Beanstalk environment. LocalStack also does not support the [`eb`](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) CLI tool. However, you can use other integrations, such as AWS CLI & Terraform, to mock the Elastic Beanstalk APIs and test your workflow locally.

--- a/content/en/user-guide/aws/elasticbeanstalk/index.md
+++ b/content/en/user-guide/aws/elasticbeanstalk/index.md
@@ -105,6 +105,6 @@ $ awslocal elasticbeanstalk describe-application-versions \
     --application-name my-app
 {{< /command >}}
 
-## Limitations
+## Current Limitations
 
 LocalStack's Elastic Beanstalk implementation is limited and lacks support for installing application and running it in a local Elastic Beanstalk environment. LocalStack also does not support the [`eb`](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) CLI tool. However, you can use other integrations, such as AWS CLI & Terraform, to mock the Elastic Beanstalk APIs and test your workflow locally.

--- a/content/en/user-guide/aws/elb/index.md
+++ b/content/en/user-guide/aws/elb/index.md
@@ -144,7 +144,7 @@ The following code snippets and sample applications provide practical examples o
 
 - [Setting up Elastic Load Balancing (ELB) Application Load Balancers using LocalStack, deployed via the Serverless framework](https://docs.localstack.cloud/tutorials/elb-load-balancing/)
 
-## Limitations
+## Current Limitations
 
 - The Application Load Balancer currently supports only the `forward` and `redirect` action types.
 - When opting for Route53 CNAMEs to direct requests towards the ALBs, it's important to remember that explicit configuration of the `Host` header to match the resource record might be necessary while making calls.

--- a/content/en/user-guide/aws/es/index.md
+++ b/content/en/user-guide/aws/es/index.md
@@ -318,6 +318,6 @@ $ curl -X PUT mylogs-2.us-east-1.es.localhost.localstack.cloud:4566/my-index
   LocalStack will return the endpoint immediately, but keep `Processing = "true"` until the cluster has been started.
 * The `CustomEndpointOptions` allows arbitrary endpoint URLs, which is not allowed in AWS
 
-## Limitations
+## Current Limitations
 
 The default Elasticsearch version used is 7.10.0. This is a slight deviation from the default version used in AWS (Elasticsearch 1.5), which is not supported in LocalStack.

--- a/content/en/user-guide/aws/es/index.md
+++ b/content/en/user-guide/aws/es/index.md
@@ -21,10 +21,6 @@ You can go ahead and use [awslocal]({{< ref "aws-cli.md#localstack-aws-cli-awslo
 Unless you use the Elasticsearch default version, the first time you create a cluster with a specific version, the Elasticsearch binary is downloaded, which may take a while to download.
 {{< /callout >}}
 
-{{< callout >}}
-The default Elasticsearch version used is 7.10.0. This is a slight deviation from the default version used in AWS (Elasticsearch 1.5), which is not supported in LocalStack.
-{{< /callout >}}
-
 {{< command >}}
 $ awslocal es create-elasticsearch-domain --domain-name my-domain
 {
@@ -321,3 +317,7 @@ $ curl -X PUT mylogs-2.us-east-1.es.localhost.localstack.cloud:4566/my-index
 * By default, AWS only sets the `Endpoint` attribute of the cluster status once the cluster is up.
   LocalStack will return the endpoint immediately, but keep `Processing = "true"` until the cluster has been started.
 * The `CustomEndpointOptions` allows arbitrary endpoint URLs, which is not allowed in AWS
+
+## Limitations
+
+The default Elasticsearch version used is 7.10.0. This is a slight deviation from the default version used in AWS (Elasticsearch 1.5), which is not supported in LocalStack.

--- a/content/en/user-guide/aws/fis/index.md
+++ b/content/en/user-guide/aws/fis/index.md
@@ -244,7 +244,7 @@ Within its `parameters` section, you can configure the following:
 
 This table summarizes the configurable parameters for the `localstack:generic:api-error` action in LocalStack FIS.
 
-## Limitations
+## Current Limitations
 
 1. LocalStack currently supports only a subset of FIS actions available in AWS.
 Unsupported actions will result in an error.

--- a/content/en/user-guide/aws/glue/index.md
+++ b/content/en/user-guide/aws/glue/index.md
@@ -427,6 +427,6 @@ The following code snippets and sample applications provide practical examples o
 
 The AWS Glue API is a fairly comprehensive service - more details can be found in the official [AWS Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html).
 
-## Limitations
+## Current Limitations
 
 Support for triggers is currently limited - the basic API endpoints are implemented, but triggers are currently still under development (more details coming soon).

--- a/content/en/user-guide/aws/iot/index.md
+++ b/content/en/user-guide/aws/iot/index.md
@@ -196,7 +196,7 @@ You can use AWS CLI and [MQTT topics](https://docs.aws.amazon.com/iot/latest/dev
 The endpoint as returned by `DescribeEndpoint` currently does not support the [device shadow REST API](https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-rest-api.html#API_GetThingShadow)
 
 
-## Limitations
+## Current Limitations
 
 LocalStack MQTT broker does not support multi-account/multi-region namespacing.
 Internally, the MQTT messages are not routed to the appropriate account ID/region even though the endpoint URL may suggest otherwise.

--- a/content/en/user-guide/aws/kinesis/index.md
+++ b/content/en/user-guide/aws/kinesis/index.md
@@ -190,6 +190,6 @@ The following code snippets and sample applications provide practical examples o
 - [Search application with Lambda, Kinesis, Firehose, ElasticSearch, S3](https://github.com/localstack/sample-fuzzy-movie-search-lambda-kinesis-elasticsearch)
 - [Streaming Data Pipeline with Kinesis, Tinybird, CloudWatch, Lambda](https://github.com/localstack/serverless-streaming-data-pipeline)
 
-## Limitations
+## Current Limitations
 
 In multi-account setups, each AWS account launches a separate instance of Kinesis Mock, which is very resource intensive when a large number of AWS accounts are used. An [open Kinesis Mock issue](https://github.com/etspaceman/kinesis-mock/issues/377) is being used to keep track of this feature.

--- a/content/en/user-guide/aws/kms/index.md
+++ b/content/en/user-guide/aws/kms/index.md
@@ -106,7 +106,7 @@ $ awslocal kms create-key --tags '[{"TagKey":"_custom_id_","TagValue":"00000000-
 }
 {{< / command >}}
 
-## Limitations
+## Current Limitations
 
 ### Encryption data format
 

--- a/content/en/user-guide/aws/memorydb/index.md
+++ b/content/en/user-guide/aws/memorydb/index.md
@@ -67,7 +67,7 @@ To start Redis clusters of a specific version, enable container mode for Redis-b
 This approach directs LocalStack to launch Redis instances in distinct containers, utilizing your chosen image tag. 
 Additionally, container mode is beneficial for independently examining the logs of each Redis instance. To activate this, set the `REDIS_CONTAINER_MODE` configuration variable to `1`.
 
-## Limitations
+## Current Limitations
 
 LocalStack's emulation support for MemoryDB primarily focuses on the creation and termination of Redis servers in cluster mode. Essential resources for running a cluster, such as parameter groups, security groups, and subnet groups, are mocked but have no effect on the Redis servers' operation.
 

--- a/content/en/user-guide/aws/mq/index.md
+++ b/content/en/user-guide/aws/mq/index.md
@@ -98,7 +98,7 @@ The following code snippets and sample applications provide practical examples o
 
 - [Demo application illustrating the use of MQ with LocalStack](https://github.com/localstack/localstack-pro-samples/tree/master/mq-broker)
 
-## Limitations
+## Current Limitations
 
 Currently, our MQ emulation offers only fundamental capabilities, and it comes with certain limitations:
 

--- a/content/en/user-guide/aws/opensearch/index.md
+++ b/content/en/user-guide/aws/opensearch/index.md
@@ -350,7 +350,7 @@ The Resource Browser allows you to perform the following actions:
 - **Edit Domain**: Edit the configuration of a domain by clicking on domain name and then clicking on the **Edit Domain** button.
 - **Delete Domain**: Delete a domain by selecting the domain name and clicking on the **Actions** dropdown menu, then selecting **Remove Selected**.
 
-## Limitations
+## Current Limitations
 
 Internally, LocalStack makes use of the [OpenSearch Python client 2.x](https://github.com/opensearch-project/opensearch-py). The functionalities marked as deprecated in OpenSearch 1.x and subsequently removed in OpenSearch 2.x may not operate reliably when interacting with OpenSearch 1.x clusters through LocalStack. You can refer to the [compatibility documentation](https://github.com/opensearch-project/opensearch-py/blob/main/COMPATIBILITY.md) provided by the [OpenSearch Python client repository](https://github.com/opensearch-project/opensearch-py).
 

--- a/content/en/user-guide/aws/pipes/index.md
+++ b/content/en/user-guide/aws/pipes/index.md
@@ -179,7 +179,7 @@ Please create a feature request on [GitHub](https://github.com/localstack/locals
 Firehose stream logs,
 or Amazon S3 logs.
 
-## Limitations
+## Current Limitations
 
 The EventBridge Pipes implementation in LocalStack is currently in preview stage and has the following limitations:
 

--- a/content/en/user-guide/aws/qldb/index.md
+++ b/content/en/user-guide/aws/qldb/index.md
@@ -327,7 +327,7 @@ The Resource Browser allows you to perform the following actions:
 - **Edit Ledger**: Edit the details of a specific ledger by clicking on the ledger name and then clicking on the **Edit Ledger** button.
 - **Delete Ledger**: Delete a specific ledger by selecting the ledger name and clicking on the **Actions** dropdown menu, then selecting **Remove Selected**.
 
-### Examples
+## Examples
 
 Interacting with Amazon QLDB (Quantum Ledger Database) is typically done using language-specific
 software

--- a/content/en/user-guide/aws/ram/index.md
+++ b/content/en/user-guide/aws/ram/index.md
@@ -34,7 +34,7 @@ $ awslocal ram create-resource-share \
     --resource-arn arn:aws:appsync:eu-central-1:000000000000:apis/wcgmjril5wuyvhmpildatuaat3
 {{< /command >}}
 
-## Limitations
+## Current Limitations
 
 RAM on LocalStack currently functions as a CRUD interface only.
 Resource shares do not lead to IAM policies being created or attached to resources. 

--- a/content/en/user-guide/aws/serverlessrepo/index.md
+++ b/content/en/user-guide/aws/serverlessrepo/index.md
@@ -103,7 +103,7 @@ Replace `<application-id>` with the Application ID of your SAM application that 
 
 You can also create a CloudFormation changeset using the [`CreateCloudFormationChangeSet`](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/serverlessrepo-how-to-publish.html) API, and then execute the changeset to deploy the SAM application using the [`ExecuteChangeSet`](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ExecuteChangeSet.html) API.
 
-## Limitations
+## Current Limitations
 
 - Keep in mind, since the application is only registered in your individual localstack instance, you won't be able to share them with other developers.
 - Currently LocalStack only supports one AWS-hosted application (`"arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSPostgreSQLRotationMultiUser`).

--- a/content/en/user-guide/aws/ses/index.md
+++ b/content/en/user-guide/aws/ses/index.md
@@ -119,7 +119,7 @@ The Resource Browser allows you to perform following actions:
 - **View Sent Emails**: View all sent emails from an email identity by clicking the email address. You can the view the details of a sent email by selecting them from the list.
 - **Send Emails**: On selecting an email identity, click **Send Message** and specify destination fields (To, CC and BCC addresses) and the body (Plaintext, HTML) to send an email.
 
-## Limitations
+## Current Limitations
 
 It is currently not possible to [receive emails via SES](https://docs.aws.amazon.com/ses/latest/dg/receiving-email.html) in LocalStack.
 Consequently, all operations related to Receipt Rules are currently mocked.

--- a/content/en/user-guide/aws/sqs/index.md
+++ b/content/en/user-guide/aws/sqs/index.md
@@ -639,6 +639,6 @@ The following code snippets and sample applications provide practical examples o
 - [Messaging Processing application with SQS, DynamoDB, and Fargate](https://github.com/localstack/sqs-fargate-ddb-cdk-go)
 - [Serverless Transcription application using Transcribe, S3, Lambda, SQS, and SES](https://github.com/localstack/sample-transcribe-app)
 
-## Limitations
+## Current Limitations
 
 * Updating a queue's `MessageRetentionPeriod` currently has no effect on existing messages

--- a/content/en/user-guide/aws/ssm/index.md
+++ b/content/en/user-guide/aws/ssm/index.md
@@ -122,7 +122,7 @@ The Resource Browser allows you to perform the following actions:
 - **View the System Parameter**: View the details of a System Parameter, such as its value, by clicking on the parameter name.
 - **Delete the System Parameter**: Delete a System Parameter by selecting the parameter and clicking on the **Actions** dropdown menu followed by **Remove Selected**.
 
-## Limitations
+## Current Limitations
 
 The following table highlights some differences between LocalStack SSM and AWS SSM.
 

--- a/content/en/user-guide/aws/timestream/index.md
+++ b/content/en/user-guide/aws/timestream/index.md
@@ -68,7 +68,7 @@ The Resource Browser allows you to perform the following actions:
 - **View Database/Table Details**: Click on a database or table to view its details, including the schema, retention policy, and other metadata.
 - **Delete Database/Table**: Delete the Timestream database/table by selecting it and clicking on the **Actions** button followed by **Remove Selected** button.
 
-## Limitations
+## Current Limitations
 
 LocalStack's Timestream implementation is under active development and only supports a limited set of operations, please refer to the API Coverage pages for an up-to-date list of implemented and tested functions within [Timestream-Query](https://docs.localstack.cloud/references/coverage/coverage_timestream-query/) and [Timestream-Write](https://docs.localstack.cloud/references/coverage/coverage_timestream-write/).
 

--- a/content/en/user-guide/aws/transcribe/index.md
+++ b/content/en/user-guide/aws/transcribe/index.md
@@ -115,7 +115,7 @@ The following code snippets and sample applications provide practical examples o
 
 - [Serverless Transcription App using Transcribe, S3, Lambda, SQS, SES](https://github.com/localstack-samples/sample-serverless-transcribe)
 
-## Limitations
+## Current Limitations
 
 Currently, our Transcribe emulation offers only supported formats and languages.
 

--- a/content/en/user-guide/aws/transfer/index.md
+++ b/content/en/user-guide/aws/transfer/index.md
@@ -73,7 +73,7 @@ Please note that this code is a simplified example for demonstration purposes.
 In a production environment, you should use more secure practices, including setting proper IAM roles and handling sensitive credentials securely.
 Additionally, error handling and cleanup code may be needed to ensure the script behaves robustly in all scenarios.
 
-## Limitations 
+## Current Limitations 
 The Transfer API does not provide a way to return the endpoint URL of created FTP servers.
 Hence, in order to determine the server endpoint, the local port is encoded as a suffix within the `ServerId` attribute, constituting the only numeric digits within the ID string.
 For example, assume the following is the response from the `CreateServer` API call, then the FTP server is accessible on port `4511` (i.e., `ftp://localhost:4511`):

--- a/content/en/user-guide/aws/xray/index.md
+++ b/content/en/user-guide/aws/xray/index.md
@@ -115,7 +115,7 @@ The following code snippets and sample applications provide practical examples o
 
 - [Lambda X-Ray](https://github.com/localstack/localstack-pro-samples/tree/master/lambda-xray) shows how to instrument Lambda functions for X-Ray using Powertools and the X-Ray SDK.
 
-## Limitations
+## Current Limitations
 
 LocalStack supports collecting trace segments but currently does not correlate multiple trace segments with the same
 `trace_id` into a single aggregated trace.

--- a/content/en/user-guide/ci/bitbucket/index.md
+++ b/content/en/user-guide/ci/bitbucket/index.md
@@ -80,7 +80,7 @@ pipelines:
           - docker run -d --rm -p 4566:4566 -p 4510-4559:4510-4559 -e LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} -e DEBUG=1 -e LS_LOG=trace -e DOCKER_SOCK=tcp://${BITBUCKET_DOCKER_HOST_INTERNAL}:2375 -e DOCKER_HOST=tcp://${BITBUCKET_DOCKER_HOST_INTERNAL}:2375 --name localstack-main localstack/localstack-pro
           ...
 ```
-## Limitations
+## Current Limitations
 
 ### Mounting Volumes
 

--- a/content/en/user-guide/ci/codebuild/index.md
+++ b/content/en/user-guide/ci/codebuild/index.md
@@ -298,7 +298,8 @@ phases:
 
 Find out more about [ephemeral instances](/user-guide/cloud-sandbox/).
 
-## Limitations and known issues
+## Limitations
+
 - We recommend using the `public.ecr.aws/localstack/localstack:latest` image to start LocalStack, instead of the `localstack/localstack:latest` image. LocalStack mirrors the Docker Hub image to the public ECR repository.
   You can use the Docker Hub image as well, though you may run into the following error:
   ```bash

--- a/content/en/user-guide/ci/codebuild/index.md
+++ b/content/en/user-guide/ci/codebuild/index.md
@@ -298,7 +298,7 @@ phases:
 
 Find out more about [ephemeral instances](/user-guide/cloud-sandbox/).
 
-## Limitations
+## Current Limitations
 
 - We recommend using the `public.ecr.aws/localstack/localstack:latest` image to start LocalStack, instead of the `localstack/localstack:latest` image. LocalStack mirrors the Docker Hub image to the public ECR repository.
   You can use the Docker Hub image as well, though you may run into the following error:

--- a/content/en/user-guide/ci/github-actions/index.md
+++ b/content/en/user-guide/ci/github-actions/index.md
@@ -192,7 +192,7 @@ jobs:
 
 Find out more about ephemeral instances [here](/user-guide/cloud-sandbox/).
 
-## Known Issues and Limitations
+## Limitations
 
 ### Running Lambdas targeting the `arm64` architecture
 

--- a/content/en/user-guide/ci/github-actions/index.md
+++ b/content/en/user-guide/ci/github-actions/index.md
@@ -192,7 +192,7 @@ jobs:
 
 Find out more about ephemeral instances [here](/user-guide/cloud-sandbox/).
 
-## Limitations
+## Current Limitations
 
 ### Running Lambdas targeting the `arm64` architecture
 

--- a/content/en/user-guide/ci/gitlab-ci/index.md
+++ b/content/en/user-guide/ci/gitlab-ci/index.md
@@ -200,7 +200,7 @@ test-job:
 
 Find out more about ephemeral instances [here](/user-guide/cloud-sandbox/).
 
-## Limitations and Known Issues
+## Limitations
 
 - Localstack must be able to reach a docker socket to provision containers for certain services, ie Lambda, EKS, ECS...etc
 - the runner must be able to resolve the Localstack domain (by default _localhost.localstack.cloud_), see the sample pipelines for a possible solution

--- a/content/en/user-guide/ci/gitlab-ci/index.md
+++ b/content/en/user-guide/ci/gitlab-ci/index.md
@@ -200,7 +200,7 @@ test-job:
 
 Find out more about ephemeral instances [here](/user-guide/cloud-sandbox/).
 
-## Limitations
+## Current Limitations
 
 - Localstack must be able to reach a docker socket to provision containers for certain services, ie Lambda, EKS, ECS...etc
 - the runner must be able to resolve the Localstack domain (by default _localhost.localstack.cloud_), see the sample pipelines for a possible solution

--- a/content/en/user-guide/integrations/aws-cdk/index.md
+++ b/content/en/user-guide/integrations/aws-cdk/index.md
@@ -83,7 +83,7 @@ $ awslocal sns list-topics
 }
 {{< /command >}}
 
-## Limitations
+## Current Limitations
 
 ### Updating CDK stacks
 

--- a/content/en/user-guide/integrations/aws-cli/index.md
+++ b/content/en/user-guide/integrations/aws-cli/index.md
@@ -113,7 +113,7 @@ awslocal kinesis list-streams
 | LOCALSTACK_HOST    | (deprecated) A variable defining where to find LocalStack (default: localhost:4566) |
 | USE_SSL             | (deprecated) Whether to use SSL when connecting to LocalStack (default: False) |
 
-### Limitations
+### Current Limitations
 
 Please note that there is a known limitation for using the `cloudformation package ...` command with the AWS CLI v2.
 The problem is that the AWS CLI v2 is [not available as a package on pypi.org](https://github.com/aws/aws-cli/issues/4947), but is instead shipped as a binary package that cannot be easily patched from `awslocal`.

--- a/content/en/user-guide/integrations/spring-cloud-function/index.md
+++ b/content/en/user-guide/integrations/spring-cloud-function/index.md
@@ -43,7 +43,7 @@ any other JVM setup.
 * [Testing, Debugging and Hot Reloading](#testing-debugging-and-hot-reloading)
 * [Useful links](#useful-links)
 
-### Limitations
+### Current Limitations
 
 This document demonstrates the usage of the Spring Cloud Function framework
 together with LocalStack.

--- a/content/en/user-guide/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/lambda-tools/debugging/index.md
@@ -112,7 +112,7 @@ The screenshot below shows the triggered breakpoint with our `'Hello from LocalS
 
 ![Visual Studio Code debugging](vscode-debugging-py-1.png)
 
-#### Limitations
+#### Current Limitations
 
 Due to the ports published by the lambda container for the debugger, you can currently only debug one Lambda at a time. Due to the port publishing, multiple concurrently running lambda environments are not supported.
 

--- a/content/en/user-guide/lambda-tools/vscode-extension/index.md
+++ b/content/en/user-guide/lambda-tools/vscode-extension/index.md
@@ -42,7 +42,7 @@ Click the CodeLens **Invoke Lambda function** and pick the stack name `my-stack`
 <img src="invoke-lambda-function.gif" alt="Invoking Lambda function via the VS Code Extension" title="Invoking Lambda function via the VS Code Extension" width="700" />
 <br>
 
-## Limitations
+## Current Limitations
 
 - The CodeLens for **Deploy Lambda function** always appears at the first line of each Python file.
 - **Invoke Lambda function** currently only works in the region `us-east-1` and with an empty payload.

--- a/content/en/user-guide/state-management/cloud-pods/index.md
+++ b/content/en/user-guide/state-management/cloud-pods/index.md
@@ -452,7 +452,7 @@ Custom remote configurations are stored within the [LocalStack volume directory]
 
 In contrast, Cloud Pods provide more detailed control over your state. Rather than just restoring a state during LocalStack restarts, Cloud Pods enable you to capture snapshots of your local instance using the `save` command and inject these snapshots into a running instance using the `load` command, all without needing to perform a full restart.
 
-### Limitations
+### Current Limitations
 
 Cloud Pods (and state management in general), come with a few limitation.
 In particular, Cloud Pods states might not be correctly restored if the LocalStack version used to create the pod and the target one differ.

--- a/scripts/create-aws-guide.js
+++ b/scripts/create-aws-guide.js
@@ -41,7 +41,7 @@ const genFrontMatter = (answers) => {
         // Link the examples from Developer Hub & Pro/Terraform/Pulumi samples
         // Provide a short description of each example
 
-        ## Limitations
+        ## Current Limitations
 
         // If there are any specific limitation or difference in behavior against AWS
         // Add sub-headings for each limitation and provide a short description


### PR DESCRIPTION
This PR:

- Collects all known issues under the **Current Limitations** heading 
- Removes all the **Known Issues** section and callouts at the beginning of the page