### PR TITLE
Update golang s3 example to avoid using deprecated bits

### DIFF
--- a/content/en/user-guide/integrations/sdks/go/index.md
+++ b/content/en/user-guide/integrations/sdks/go/index.md
@@ -64,22 +64,8 @@ func main() {
   awsEndpoint := "http://localhost:4566"
   awsRegion := "us-east-1"
   
-  customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-    if awsEndpoint != "" {
-      return aws.Endpoint{
-        PartitionID:   "aws",
-        URL:           awsEndpoint,
-        SigningRegion: awsRegion,
-      }, nil
-    }
-
-    // returning EndpointNotFoundError will allow the service to fallback to its default resolution
-    return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-  })
-  
   awsCfg, err := config.LoadDefaultConfig(context.TODO(),
     config.WithRegion(awsRegion),
-    config.WithEndpointResolverWithOptions(customResolver),
   )
   if err != nil {
     log.Fatalf("Cannot load the AWS configs: %s", err)
@@ -88,6 +74,7 @@ func main() {
   // Create the resource client
   client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
     o.UsePathStyle = true
+    o.BaseEndpoint = aws.String(awsEndpoint)
   })
   // ...
 }{{< /tab >}}


### PR DESCRIPTION
Upon [upgrading the v2 aws sdk dependency](https://github.com/dorklyorg/dorkly/commit/3a212cea2099d504ba73c43c678e4bce668a9d9f) I noticed some deprecation warnings. 

Removes deprecated usages of EndpointResolver in favor of specifying BaseEndpoint. 

This change 'works for me' (my test passes) but could use some additional verification for those with different use cases.
See aws docs: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/#mutable-endpoint
