### PR TITLE
add reference to the swagger UI

### DIFF
--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -12,24 +12,16 @@ LocalStack provides several internal endpoints for various local AWS services an
 These endpoints are not part of the official AWS API and are available in the `/_localstack` and `/_aws` paths.
 You can use [curl](https://curl.se/) or your favourite HTTP REST client to access endpoints.
 
-## LocalStack endpoints
+You can start your LocalStack instance and go to [http://localhost.localstack.cloud:4566/_localstack/swagger](http://localhost.localstack.cloud:4566/_localstack/swagger)
+to browse the Swagger UI, visualize and interact with all the API's resources implemented in LocalStack.
+
+### LocalStack endpoints
 
 The API path for the LocalStack internal resources is `/_localstack`.
-The following endpoints are available:
-
-| Endpoint | Description |
-| ------------------------------------ | --------------------------------------------------------------------------- |
-| `/_localstack/health`                | To check the available and running AWS services in LocalStack. You can use the endpoint to restart the LocalStack services.  |
-| `/_localstack/plugins`               | Shows the [Plux plugins](https://github.com/localstack/localstack/blob/master/docs/localstack-concepts/README.md#plugins) information in LocalStack. |
-| `/_localstack/init`                  | Shows the initialization status after setting up [Init hooks](https://docs.localstack.cloud/references/init-hooks/). |
-| `/_localstack/cloudformation/deploy` | Enables you to deploy CloudFormation templates locally through a web interface. |
-| `/_localstack/diagnose`              | Reports extensive and sensitive data from LocalStack instance, enabled via the `DEBUG=1` configuration variable. |
-| `/_localstack/config`                | Enables dynamic configuration updates at runtime, enabled via the `ENABLE_CONFIG_UPDATES` configuration variable.  |
-| `/_localstack/chaos`                 | [Chaos API]({{< ref "chaos-api" >}}) configuration endpoint |
-| `/_localstack/state/<service>/save`  | Get a snapshot of the given AWS service using the Persistence mechanism. |
-| `/_localstack/state/<service>/load`  | Load the most recent snapshot of the given service using the Persistence mechanism. |
-| `/_localstack/state/reset`           | Reset the state of the services using the Persistence mechanism. |
-| `/_localstack/state/<service>/reset` | Reset the state of the given service using the Persistence mechanism. |
+Several endpoints are available under this path. 
+For instance, `/_localstack/health` checks the available and running AWS services in LocalStack while
+`/_localstack/diagnose` (enable with the `DEBUG=1` configuration variable), reports extensive and sensitive data from
+the LocalStack instance.
 
 {{< callout "tip" >}}
 You can use the `/_localstack/health` endpoint to restart or kill the services.
@@ -40,17 +32,8 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 {{< /command >}}
 {{< /callout >}}
 
-## AWS endpoints
+### AWS endpoints
 
 The API path for the AWS internal resources is `/_aws`.
-The following endpoints are available:
-
-| Endpoint                               | Description                                               |
-|----------------------------------------|-----------------------------------------------------------|
-| `/_aws/lambda/runtimes`                | List Lambda runtimes. See [Lambda – Special Tools]({{< ref "user-guide/aws/lambda#special-tools" >}}) |
-| `/_aws/sqs/messages`                   | Access all messages within a SQS queue                    |
-| `/_aws/sns/platform-endpoint-messages` | Access and delete all the published SNS platform messages |
-| `/_aws/ses`                            | Access and delete all the sent SES emails                 |
-| `/_aws/cloudwatch/metrics/raw`         | Access all the raw CloudWatch metrics                     |
-| `/_aws/cognito-idp`                    | Access the local Cognito login form                       |
-| `/_aws/dynamodb/expired`               | Trigger the DynamoDB TTL worker at convenience            |
+These endpoints offer LocalStack-specific features in addition to the ones offered by the AWS services. 
+For instance, `/aws/sqs/messages` conveniently access all messages withing a SQS queue, without deleting them.

--- a/content/en/references/internal-endpoints.md
+++ b/content/en/references/internal-endpoints.md
@@ -18,7 +18,7 @@ to browse the Swagger UI, visualize and interact with all the API's resources im
 ### LocalStack endpoints
 
 The API path for the LocalStack internal resources is `/_localstack`.
-Several endpoints are available under this path. 
+Several endpoints are available under this path.
 For instance, `/_localstack/health` checks the available and running AWS services in LocalStack while
 `/_localstack/diagnose` (enable with the `DEBUG=1` configuration variable), reports extensive and sensitive data from
 the LocalStack instance.
@@ -35,5 +35,5 @@ $ curl -v --request POST --header "Content-Type: application/json"  --data '{"ac
 ### AWS endpoints
 
 The API path for the AWS internal resources is `/_aws`.
-These endpoints offer LocalStack-specific features in addition to the ones offered by the AWS services. 
+These endpoints offer LocalStack-specific features in addition to the ones offered by the AWS services.
 For instance, `/aws/sqs/messages` conveniently access all messages withing a SQS queue, without deleting them.


### PR DESCRIPTION
We recently introduced Swagger UI served directly via LocalStack, documenting all our internal endpoints.
We add this link to the docs and remove the manually-written list of endpoints contained in this page.