### PR TITLE
Lambda Hot Reloading not updating function when not using Docker desktop

### DIFF
--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -45,9 +45,8 @@ When hot reloading is active for a Lambda layer (Pro), the function can use at m
 {{< callout >}}
 The file sharing mechanism in Rancher Desktop or Colima distributions requires additional configuration for Lambda to be reloaded automatically.
 
-- For Rancher Desktop it is required to set the configuration `LAMBDA_DOCKER_FLAGS=-e LOCALSTACK_FILE_WATCHER_STRATEGY=polling`.
-
-- In case of Colima, we recommend starting it with Virtiofs mount type like this: `colima start --vm-type vz --mount-type virtiofs`.
+* For Rancher Desktop it is required to set the configuration `LAMBDA_DOCKER_FLAGS=-e LOCALSTACK_FILE_WATCHER_STRATEGY=polling`.
+* In case of Colima, we recommend starting it with Virtiofs mount type like this: `colima start --vm-type vz --mount-type virtiofs`.
 
 More information about this behavior can be found in the following [GitHub issue.](https://github.com/localstack/localstack/issues/11415#issuecomment-2341140998)
 

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -46,7 +46,7 @@ When hot reloading is active for a Lambda layer (Pro), the function can use at m
 Configuring the file sharing mechanism in Rancher Desktop or Colima distributions is necessary to enable hot reloading for Lambda.
 
 * For Rancher Desktop it is required to set the configuration `LAMBDA_DOCKER_FLAGS=-e LOCALSTACK_FILE_WATCHER_STRATEGY=polling`.
-* In case of Colima, we recommend starting it with Virtiofs mount type like this: `colima start --vm-type vz --mount-type virtiofs`.
+* For Colima, it is required to start with the Virtiofs mount type: `colima start --vm-type vz --mount-type virtiofs`.
 
 More information about this behavior can be found in the following [GitHub issue.](https://github.com/localstack/localstack/issues/11415#issuecomment-2341140998)
 

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -42,6 +42,17 @@ MacOS may prompt you to grant Docker access to your target folders.
 **Layer limit with hot reloading for layers:**
 When hot reloading is active for a Lambda layer (Pro), the function can use at most one layer.
 
+{{< callout >}}
+The file sharing mechanism in Rancher Desktop or Colima distributions requires additional configuration for Lambda to be reloaded automatically.
+
+- For Rancher Desktop it is required to set the configuration `LAMBDA_DOCKER_FLAGS=-e LOCALSTACK_FILE_WATCHER_STRATEGY=polling`.
+
+- In case of Colima, we recommend starting it with Virtiofs mount type like this: `colima start --vm-type vz --mount-type virtiofs`.
+
+More information about this behavior can be found in the following [GitHub issue.](https://github.com/localstack/localstack/issues/11415#issuecomment-2341140998)
+
+{{< /callout >}}
+
 ## Application Configuration Examples
 
 ### Hot reloading for JVM Lambdas

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -43,7 +43,7 @@ MacOS may prompt you to grant Docker access to your target folders.
 When hot reloading is active for a Lambda layer (Pro), the function can use at most one layer.
 
 {{< callout >}}
-The file sharing mechanism in Rancher Desktop or Colima distributions requires additional configuration for Lambda to be reloaded automatically.
+Configuring the file sharing mechanism in Rancher Desktop or Colima distributions is necessary to enable hot reloading for Lambda.
 
 * For Rancher Desktop it is required to set the configuration `LAMBDA_DOCKER_FLAGS=-e LOCALSTACK_FILE_WATCHER_STRATEGY=polling`.
 * In case of Colima, we recommend starting it with Virtiofs mount type like this: `colima start --vm-type vz --mount-type virtiofs`.


### PR DESCRIPTION
## Motivation

When using Lambda Hot Reloading in Docker distributions that are not Docker Desktop, the code is not updated. There have been a few issues related to this matter.

I believe this should be documented, as it would help troubleshoot similar issues related to this behaviour more quickly.

## Fix

Based on the following [Github issue](https://github.com/localstack/localstack/issues/11415#issuecomment-2341140998) I added a note on the Lambda Hot Reloading documentation on how to set up LS to use Hot Reloading in Rancher Desktop and Colima environments.