### PR TITLE
Fix hardcoded links and replace them with references

### DIFF
--- a/content/en/user-guide/aws/elasticache/index.md
+++ b/content/en/user-guide/aws/elasticache/index.md
@@ -18,7 +18,7 @@ It supports popular open-source caching engines like Redis and Memcached (LocalS
 providing a means to efficiently store and retrieve frequently accessed data with minimal latency.
 
 LocalStack supports ElastiCache via the Pro offering, allowing you to use the ElastiCache APIs in your local environment.
-The supported APIs are available on our [API Coverage Page](https://docs.localstack.cloud/references/coverage/coverage_elasticache/),
+The supported APIs are available on our [API Coverage Page]({{< ref "references/coverage/coverage_elasticache" >}}),
 which provides information on the extent of ElastiCache integration with LocalStack.
 
 ## Getting started

--- a/content/en/user-guide/aws/iam/index.md
+++ b/content/en/user-guide/aws/iam/index.md
@@ -13,8 +13,8 @@ IAM allows organizations to create and manage AWS users, groups, and roles, defi
 By centralizing access control, administrators can enforce the principle of least privilege, ensuring users have only the necessary permissions for their tasks.
 
 LocalStack allows you to use the IAM APIs in your local environment to create and manage users, groups, and roles, granting permissions that adhere to the principle of least privilege.
-The supported APIs are available on our [API coverage page](https://docs.localstack.cloud/references/coverage/coverage_iam/), which provides information on the extent of IAM's integration with LocalStack.
-The policy coverage is documented in the [IAM coverage documentation](https://docs.localstack.cloud/references/iam-coverage/).
+The supported APIs are available on our [API coverage page]({{< ref "references/coverage/coverage_iam" >}}), which provides information on the extent of IAM's integration with LocalStack.
+The policy coverage is documented in the [IAM coverage documentation]({{< ref "iam-coverage" >}}).
 
 ## Getting started
 

--- a/content/en/user-guide/security-testing/iam-enforcement/index.md
+++ b/content/en/user-guide/security-testing/iam-enforcement/index.md
@@ -116,4 +116,4 @@ If the IAM policies are not correctly enforced, you will get an unsuccessful res
 
 ## Feature coverage
 
-The feature coverage is documented in the [IAM coverage documentation](https://docs.localstack.cloud/references/iam-coverage/).
+The feature coverage is documented in the [IAM coverage documentation]({{< ref "references/coverage/coverage_iam" >}}).


### PR DESCRIPTION
## Motivation

With recent PRs #1496 and #1490 we introduced some hard-coded links as bandages for link errors.

However, we should try to resort to ref shortcodes if possible.

## Changes
* Change links back to use the ref shortcode
