### PR TITLE
Revamp IAM docs

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -183,8 +183,8 @@ See [here](#opensearch).
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `ENFORCE_IAM` | `0` (default)\|`1` | Enable IAM policy evaluation and enforcement. If this is disabled (the default), IAM policies will have no effect to your requests. |
-| `IAM_SOFT_MODE` | `0` (default)\|`1` | Enable IAM soft mode. This leads to policy evaluation without actually denying access. Needs `ENFORCE_IAM` enabled as well. For more information, see [Identity and Access Management]({{< ref "user-guide/aws/iam" >}}).|
+| `ENFORCE_IAM` (pro) | `0` (default)\|`1` | Enable IAM policy evaluation and enforcement. If this is disabled (the default), IAM policies will have no effect to your requests. |
+| `IAM_SOFT_MODE` (pro) | `0` (default)\|`1` | Enable IAM soft mode. This leads to policy evaluation without actually denying access. Needs `ENFORCE_IAM` enabled as well. For more information, see [Identity and Access Management]({{< ref "user-guide/aws/iam" >}}).|
 
 ### Kinesis
 

--- a/content/en/user-guide/aws/iam/index.md
+++ b/content/en/user-guide/aws/iam/index.md
@@ -102,11 +102,11 @@ The Resource Browser allows you to perform the following actions:
 LocalStack provides various tools to help you generate, test, and enforce IAM policies more efficiently.
 
 - **IAM Policy Stream**: IAM Policy Stream provides a real-time view of API calls and the corresponding IAM policies they generate, simplifying permission management and ensuring correct permissions are assigned.
-  Learn more in the [IAM Policy Stream documentation]({{< ref "iam-policy-stream" >}}).
+  Learn more in the [IAM Policy Stream documentation]({{< ref "user-guide/security-testing/iam-policy-stream" >}}).
 - **IAM Policy Enforcement**: This configuration enforces IAM policies when interacting with local cloud APIs, simulating a real AWS environment.
   For additional information, refer to the [IAM Policy Enforcement documentation]({{< ref "iam-enforcement" >}}).
 - **Explainable IAM**: Explainable IAM logs outputs related to failed policy evaluations directly to LocalStack logs, aiding in the identification of necessary policies for successful requests.
-  More details are available in the [Explainable IAM documentation]({{< ref "iam-explain" >}}).
+  More details are available in the [Explainable IAM documentation]({{< ref "explainable-iam" >}}).
 
 ## Examples
 

--- a/content/en/user-guide/aws/iam/index.md
+++ b/content/en/user-guide/aws/iam/index.md
@@ -97,6 +97,17 @@ The Resource Browser allows you to perform the following actions:
 - **Edit User, Group, Role, and Policy Details**: Click on any listed resources to edit its details by clicking on the desired User, Group, Role, or Policy.
 - **Delete User, Group, Role, and Policy**: Select any listed resources to delete them by clicking the **Actions** button and selecting **Remove Selected**.
 
+## Special Tools
+
+LocalStack provides various tools to help you generate, test, and enforce IAM policies more efficiently.
+
+- **IAM Policy Stream**: IAM Policy Stream provides a real-time view of API calls and the corresponding IAM policies they generate, simplifying permission management and ensuring correct permissions are assigned.
+  Learn more in the [IAM Policy Stream documentation]({{< ref "iam-policy-stream" >}}).
+- **IAM Policy Enforcement**: This configuration enforces IAM policies when interacting with local cloud APIs, simulating a real AWS environment.
+  For additional information, refer to the [IAM Policy Enforcement documentation]({{< ref "iam-enforcement" >}}).
+- **Explainable IAM**: Explainable IAM logs outputs related to failed policy evaluations directly to LocalStack logs, aiding in the identification of necessary policies for successful requests.
+  More details are available in the [Explainable IAM documentation]({{< ref "iam-explain" >}}).
+
 ## Supported APIs
 
 IAM security enforcement is comprehensively available for all AWS APIs in LocalStack and has undergone thorough testing across multiple services.

--- a/content/en/user-guide/aws/iam/index.md
+++ b/content/en/user-guide/aws/iam/index.md
@@ -108,27 +108,6 @@ LocalStack provides various tools to help you generate, test, and enforce IAM po
 - **Explainable IAM**: Explainable IAM logs outputs related to failed policy evaluations directly to LocalStack logs, aiding in the identification of necessary policies for successful requests.
   More details are available in the [Explainable IAM documentation]({{< ref "iam-explain" >}}).
 
-## Supported APIs
-
-IAM security enforcement is comprehensively available for all AWS APIs in LocalStack and has undergone thorough testing across multiple services.
-The services that have been rigorously tested include:
-
-- ACM
-- API Gateway
-- CloudFormation
-- CloudWatch (metrics/events/logs)
-- DynamoDB
-- DynamoDB Streams
-- Elasticsearch Service
-- EventBus, Kinesis
-- KMS
-- Lambda
-- Redshift
-- S3
-- SecretsManager
-- SNS
-- SQS
-
 ## Examples
 
 The following code snippets and sample applications provide practical examples of how to use IAM in LocalStack for various use cases:

--- a/content/en/user-guide/aws/iam/index.md
+++ b/content/en/user-guide/aws/iam/index.md
@@ -14,6 +14,7 @@ By centralizing access control, administrators can enforce the principle of leas
 
 LocalStack allows you to use the IAM APIs in your local environment to create and manage users, groups, and roles, granting permissions that adhere to the principle of least privilege.
 The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_iam/), which provides information on the extent of IAM's integration with LocalStack.
+The policy coverage is documented in the [IAM coverage documentation]({{ ref "iam-coverage"}}.
 
 ## Getting started
 

--- a/content/en/user-guide/security-testing/iam-enforcement/index.md
+++ b/content/en/user-guide/security-testing/iam-enforcement/index.md
@@ -113,3 +113,7 @@ You can view the LocalStack logs to validate the policy enforcement:
 
 You can further use the IAM Policy Enforcement feature to test your Infrastructure as Code (IaC) deployments and ensure that your policies are correctly enforced.
 If the IAM policies are not correctly enforced, you will get an unsuccessful response from the API call, and the LocalStack logs will provide you with the necessary information to debug the issue.
+
+## Feature coverage
+
+The feature coverage is documented in the [IAM coverage documentation]({{ ref "iam-coverage"}}.


### PR DESCRIPTION
This PR:

- Adds pro tags to IAM config options (such as `ENFORCE_IAM` etc.) 
- Adds a section on IAM Special Tools (IAM Policy Stream, IAM Enforcement, etc.) 
- Links IAM feature coverage to IAM Enforcement doc