### PR TITLE
Fix endpoint url correctly for DynamoDB TTL

### DIFF
--- a/content/en/user-guide/aws/dynamodb/index.md
+++ b/content/en/user-guide/aws/dynamodb/index.md
@@ -166,7 +166,7 @@ In addition, to programmatically trigger the worker at convenience, we provide t
 The response returns the number of deleted items:
 
 ```console
-curl -X DELETE localhost:4566//_aws/dynamodb/expired
+curl -X DELETE localhost:4566/_aws/dynamodb/expired
 {"ExpiredItems": 3}
 ```
 


### PR DESCRIPTION
I found that the endpoint URL for DynamoDB TTL has a wrong double slash `//`. I fixed it to single slash `/`.

Other document (e.g., for [SNS](https://github.com/search?q=repo%3Alocalstack%2Fdocs+%22localhost%3A4566%2F_aws%2F%22&type=code)) also uses the format `localhost:4566/_aws/`.

It worked good on my sandbox environment😀

```sh
$ curl -X DELETE localhost:4566/_aws/dynamodb/expired
{"ExpiredItems": 1}%
```

Thanks!