### PR TITLE
Correcting commands in Ingress configuration from EKS docs.

### DIFF
--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -423,6 +423,7 @@ In such cases, path-based routing may not be ideal if you need the services to b
 To address this requirement, we recommend utilizing host-based routing rules, as demonstrated in the example below:
 
 {{< command >}}
+<!-- markdownlint-disable -->
 $ cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -453,6 +454,7 @@ spec:
             port:
               number: 80
 EOF
+<!-- markdownlint-enable -->
 {{< /command >}}
 
 The example defines routing rules for two local endpoints - the first rule points to a service `service-1` accessible under `/v1`, and the second rule points to a service `service-2` accessible under the same path `/v1`.

--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -421,9 +421,8 @@ For instance, you might have multiple microservices, each following a common pat
 In such cases, path-based routing may not be ideal if you need the services to be accessible in a uniform manner.
 
 To address this requirement, we recommend utilizing host-based routing rules, as demonstrated in the example below:
-
-{{< command >}}
 <!-- markdownlint-disable -->
+{{< command >}}
 $ cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -454,9 +453,8 @@ spec:
             port:
               number: 80
 EOF
-<!-- markdownlint-enable -->
 {{< /command >}}
-
+<!-- markdownlint-enable -->
 The example defines routing rules for two local endpoints - the first rule points to a service `service-1` accessible under `/v1`, and the second rule points to a service `service-2` accessible under the same path `/v1`.
 
 In the provided example, we define routing rules for two local endpoints.

--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -421,7 +421,7 @@ For instance, you might have multiple microservices, each following a common pat
 In such cases, path-based routing may not be ideal if you need the services to be accessible in a uniform manner.
 
 To address this requirement, we recommend utilizing host-based routing rules, as demonstrated in the example below:
-<!-- markdownlint-disable -->
+<!-- markdownlint-disable MD007 -->
 {{< command >}}
 $ cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
@@ -454,7 +454,7 @@ spec:
               number: 80
 EOF
 {{< /command >}}
-<!-- markdownlint-enable -->
+<!-- markdownlint-enable MD007 -->
 The example defines routing rules for two local endpoints - the first rule points to a service `service-1` accessible under `/v1`, and the second rule points to a service `service-2` accessible under the same path `/v1`.
 
 In the provided example, we define routing rules for two local endpoints.

--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -432,20 +432,20 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:
-- host: eks-service-1.localhost.localstack.cloud
+  - host: eks-service-1.localhost.localstack.cloud
     http:
       paths:
-  - path: /v1
+      - path: /v1
         pathType: Prefix
         backend:
           service:
             name: service-1
             port:
               number: 80
-- host: eks-service-2.localhost.localstack.cloud
+  - host: eks-service-2.localhost.localstack.cloud
     http:
       paths:
-  - path: /v1
+      - path: /v1
         pathType: Prefix
         backend:
           service:

--- a/content/en/user-guide/aws/eks/index.md
+++ b/content/en/user-guide/aws/eks/index.md
@@ -253,10 +253,10 @@ spec:
   selector:
     app: fancier-nginx
   ports:
-- name: http
-    protocol: TCP
-    port: 80
-    targetPort: 80
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
 EOF
 {{< /command >}}
 
@@ -272,15 +272,15 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:
-- http:
-      paths:
-  - path: /test123
-        pathType: Prefix
-        backend:
-          service:
-            name: nginx
-            port:
-              number: 80
+    - http:
+        paths:
+          - path: /test123
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80
 EOF
 {{< /command >}}
 


### PR DESCRIPTION
## Motivation
The current commands for configuring the [ingress](https://docs.localstack.cloud/user-guide/aws/eks/#configuring-an-ingress-for-your-services) in the EKS documentation don't have the proper indentation:

```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Service
metadata:
  name: nginx
spec:
  selector:
    app: fancier-nginx
  ports:
- name: http
    protocol: TCP
    port: 80
    targetPort: 80
EOF
```

```
cat <<EOF | kubectl apply -f -
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: nginx
  annotations:
    ingress.kubernetes.io/ssl-redirect: "false"
spec:
  rules:
- http:
      paths:
  - path: /test123
        pathType: Prefix
        backend:
          service:
            name: nginx
            port:
              number: 80
EOF
```

When running it I receive the following message error:

> error: error parsing STDIN: error converting YAML to JSON: yaml: line 8: did not find expected key
