### PR TITLE
Adding code example to Cognito Lambda trigger documentation.

### DIFF
--- a/content/en/user-guide/aws/cognito/index.md
+++ b/content/en/user-guide/aws/cognito/index.md
@@ -222,7 +222,7 @@ $ curl http://localhost:4566/.well-known/jwks_uri
 Cognito offers a variety of lifecycle hooks called Cognito Lambda triggers, which allow you to react to different lifecycle events and customize the behavior of user signup, confirmation, migration, and more.
 
 To illustrate, suppose you wish to define a _user migration_ Lambda trigger in order to migrate users from your existing user directory into Amazon Cognito user pools at sign-in.
-In this case, you can start by creating a Lambda function, let's say named `"migrate_users"`, responsible for performing the migration by using this code:
+In this case, you can start by creating a Lambda function, let's say named `"migrate_users"`, responsible for performing the migration by creating a new file `index.js` with the following code:
 
 ```javascript
 const validUsers = {

--- a/content/en/user-guide/aws/cognito/index.md
+++ b/content/en/user-guide/aws/cognito/index.md
@@ -276,6 +276,7 @@ exports.handler = async (event) => {
   return event;
 };
 ```
+
 Enter the following commands to create the Lambda function:
 
 {{< command >}}


### PR DESCRIPTION
I believe the Lambda Trigger section in Cognito's documentation would be more illustrative if it included a Lambda function example demonstrating how to migrate a user on authentication.