### PR TITLE
Fix labels for filters

### DIFF
--- a/content/en/tutorials/elb-load-balancing/index.md
+++ b/content/en/tutorials/elb-load-balancing/index.md
@@ -10,7 +10,7 @@ services:
 - elb
 - lmb
 platform:
-- javascript
+- JavaScript
 deployment:
 - serverless
 tags:

--- a/content/en/tutorials/ephemeral-application-previews/index.md
+++ b/content/en/tutorials/ephemeral-application-previews/index.md
@@ -7,14 +7,14 @@ description: >
 type: tutorials
 teaser: "ephemeral-application-previews-banner.png"
 services:
-- lambda
-- cloudfront
-- dynamodb
+- lmb
+- cfr
+- ddb
 - s3
 platform:
 - JavaScript
 deployment:
-- AWS CLI
+- awscli
 pro: true
 leadimage: "ephemeral-application-previews-banner.png"
 ---

--- a/content/en/tutorials/gitlab_ci_testcontainers/index.md
+++ b/content/en/tutorials/gitlab_ci_testcontainers/index.md
@@ -8,13 +8,13 @@ type: tutorials
 teaser: "Learn how you can set up end-to-end testing using Testcontainers and LocalStack in GitLab CI. This tutorial covers setting up the `.gitlab-ci.yml` file, configuring GitLab runners, and setting up a local Docker runner. With this setup, you can ensure your application is thoroughly tested in a CI/CD environment."
 services:
 - s3
-- lambda
-- api-gw
+- lmb
+- agw
 platform:
-- java
+- Java
 deployment:
 - aws-java-sdk
-- aws-cli
+- awscli
 tags:
 - Java
 - AWS Java SDK

--- a/content/en/tutorials/java-notification-app/index.md
+++ b/content/en/tutorials/java-notification-app/index.md
@@ -12,7 +12,7 @@ services:
 - sns
 - clf
 platform:
-- java
+- Java
 deployment:
 - aws-java-sdk
 - CloudFormation

--- a/content/en/tutorials/replicate-aws-resources-localstack-extension/index.md
+++ b/content/en/tutorials/replicate-aws-resources-localstack-extension/index.md
@@ -8,11 +8,11 @@ type: tutorials
 teaser: ""
 services:
 - sqs
-- lambda
+- lmb
 platform:
 - Python
 deployment:
-- AWS CLI
+- awscli
 pro: true
 leadimage: "aws-replicator-extension-tutorial-cover.png"
 ---

--- a/content/en/tutorials/schema-evolution-glue-msk/index.md
+++ b/content/en/tutorials/schema-evolution-glue-msk/index.md
@@ -10,7 +10,7 @@ services:
 - msk
 - glu
 platform:
-- java
+- Java
 deployment:
 - awscli
 tags:

--- a/content/en/tutorials/simulating-outages-in-your-application-stack/index.md
+++ b/content/en/tutorials/simulating-outages-in-your-application-stack/index.md
@@ -12,7 +12,7 @@ services:
 - agw
 - ddb
 platform:
-- Javascript
+- JavaScript
 deployment:
 - terraform
 tags:

--- a/data/developerhub/services.json
+++ b/data/developerhub/services.json
@@ -56,5 +56,8 @@
   "msk": "MSK",
   "r53": "Route53",
   "fis": "Fault Injection Simulator",
-  "farg": "Fargate"
+  "fargate": "Fargate",
+  "dms": "DMS",
+  "rs": "Redshift",
+  "appconfig": "AppConfig"
 }


### PR DESCRIPTION
There was inconsistent naming of the services and platforms that were used to generate the filters. This fixes that and removes the duplicate filters on the sidebar.