### PR TITLE
MWAA: Add MWAA_S3_POLL_INTERVAL config option

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -238,6 +238,7 @@ Please consult the [migration guide]({{< ref "user-guide/aws/lambda#migrating-to
 | Variable | Example Values | Description |
 | - | - | - |
 | `MWAA_PIP_TRUSTED_HOSTS` | `pypi.org,files.pythonhosted.org` | Comma-separated list of hosts for which SSL verification is not performed when installing Python dependencies for MWAA environment. |
+| `MWAA_S3_POLL_INTERVAL` | `30` (default) | Interval in seconds with which MWAA polls S3 bucket to check for new or updated assets. |
 
 ### Neptune
 

--- a/content/en/user-guide/aws/mwaa/index.md
+++ b/content/en/user-guide/aws/mwaa/index.md
@@ -91,11 +91,14 @@ This transformation process ensures that your configuration settings are easily 
 When it comes to adding or updating DAGs in Airflow, the process is simple and efficient.
 Just upload your DAGs to the designated S3 bucket path, configured by the `DagS3Path` argument.
 
-Follow this example command to upload a sample DAG named `sample_dag.py` to your S3 bucket named `my-mwaa-bucket`:
+For example, the command below uploads a sample DAG named `sample_dag.py` to your S3 bucket named `my-mwaa-bucket`:
 
 {{< command >}} 
 $ awslocal s3 cp sample_dag.py s3://my-mwaa-bucket/dags 
 {{< /command >}}
+
+LocalStack syncs new and changed objects in the S3 bucket to the Airflow container every 30 seconds.
+The polling interval can be changed using the [`MWAA_S3_POLL_INTERVAL`]({{< ref "configuration#mwaa" >}}) config option.
 
 ## Installing custom plugins
 


### PR DESCRIPTION
> [!CAUTION]
> Reviewers please do not merge

## Background

MWAA now behaves similar to AWS when checking S3 bucket for updates. Earlier MWAA acted on the updates synchronously eg. a DAG would be registered in Airflow immediately after uploading to S3.

## Changes

Now updates are done in batches every 30 seconds. The update frequency can be adjusted with config option `MWAA_S3_POLL_INTERVAL`.

## Related

https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-folder.html#configuring-dag-folder-how