### PR TITLE
Correcting format for Api coverage url

### DIFF
--- a/content/en/user-guide/aws/elasticache/index.md
+++ b/content/en/user-guide/aws/elasticache/index.md
@@ -18,7 +18,7 @@ It supports popular open-source caching engines like Redis and Memcached (LocalS
 providing a means to efficiently store and retrieve frequently accessed data with minimal latency.
 
 LocalStack supports ElastiCache via the Pro offering, allowing you to use the ElastiCache APIs in your local environment.
-The supported APIs are available on our [API Coverage Page]{{< ref "coverage_elasticache" >}},
+The supported APIs are available on our [API Coverage Page](https://docs.localstack.cloud/references/coverage/coverage_elasticache/),
 which provides information on the extent of ElastiCache integration with LocalStack.
 
 ## Getting started


### PR DESCRIPTION
Small fix. The url to the API coverage is not properly set:
![image](https://github.com/user-attachments/assets/74ae1f99-0656-4ce8-ae1e-8398a9bf4489)
