### PR TITLE
Update permissions for key pair file in EC2 documentation

### DIFF
--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -61,11 +61,29 @@ Set-Acl -Path "key.pem" -AclObject $acl
 
 {{< /tabpane >}}
 
-Alternatively, we can import an existing key pair, for example if you have an SSH public key in your home directory under `~/.ssh/id_rsa.pub`:
+Alternatively, you can import an existing key pair, such as an SSH public key located in your home directory at `~/.ssh/id_rsa.pub`.
+Additionally, you can produce a public key from an existing private key with the `ssh-keygen` command, which means you don't need to generate a new key pair each time you use LocalStack.
+
+{{< tabpane text=true >}}
+
+{{< tab header="**Existing Key Pair**" >}}
 
 {{< command >}}
 $ awslocal ec2 import-key-pair --key-name my-key --public-key-material file://~/.ssh/id_rsa.pub
 {{< /command >}}
+
+{{< /tab >}}
+
+{{< tab header="**Generate Public Key**" >}}
+
+{{< command >}}
+$ ssh-keygen -y -f key.pem > key.pub
+$ awslocal ec2 import-key-pair --key-name my-key --public-key-material fileb://key.pub
+{{< /command >}}
+
+{{< /tab >}}
+
+{{< /tabpane >}}
 
 ### Add rules to your security group
 

--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -35,13 +35,34 @@ $ awslocal ec2 create-key-pair \
     --output text | tee key.pem
 {{< /command >}}
 
-You can assign necessary permissions to the key pair file using the following command:
+You can assign necessary permissions to the key pair file using the following commands:
+
+{{< tabpane text=true >}}
+
+{{< tab header="**Linux**" >}}
 
 {{< command >}}
 $ chmod 400 key.pem
 {{< /command >}}
 
+{{< /tab >}}
+
+{{< tab header="**Windows**" >}}
+
+{{< command >}}
+$acl = Get-Acl -Path "key.pem"
+$fileSystemAccessRule = New-Object System.Security.AccessControl.FileSystemAccessRule("$env:username", "Read", "Allow")
+$acl.SetAccessRule($fileSystemAccessRule)
+$acl.SetAccessRuleProtection($true, $false)
+Set-Acl -Path "key.pem" -AclObject $acl
+{{< /command >}}
+
+{{< /tab >}}
+
+{{< /tabpane >}}
+
 Alternatively, we can import an existing key pair, for example if you have an SSH public key in your home directory under `~/.ssh/id_rsa.pub`:
+
 {{< command >}}
 $ awslocal ec2 import-key-pair --key-name my-key --public-key-material file://~/.ssh/id_rsa.pub
 {{< /command >}}

--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -124,7 +124,7 @@ Run the following command to run an EC2 instance by adding the appropriate Secur
 
 {{< command >}}
 $ awslocal ec2 run-instances \
-    --image-id ami-ff0fea8310f3 \
+    --image-id ami-df5de72bdb3b \
     --count 1 \
     --instance-type t3.nano \
     --key-name my-key \

--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -23,7 +23,9 @@ LocalStack Pro running on a Linux host is required as network access to containe
 
 Start your LocalStack container using your preferred method.
 
-### Create a key pair
+### Create or import a key pair
+
+Key pairs are SSH public key/private key combinations that are used to log in to created instances.
 
 To create a key pair, you can use the [`CreateKeyPair`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateKeyPair.html) API.
 Run the following command to create the key pair and pipe the output to a file named `key.pem`:
@@ -35,7 +37,8 @@ $ awslocal ec2 create-key-pair \
     --output text | tee key.pem
 {{< /command >}}
 
-You can assign necessary permissions to the key pair file using the following commands:
+You may need to assign necessary permissions to the key files for security reasons.
+This can be done using the following commands:
 
 {{< tabpane text=true >}}
 
@@ -47,7 +50,7 @@ $ chmod 400 key.pem
 
 {{< /tab >}}
 
-{{< tab header="**Windows**" >}}
+{{< tab header="**Windows (Powershell)**" >}}
 
 {{< command >}}
 $acl = Get-Acl -Path "key.pem"
@@ -59,31 +62,29 @@ Set-Acl -Path "key.pem" -AclObject $acl
 
 {{< /tab >}}
 
+{{< tab header="**Windows (Command Prompt)**" >}}
+
+{{< command >}}
+icacls.exe key.pem /reset
+icacls.exe key.pem /grant:r "$($env:username):(r)"
+icacls.exe key.pem /inheritance:r
+{{< /command >}}
+
+{{< /tab >}}
+
 {{< /tabpane >}}
 
-Alternatively, you can import an existing key pair, such as an SSH public key located in your home directory at `~/.ssh/id_rsa.pub`.
-Additionally, you can produce a public key from an existing private key with the `ssh-keygen` command, which means you don't need to generate a new key pair each time you use LocalStack.
-
-{{< tabpane text=true >}}
-
-{{< tab header="**Existing Key Pair**" >}}
+If you already have an SSH public key that you wish to use, such as the one located in your home directory at `~/.ssh/id_rsa.pub`, you can import it instead.
 
 {{< command >}}
 $ awslocal ec2 import-key-pair --key-name my-key --public-key-material file://~/.ssh/id_rsa.pub
 {{< /command >}}
 
-{{< /tab >}}
-
-{{< tab header="**Generate Public Key**" >}}
+If you only have the SSH private key, a public key can be generated using the following command, and then imported:
 
 {{< command >}}
-$ ssh-keygen -y -f key.pem > key.pub
-$ awslocal ec2 import-key-pair --key-name my-key --public-key-material fileb://key.pub
+$ ssh-keygen -y -f id_rsa > id_rsa.pub
 {{< /command >}}
-
-{{< /tab >}}
-
-{{< /tabpane >}}
 
 ### Add rules to your security group
 


### PR DESCRIPTION
1. I have added a way to set the correct file permissions for the `key.pem` file. Using the SSH connection on a Windows system requires this.

For more information, refer to the [documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-acl?view=powershell-7.4) for the `Set-Acl` command.

Additionally, there is an alternative method.

```powershell
# Reset the ACL of a file and grant read access to the current user
icacls.exe key.pem /reset 
# Grant read access to the current user
icacls.exe key.pem /grant:r "$($env:username):(r)"
# Disable inheritance
icacls.exe key.pem /inheritance:r
```

For more information, refer to the [documentation ](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls)for the `icacls` command.

 I prefer to use the PowerShell version, but we can change it.

3. Updated the AMI to use a new version of Ubuntu that uses ssh instead of dropbear.
4. Added the ability to reuse already-created key pairs by generating the public key and importing it to LocalStack.