### PR TITLE
Mention new Pipes target

### DIFF
--- a/content/en/user-guide/aws/pipes/index.md
+++ b/content/en/user-guide/aws/pipes/index.md
@@ -167,7 +167,8 @@ Firehose delivery stream,
 Inspector assessment template,
 Redshift cluster data API queries,
 SageMaker Pipeline,
-or Step Functions state machine: Express workflows (SYNC or ASYNC).
+Step Functions state machine: Express workflows (SYNC or ASYNC),
+or Timestream for LiveAnalytics table.
 
 ## Supported log destinations
 


### PR DESCRIPTION
Explicitly mention the new target supported by AWS, but not for LocalStack: https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-timestream-liveanalytics-eventbridge-pipes-target/

Let's stay in sync with the AWS list here: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-event-target.html