### PR TITLE
Document new EKS_K8S_PROVIDER configuration

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -165,6 +165,7 @@ This section covers configuration options that are specific to certain AWS servi
 | - | - | - |
 | `EKS_LOADBALANCER_PORT` | `8081` (default) | Local port on which the Kubernetes load balancer is exposed on the host. |
 | `EKS_K3S_IMAGE_TAG` | `v1.22.6-k3s1` (default) | Custom tag of the `k8s/rancher` image used to spin up Kubernetes clusters locally. |
+| `EKS_K8S_PROVIDER` | `k3s` (default)\|`local` | The k8s provider which should be used to start the k8s cluster backing EKS. For more information on the providers, please see [Elastic Kubernetes Service (EKS)]({{< ref "user-guide/aws/eks" >}}) |
 
 ### ElastiCache
 

--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -335,12 +335,23 @@ If your ingress and services are residing in a custom namespace, it is essential
 ## Use an existing Kubernetes installation
 
 You can also access the EKS API using your existing local Kubernetes installation.
-This can be achieved by mounting the `$HOME/.kube/config` file into the LocalStack container, especially when using a `docker-compose.yml` file:
+This can be achieved by setting the configuration variable `EKS_K8S_PROVIDER=local` and mounting the `$HOME/.kube/config` file into the LocalStack container.
+When using a `docker-compose.yml` file, you need to add a bind mount like this:
 
 ```yaml
 volumes:
   - "${HOME}/.kube/config:/root/.kube/config"
 ```
+
+When using the LocalStack CLI, please configure the `DOCKER_FLAGS` to mount the kubeconfig into the container:
+
+{{< command >}}
+$ DOCKER_FLAGS="-v ${HOME}/.kube/config:/root/.kube/config" localstack start
+{{</ command >}}
+
+{{< callout >}}
+Using an existing Kubernetes installation is currently only possible when the authentication with the cluster uses X509 client certificates: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certificates
+{{< /callout >}}
 
 In recent versions of Docker, you can enable Kubernetes as an embedded service running inside Docker.
 The picture below illustrates the Kubernetes settings in Docker for macOS (similar configurations apply for Linux/Windows).

--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -63,7 +63,7 @@ You can see an output similar to the following:
 
 {{< callout >}}
 When setting up a local EKS cluster, if you encounter a `"status": "FAILED"` in the command output and see `Unable to start EKS cluster` in LocalStack logs, remove or rename the `~/.kube/config` file on your machine and retry.
-The CLI mounts this file automatically, leading EKS to assume you intend to use the specified cluster, a feature that has specific requirements.
+The CLI mounts this file automatically for CLI versions before `3.7`, leading EKS to assume you intend to use the specified cluster, a feature that has specific requirements.
 {{< /callout >}}
 
 You can use the `docker` CLI to check that some containers have been created:


### PR DESCRIPTION
## Motivation
We are currently making some changes, to replace the implicit switch between the `k3s` and `local` EKS K8S providers, which lead to a lot of confusion.

In the future, the switch is made purely by the `EKS_K8S_PROVIDER` configuration variable, the mounting of a kubeconfig alone will no longer suffice to switch to the `local` provider.

Also, we stop automatically mounting the kube config at `~/.kube/config` from the host into the container.

## Changes
* Document the new `EKS_K8S_PROVIDER` config variable
* Document the flag in the local provider documentation, and clarify how to mount the kubeconfig in the LocalStack container from now on
* Document requirement for X509 certificate authentication to the local cluster.
