### PR TITLE
fix parity update action

### DIFF
--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-ext
           ARTIFACT_ID: parity-metric-ext-raw-*
-          WORKFLOW: "Build, Test, Push" 
+          WORKFLOW: "AWS / Build, Test, Push" 
           PREFIX_ARTIFACT: pro-integration-test
       
       - name: Download coverage (capture-notimplemented) data from Pro pipeline (GitHub)
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-ext
           ARTIFACT_ID: capture-notimplemented-pro 
-          WORKFLOW: "Build, Test, Push" 
+          WORKFLOW: "AWS / Build, Test, Push" 
           RESOURCE_FOLDER: "metrics-implementation-details"
 
       - name: Download metrics data from latest Community test run (CircleCI)


### PR DESCRIPTION
## Motivation
We just recently adjusted some of our workflow names by introducing a prefix (`AWS / ...`).
This unfortunately broke the parity update workflow because it directly references the workflow by its name, [see this run](https://github.com/localstack/docs/actions/runs/10034961759).
This PR fixes this issue.

## Changes
- Adjust the workflow name for our pro parity metrics download.