### PR TITLE
docs(pulumi): Add callout on aws-native package in pulumi-local

### DIFF
--- a/content/en/user-guide/integrations/pulumi/index.md
+++ b/content/en/user-guide/integrations/pulumi/index.md
@@ -22,7 +22,7 @@ This guide will show you how to set up local AWS resources using both the `pulum
 
 {{< callout >}}
 `pulumi-local` currently does not support the `aws-native` package as it relies on the AWS Cloud Control API.
-Follow the [issue](https://github.com/localstack/localstack/issues/11523).
+For additional information, refer to the [GitHub issue](https://github.com/localstack/localstack/issues/11523).
 {{< /callout >}}
 
 `pulumilocal` is a wrapper for the `pulumi` command line interface, facilitating the use of Pulumi with LocalStack.

--- a/content/en/user-guide/integrations/pulumi/index.md
+++ b/content/en/user-guide/integrations/pulumi/index.md
@@ -20,6 +20,11 @@ This guide will show you how to set up local AWS resources using both the `pulum
 
 ## `pulumilocal` wrapper script
 
+{{< callout >}}
+`pulumi-local` currently does not support the `aws-native` package as it relies on the AWS Cloud Control API.
+Follow the [issue](https://github.com/localstack/localstack/issues/11523).
+{{< /callout >}}
+
 `pulumilocal` is a wrapper for the `pulumi` command line interface, facilitating the use of Pulumi with LocalStack.
 When executing deployment commands like `pulumilocal ["up", "destroy", "preview", "cancel"]`, the script configures the Pulumi settings for LocalStack and runs the specified Pulumi command.
 


### PR DESCRIPTION
# Motivation
`pulumi-local` currently does not support the `aws-native` package, but this is not mentioned anywhere in the docs.

# Changes
- add callout into Pulumi docs