### PR TITLE
Add note to CFn service page about the new default deployment engine

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -94,8 +94,9 @@ This section covers configuration options that are specific to certain AWS servi
 ### CloudFormation
 | Variable | Example Values | Description |
 | - | - | - |
+| `CFN_LEGACY_TEMPLATE_DEPLOYER` | `0` (default) \|`1` | Switch back to the old deployment engine. Note that this is only available temporarily to allow for a smoother roll-out of the new deployment order. 
 | `CFN_PER_RESOURCE_TIMEOUT` | `300` (default) | Set the timeout to deploy each individual CloudFormation resource.
-| `CFN_VERBOSE_ERRORS` | `0` (default) | Show exceptions for CloudFormation deploy errors.
+| `CFN_VERBOSE_ERRORS` | `0` (default) \|`1` | Show exceptions for CloudFormation deploy errors.
 
 ### CloudWatch
 

--- a/content/en/user-guide/aws/cloudformation/index.md
+++ b/content/en/user-guide/aws/cloudformation/index.md
@@ -4,6 +4,10 @@ linkTitle: "CloudFormation"
 description: Get started with Cloudformation on LocalStack
 ---
 
+{{< callout >}}
+With LocalStack 3.5 we've improved how the internal engine orders resources for deployment and deletion of stacks. Specifically it now more accurately calculates dependencies between resources and doesn't try to deploy/delete resources which don't have their dependencies available yet. Should you encounter any issues, please report them on [GitHub](https://github.com/localstack/localstack/issues/new/choose). You can temporarily revert to the old behavior with `CFN_LEGACY_TEMPLATE_DEPLOYER=1`, but be aware that this is only a temporary option.
+{{< /callout >}}
+
 ## Introduction
 
 CloudFormation is a service provided by Amazon Web Services (AWS) that allows you to define and provision infrastructure as code. It enables you to create, update, and manage resources in a repeatable and automated manner using declarative templates. With CloudFormation, you can use JSON or YAML templates to define your desired infrastructure state. You can specify resources, their configurations, dependencies, and relationships in these templates.


### PR DESCRIPTION
- Add callout to warn users that with 3.5 there's a new default resource deployment engine that more accurately orders resources by their dependencies.  See https://github.com/localstack/localstack/pull/10849
- Add config option to revert to the old behavior
  - (explicitly mentioned that this is only available temporarily because we don't wan't to commit to keeping this alive for long.