### PR TITLE
fix parity upgrade action by updating CircleCI URL

### DIFF
--- a/scripts/get_latest_circleci_metrics.sh
+++ b/scripts/get_latest_circleci_metrics.sh
@@ -24,7 +24,7 @@ METRICS_IMPL="$PARENT_FOLDER/metrics-implementation-details/"
 
 echo "Project: $PROJECT_SLUG."
 
-WORKFLOW_ID=$(curl -X 'GET' "https://circleci.com/api/v2/insights/${PROJECT_SLUG}/workflows/main?branch=${METRICS_ARTIFACTS_BRANCH}" -H 'accept: application/json' | jq -r '[.items[] | select(.status == "success")][0].id')
+WORKFLOW_ID=$(curl -X 'GET' "https://circleci.com/api/v2/insights/${PROJECT_SLUG}/workflows/full-run?branch=${METRICS_ARTIFACTS_BRANCH}" -H 'accept: application/json' | jq -r '[.items[] | select(.status == "success")][0].id')
 echo "Latest successful workflow: $WORKFLOW_ID"
 
 JOB_NUMBER=$(curl -X 'GET' "https://circleci.com/api/v2/workflow/${WORKFLOW_ID}/job" -H 'accept: application/json'| jq -r '.items[] | select(.name == "report") | .job_number')


### PR DESCRIPTION
## Motivation
We recently had a few changes to our pipelines.
https://github.com/localstack/docs/pull/1342 already adjusted the Parity Update scripts to some of the changes.
Unfortunately, we've overlooked one change: The pipeline in CircleCI in `localstack/localstack` has been changed such that it is not called `main` anymore: https://github.com/localstack/localstack/pull/11049 renamed `main` to `full-run` and introduced a new `acceptance-only-run`.

Unfortunately, we haven't realized that this would have to change this here as well.
Now the artifacts of the old pipeline are not available anymore, which is why the run failed: https://github.com/localstack/docs/actions/runs/10242910192

## Changes
- This PR fixes the parity update action by referencing the correct workflow again.

## Testing
- [Triggered a run from this PR](https://github.com/localstack/docs/actions/runs/10248668104/job/28350431431) to verify that the download of the artifacts is fixed by the changes in this PR.
  - https://github.com/localstack/docs/pull/1416 was created by the run, which verifies that the fix is working.