### PR TITLE
skip duplicated test details for api coverage

### DIFF
--- a/scripts/create_data_coverage.py
+++ b/scripts/create_data_coverage.py
@@ -423,8 +423,9 @@ def aggregate_recorded_raw_data(
                     "snapshot_tested": snapshot_tested,
                     "origin": metric.get("origin", ""),
                 }
-
-                test_list.append(test_detail)
+                if test_detail not in test_list:
+                    # avoid duplicates
+                    test_list.append(test_detail)
 
     return recorded_data
 


### PR DESCRIPTION
Some API coverage details contained the same test (including the same response code) in the list of tests.
This PR fixes this, by not adding duplicated information to the test-details.

