### PR TITLE
CFn: remove CFN_LEGACY_TEMPLATE_DEPLOYER flag option

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -94,7 +94,6 @@ This section covers configuration options that are specific to certain AWS servi
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `CFN_LEGACY_TEMPLATE_DEPLOYER` | `0` (default) \|`1` | Switch back to the old deployment engine. Note that this is only available temporarily to allow for a smoother roll-out of the new deployment order.
 | `CFN_PER_RESOURCE_TIMEOUT` | `300` (default) | Set the timeout to deploy each individual CloudFormation resource.
 | `CFN_VERBOSE_ERRORS` | `0` (default) \|`1` | Show exceptions for CloudFormation deploy errors.
 | `CFN_STRING_REPLACEMENT_DENY_LIST` | `""` (default) \|`https://api-1.execute-api.us-east-2.amazonaws.com/test-resource,https://api-2.execute-api.us-east-2.amazonaws.com/test-resource` | Comma-separated list of AWS URLs that should not be modified to point to Localstack. For example, when deploying a CloudFormation template we might want to leave certain resources pointing to actual AWS URLs, or even leave environment variables with URLs like that untouched.


### PR DESCRIPTION
# Motivation

With https://github.com/localstack/localstack/pull/11414 we removed the legacy fallback option for CloudFormation deploy implementation. This PR removes the documentation for that flag.

# Changes

* Remove documentation for `CFN_LEGACY_TEMPLATE_DEPLOYER` documentation
