### PR TITLE
Add callouts for DNS configuration of TEI

### DIFF
--- a/content/en/user-guide/tools/transparent-endpoint-injection/index.md
+++ b/content/en/user-guide/tools/transparent-endpoint-injection/index.md
@@ -13,6 +13,17 @@ The [DNS Server]({{< ref "dns-server" >}}) resolves AWS domains such as `*.amazo
 Therefore, your application seamlessly accesses the LocalStack APIs instead of the real AWS APIs.
 For local testing, you might need to disable SSL validation as explained under [Self-signed certificates](#self-signed-certificates).
 
+{{< callout >}}
+This feature is enabled when the LocalStack DNS server is used.
+If you wish to use Transparent Endpoint Injection, do not set `DNS_ADDRESS=0` when configuring LocalStack.
+{{< /callout >}}
+
+{{< callout "warning" >}}
+Transparent endpoint injection is required when using some tooling, for example AWS CDK custom resources.
+These resources invoke lambda functions, which execute code written by the CDK authors.
+They cannot be configured to make requests against LocalStack, so Transparent Endpoint Injection is used to redirect requests made against AWS to target LocalStack.
+{{< /callout >}}
+
 ## Motivation
 
 Previously, your application code targeting AWS needs to be modified to target LocalStack.


### PR DESCRIPTION
Our documentation of Transparent Endpoint Injection does not cover:
* that it's implicitly disabled with the `DNS_ADDRESS=0` configuration, which is common in old examples, and still very present in users' configurations
* that it's required for e.g. CDK custom resources to function
    * actually if the lambda uses an SDK that supports `AWS_ENDPOINT_URL` then we don't technically need TEI, however
    * we also disable the required TLS verification when `DNS_ADDRESS=0'`.

[Rendered](https://localstack-docs-preview-pr-1419.surge.sh/user-guide/tools/transparent-endpoint-injection/)
