### PR TITLE
Document new CLI flag `--host-dns` for exposing port 53 to the host

### DIFF
--- a/content/en/user-guide/tools/dns-server/index.md
+++ b/content/en/user-guide/tools/dns-server/index.md
@@ -129,7 +129,8 @@ Remember to save the default configuration and restore it after testing.
 
 1. Expose the LocalStack DNS server:
 
-    a) The LocalStack CLI automatically publishes port 53 if it can be bound on the host.
+    a) Since version 3.5, the LocalStack CLI does not publish port `53` anymore by default. 
+       Use the CLI flag `--host-dns` to expose the port on the host.
 
     b) For Docker Compose, add the following port mappings to your `docker-compose.yml`:
 


### PR DESCRIPTION
## Motivation

With 3.5, the LocalStack CLI won't try to publish port 53 on the host anymore by default.

However, there is a new flag `--host-dns`, which will instruct the CLI to publish it.

This PR adds this information to the DNS server documentation page.

## Changes

* Document new behavior for the DNS port publishing of the CLI. Instead of publishing automatically, you now have to provide a flag
