### PR TITLE
Update latest version to 3.7.2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -210,7 +210,7 @@ enable = true
 
 [params.localstack]
 # LocalStack specific configuration values
-latest_version = "3.7.0"
+latest_version = "3.7.2"
 
 [params.localstack.cli_links]
 # Configure the different download links for the cli-binary-download shortcode


### PR DESCRIPTION
We just released [3.7.2](https://github.com/localstack/localstack/releases/tag/v3.7.2). This PR updates the version in the docs (to update the download links and version mentions).