### PR TITLE
Typos in Gitpod integration docs

### DIFF
--- a/content/en/user-guide/integrations/gitpod/index.md
+++ b/content/en/user-guide/integrations/gitpod/index.md
@@ -1,11 +1,11 @@
 ---
-title: "GitPod"
-linkTitle: "GitPod"
+title: "Gitpod"
+linkTitle: "Gitpod"
 description: >
-  Use GitPod's fully automated, ephemeral workspaces to develop & test your cloud applications with LocalStack
+  Use Gitpod's fully automated, ephemeral workspaces to develop & test your cloud applications with LocalStack
 ---
 
-<img src="gitpod_logo.png" width="600px" alt="GitPod logo">
+<img src="gitpod_logo.png" width="600px" alt="Gitpod logo">
 
 ## Overview
 
@@ -14,15 +14,15 @@ It provides an automated setup with cloud-based, remote developer environments c
 Gitpod allow users to codify their developer environment as code.
 With projects codified, you can spin up a new workspace, start coding and throw away the workspace when they are done!
 
-## LocalStack on GitPod
+## LocalStack on Gitpod
 
 LocalStack allows you to set up a development environment with a cloud sandbox that can be used to test and develop cloud applications.
-Using GitPod's environment you can run a LocalStack container inside the runtime that allows to instantiate your application on a code editor of your choice.
+Using Gitpod's environment you can run a LocalStack container inside the runtime that allows to instantiate your application on a code editor of your choice.
 You can then conveniently deploy your cloud application assets into LocalStack's cloud sandbox, to then preview the results.
 
-To configure LocalStack on GitPod, you would need to set up a `.gitpod.yml` on the root of your repository.
+To configure LocalStack on Gitpod, you would need to set up a `.gitpod.yml` on the root of your repository.
 The file configures your workspace and the environment that you would like to use.
-You can find more information on the [GitPod documentation](https://www.gitpod.io/docs/config-gitpod-file/).
+You can find more information on the [Gitpod documentation](https://www.gitpod.io/docs/config-gitpod-file/).
 
 ```yaml
 tasks:
@@ -60,7 +60,7 @@ ports:
     onOpen: ignore
 ```
 
-If you are using GitHub, you can also use the [GitPod Prebuilds](https://www.gitpod.io/docs/prebuilds/) feature to automatically build your workspace.
+If you are using GitHub, you can also use the [Gitpod Prebuilds](https://www.gitpod.io/docs/prebuilds/) feature to automatically build your workspace.
 This will allow you to start your workspace faster and with all the dependencies already installed.
 Add the following to your `.gitpod.yml` file:
 
@@ -83,8 +83,8 @@ github:
     addBadge: true
 ```
 
-After adding the configuration, you can start your development & testing by creating [your workspace in GitPod](https://www.gitpod.io/docs/getting-started/#start-your-first-workspace).
+After adding the configuration, you can start your development & testing by creating [your workspace in Gitpod](https://www.gitpod.io/docs/getting-started/#start-your-first-workspace).
 Upon creation, you will be able to see the LocalStack container running in the background (you can use `localstack status` to check the status of the container).
 
-For a simple demonstration, check out the [LocalStack GitPod demo](https://github.com/Gitpod-Samples/localstack-gitpod-demo) repository.
+For a simple demonstration, check out the [LocalStack Gitpod demo](https://github.com/Gitpod-Samples/localstack-gitpod-demo) repository.
 Check out our [in-depth walkthrough over the demo](https://localstack.cloud/blog/2022-09-26-localstack-x-gitpod-run-cloud-applications-with-localstack-and-gitpod/) on our blog!


### PR DESCRIPTION
Proper casing for `Gitpod` in [relevant integration docs](https://docs.localstack.cloud/user-guide/integrations/gitpod/).