### PR TITLE
add EXTENSION_AUTO_INSTALL to config reference

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -347,6 +347,7 @@ To learn more about these configuration options, see [Persistence]({{< ref "user
 | `OUTBOUND_HTTPS_PROXY` | `https://10.10.1.3` | HTTPS Proxy used for downloads of runtime dependencies and connections outside LocalStack itself |
 | `REQUESTS_CA_BUNDLE` | `/var/lib/localstack/lib/ca_bundle.pem` | CA Bundle to be used to verify HTTPS requests made by LocalStack |
 | `DOCKER_HOST` | `unix:///var/run/docker.sock` (default) | Daemon socket to connect Docker. Used by the LocalStack dependency [Docker](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables). |
+| `EXTENSION_AUTO_INSTALL` | | Install a list of extensions automatically at startup. Comma-separated list of extensions directives which will be installed automatically at startup (see [managing extensions]({{< ref "user-guide/extensions/managing-extensions/#automating-extensions-installation" >}}))|
 
 
 ## Debugging


### PR DESCRIPTION
## Motivation
@robertlcx mentioned that the configuration reference is currently missing `EXTENSION_AUTO_INSTALL`.
This PR adds this env var to the config reference.

## Changes
- Adds `EXTENSION_AUTO_INSTALL` to "Miscellaneous" in the config reference and links to the detailed description of the feature.