### PR TITLE
Adding parameter substitution implementation example to Batch docs

### DIFF
--- a/content/en/user-guide/aws/batch/index.md
+++ b/content/en/user-guide/aws/batch/index.md
@@ -153,7 +153,7 @@ You should see the following output:
 }
 ```
 
-If you want to pass arguments to the command as [parameters](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters), you can use the `Ref::` declaration to set placeholders for parameter substitution. 
+If you want to pass arguments to the command as [parameters](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters), you can use the `Ref::` declaration to set placeholders for parameter substitution.
 This allows the dynamic passing of values at runtime for specific job definitions.
 
 {{< command >}}

--- a/content/en/user-guide/aws/batch/index.md
+++ b/content/en/user-guide/aws/batch/index.md
@@ -153,7 +153,7 @@ You should see the following output:
 }
 ```
 
-In case that you would like to pass the arguments to the command as [`parameters`](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html), it can be done by using the `Ref::` declaration to set placeholders for parameter substitution:
+If you want to pass arguments to the command as [parameters](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters), you can use the `Ref::` declaration to set placeholders for parameter substitution. This allows the dynamic passing of values at runtime for specific job definitions.
 
 {{< command >}}
 $  awslocal batch register-job-definition \

--- a/content/en/user-guide/aws/batch/index.md
+++ b/content/en/user-guide/aws/batch/index.md
@@ -153,7 +153,8 @@ You should see the following output:
 }
 ```
 
-If you want to pass arguments to the command as [parameters](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters), you can use the `Ref::` declaration to set placeholders for parameter substitution. This allows the dynamic passing of values at runtime for specific job definitions.
+If you want to pass arguments to the command as [parameters](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters), you can use the `Ref::` declaration to set placeholders for parameter substitution. 
+This allows the dynamic passing of values at runtime for specific job definitions.
 
 {{< command >}}
 $  awslocal batch register-job-definition \

--- a/content/en/user-guide/aws/batch/index.md
+++ b/content/en/user-guide/aws/batch/index.md
@@ -153,6 +153,16 @@ You should see the following output:
 }
 ```
 
+In case that you would like to pass the arguments to the command as **parameters**, it can be done by using the `Reff::` declaration to set placeholders for parameter substitution:
+
+{{< command >}}
+$  awslocal batch register-job-definition \
+    --job-definition-name myjobdefn \
+    --type container \
+    --parameters '{"time":"10"}' \
+    --container-properties '{"image":"busybox","vcpus":1,"memory":128,"command":["sleep","Reff::time"]}'
+{{< / command >}}
+
 ### Submit a job to the job queue
 
 You can now run a compute job.

--- a/content/en/user-guide/aws/batch/index.md
+++ b/content/en/user-guide/aws/batch/index.md
@@ -153,14 +153,14 @@ You should see the following output:
 }
 ```
 
-In case that you would like to pass the arguments to the command as **parameters**, it can be done by using the `Reff::` declaration to set placeholders for parameter substitution:
+In case that you would like to pass the arguments to the command as [`parameters`](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html), it can be done by using the `Ref::` declaration to set placeholders for parameter substitution:
 
 {{< command >}}
 $  awslocal batch register-job-definition \
     --job-definition-name myjobdefn \
     --type container \
     --parameters '{"time":"10"}' \
-    --container-properties '{"image":"busybox","vcpus":1,"memory":128,"command":["sleep","Reff::time"]}'
+    --container-properties '{"image":"busybox","vcpus":1,"memory":128,"command":["sleep","Ref::time"]}'
 {{< / command >}}
 
 ### Submit a job to the job queue


### PR DESCRIPTION
Recently, we implemented parameter substitution to Batch. As [AWS](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters) have its own way to do this, I believe the docs should illustrate how to configure parameter substitution to set default values.

