### PR TITLE
KMS: Fix method for specifying custom key material

### DIFF
--- a/content/en/user-guide/aws/kms/index.md
+++ b/content/en/user-guide/aws/kms/index.md
@@ -136,8 +136,11 @@ This can be useful to pre-seed a development environment so values encrypted wit
 Here is an example of using custom key material with the value being base64 encoded:
 
 {{< command >}}
-$ CUSTOM_KEY_MATERIAL=$(openssl rand -base64 32)
-$ awslocal kms create-key --tags "[{\"TagKey\":\"_custom_key_material_\",\"TagValue\":\"$CUSTOM_KEY_MATERIAL\"}]"
+$ echo 'dGhpc2lzYXNlY3VyZWtleQ==' | base64 -d
+<disable-copy>
+thisisasecurekey
+</disable-copy>
+$ awslocal kms create-key --tags '[{"TagKey":"_custom_key_material_","TagValue":"dGhpc2lzYXNlY3VyZWtleQ=="}]'
 <disable-copy>
 {
     "KeyMetadata": {

--- a/content/en/user-guide/aws/kms/index.md
+++ b/content/en/user-guide/aws/kms/index.md
@@ -136,11 +136,8 @@ This can be useful to pre-seed a development environment so values encrypted wit
 Here is an example of using custom key material with the value being base64 encoded:
 
 {{< command >}}
-$ echo 'c3VwZXIgc2VjcmV0IGtleQo=' | base64 -d
-<disable-copy>
-super secret key
-</disable-copy>
-$ awslocal kms create-key --tags '[{"TagKey":"_custom_key_material_","TagValue":"c3VwZXIgc2VjcmV0IGtleQo="}]'
+$ CUSTOM_KEY_MATERIAL=$(openssl rand -base64 32)
+$ awslocal kms create-key --tags "[{\"TagKey\":\"_custom_key_material_\",\"TagValue\":\"$CUSTOM_KEY_MATERIAL\"}]"
 <disable-copy>
 {
     "KeyMetadata": {


### PR DESCRIPTION
In the previous documentation, it was possible to create a key, but when running `kms encrypt`, the error `Invalid key size (136) for AES.` would occur. I've updated the documentation to ensure that the key is generated with a size of 32 bytes.

Example:
```bash
$ echo 'c3VwZXIgc2VjcmV0IGtleQo=' | base64 -d
super secret key
$ awslocal kms create-key --tags '[{"TagKey":"_custom_key_material_","TagValue":"c3VwZXIgc2VjcmV0IGtleQo="}]'
{
    "KeyMetadata": {
        "AWSAccountId": "000000000000",
        "KeyId": "74a102af-5a49-40bb-bac6-530e7c0cb9cd",
        "Arn": "arn:aws:kms:ap-northeast-1:000000000000:key/74a102af-5a49-40bb-bac6-530e7c0cb9cd",
        "CreationDate": "2024-09-14T14:37:48.238508+09:00",
        "Enabled": true,
        "Description": "",
        "KeyUsage": "ENCRYPT_DECRYPT",
        "KeyState": "Enabled",
        "Origin": "AWS_KMS",
        "KeyManager": "CUSTOMER",
        "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
        "KeySpec": "SYMMETRIC_DEFAULT",
        "EncryptionAlgorithms": [
            "SYMMETRIC_DEFAULT"
        ],
        "MultiRegion": false
    }
}

$ awslocal kms encrypt --key-id 74a102af-5a49-40bb-bac6-530e7c0cb9cd --plaintext supersecret --output text --query CiphertextBlob --cli-binary-format raw-in-base64-out 

An error occurred (InternalError) when calling the Encrypt operation (reached max retries: 2): exception while calling kms.Encrypt: Invalid key size (136) for AES.
```

