### PR TITLE
fix bootstrap 5 upgrade issues

### DIFF
--- a/layouts/partials/developer-hub/application.html
+++ b/layouts/partials/developer-hub/application.html
@@ -27,13 +27,13 @@
                 {{ range .services }}
                 <img
                     src="/images/services/{{ . }}.svg"
-                    class="application-icon" data-toggle="tooltip" data-placement="top"
+                    class="application-icon" data-bs-toggle="tooltip" data-placement="top"
                     title="{{index $servicesData .}}" aria-label="{{index $servicesData .}}"
                 />
                 {{ end }}
                 {{ with .pro }}
                 <img
-                src="/images/pro-badge.png" class="application-icon" data-toggle="tooltip"
+                src="/images/pro-badge.png" class="application-icon" data-bs-toggle="tooltip"
                 data-placement="top" title="Localstack Pro" aria-label="Localstack Pro"
                 />
                 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -46,7 +46,7 @@
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+  <li class="list-inline-item mx-2 h3" data-bs-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
     <a target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
       <i class="{{ .icon }}"></i>
     </a>

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -5,14 +5,14 @@
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ms-3 fas fa-bars collapsed" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ms-3 fas fa-bars collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
   {{ else -}}
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ms-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ms-3 fas fa-bars" type="button" data-bs-toggle="collapse" data-bs-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
   </div>

--- a/layouts/tutorials/single.html
+++ b/layouts/tutorials/single.html
@@ -34,7 +34,7 @@
                 {{ end }}
                 <div>—</div>
                 <div class="dropdown">
-                  <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <i class="fas fa-share-alt"></i>
                   </button>
                   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">


### PR DESCRIPTION
## Motivation
While looking into another small issue, I stumbled upon an issue in the mobile rendering: The navigation bar is not working correctly: [Screencast](https://github.com/localstack/docs/assets/2796604/702d174f-a8ef-49a0-a2e9-752fd1b1bf62)

As it turns out that this was missed in our overwritten layout files during the upgrade of docsy to v0.10 which came with an upgrade to Bootstrap 5: https://github.com/localstack/docs/pull/1268
Bootstrap 5 introduced a breaking change by renaming `data-toggle` to `data-bs-toggle`: https://getbootstrap.com/docs/5.0/migration/#javascript

It seems like this might be an issue for other people as well: https://github.com/localstack/docs/pull/1336

## Changes
- Migrates usages of `data-toggle` to `data-bs-toggle`.

## Testing
- We can test in the preview deployment that his fixes:
  - The collapse of the hamburger menu on small screens.
  - The toggling of the tooltip for DevHub applications
  - The toggling of the tooltip for footer links
  - The dropdown button for the share links on tutorial pages