### PR TITLE
drop references to postgresql 10 from rds

### DIFF
--- a/content/en/user-guide/aws/rds/index.md
+++ b/content/en/user-guide/aws/rds/index.md
@@ -171,7 +171,7 @@ For instance, the `storage-encrypted` flag is returned as configured, but active
 ### PostgreSQL Engine
 
 When you establish an RDS DB cluster or instance using the `postgres`/`aurora-postgresql` DB engine along with a specified `EngineVersion`, LocalStack will dynamically install and configure the corresponding PostgreSQL version as required.
-Presently, you have the option to choose major versions ranging from 10 to 15.
+Presently, you have the option to choose major versions ranging from 11 to 15.
 If you select a major version beyond this range, the system will automatically default to version 11.
 
 It's important to note that the selection of minor versions is not available.


### PR DESCRIPTION
From @viren-nadkarni's PR:

> AWS dropped RDS PostgreSQL 10 support on 17 April 2023.

> https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.DBVersions.html#PostgreSQL.Concepts.General.DBVersions.Deprecation10

> LocalStack deprecated this in v3.2.0.

This PR removes any references to PostgreSQL 10 