### PR TITLE
fix EC2 create-a-key-pair anchor links

### DIFF
--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -154,7 +154,7 @@ Any execution of this data is recorded in the `/var/log/cloud-init-output.log` f
 
 You can also set up an SSH connection to the locally emulated EC2 instance using the instance IP address.
 
-This section assumes that you have created or imported an SSH key pair named `my-key` (see [instructions above](#create-a-key-pair)).
+This section assumes that you have created or imported an SSH key pair named `my-key` (see [instructions above]({{< relref "#create-a-key-pair" >}})).
 When running the EC2 instance, make sure to pass the `--key-name` parameter to the command:
 
 {{< command >}}
@@ -169,7 +169,7 @@ $ ssh -p 12862 -i key.pem root@127.0.0.1
 {{< /command >}}
 
 {{< callout "tip" >}}
-If the `ssh` command throws an error like "Identity file not accessible" or "bad permissions", then please make sure that the key file has a restrictive `0400` permission as illustrated [here](#create-a-key-pair).
+If the `ssh` command throws an error like "Identity file not accessible" or "bad permissions", then please make sure that the key file has a restrictive `0400` permission as illustrated [here]({{< relref "ec2#create-a-key-pair" >}}).
 {{< /callout >}}
 
 

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -1,8 +1,10 @@
 {{/*
 
-This shortcode is a modification of Docsy `alert` shortcode to maintain styling consistency.
+This shortcode is a modification of Docsy `alert` shortcode.
+It was added to maintain the styling consistency by fixing the alert box titles to their severity.
 
-Usage:
+Usage
+-----
 
   {{< callout TITLE >}}
   This is the text that goes in the callout box.
@@ -14,7 +16,17 @@ TITLE must be one of:
 - 'tip'
 
 If TITLE is omitted, the default is used.
-If TITLE is set to any other value the the above, the default is used.
+If TITLE is set to any other value than the above, the default is used.
+
+Limitations
+-----------
+
+When using relative references with `[]()`, the link is incorrectly rendered.
+Please use the `relref` shortcode, like so:
+  
+  {{< callout "tip" >}}
+  See [instructions above]({{< relref "ec2#do-something" >}})
+  {{< /callout >}}
 
 */}}
 


### PR DESCRIPTION
## Motivation
@Anze1508 made me aware that the EC2 link from the callout to the "Create a key pair" anchor wrongly leads to "/#create-a-key-pair" instead of "#create-a-key-pair"

## Changes
- Fix the links by directly referencing the anchor on the EC2 page using the `relref` shortcode.

## Next steps
This is just a workaround, it would be great if anchor links would work in the `callout` shortcode introduced by @viren-nadkarni.
Unfortunately this is actually a bug in the `alert` shortcode of docsy (of which the `callout` shortcode is a fork of).