### PR TITLE
FIS: Drop support for LocalStack-only actions

### DIFF
--- a/content/en/user-guide/aws/fis/index.md
+++ b/content/en/user-guide/aws/fis/index.md
@@ -237,27 +237,6 @@ LocalStack FIS currently supports the following actions:
 If you would like support for more FIS actions, please make a feature request on [GitHub](https://github.com/localstack/localstack/issues/new/choose).
 {{< /callout >}}
 
-The following actions are deprecated and marked for removal:
-
-- **`localstack:generic:api-error`**: Raise a custom HTTP error.
-    This action accepts the following parameters.
-    Please migrate to the [Chaos API]({{< ref "chaos-api" >}}) which supports this capability and more.
-  - `region`: The region name where faults will be introduced, e.g. `us-west-1`.
-      Default: region of the experiment
-  - `service`: The service name to limit faults to, e.g. `kms`.
-      Default: all services
-  - `operation`: The operation name for the specified service to limit faults to, e.g. `ListKeys`
-  - `percentage`: The percentage of API calls to fail among matching calls.
-      Default: 100
-  - `exception`: The name of the exception to raise for affected API calls.
-      Default: `InternalError`
-  - `errorCode`: The HTTP error code to return for impacted API calls.
-      Default: 500
-- **`localstack:kms:inject-api-internal-error`**: Special case of the previous action which injects an InternalError for KMS operations.
-- **`localstack:log-debug`**: Prints a debug message in the LocalStack logs when experiment is started and stopped.
-- **`localstack:generic:latency`**: Introduces a latency in the network call.
-    Please migrate to the [Chaos API]({{< ref "chaos-api" >}}).
-
 ## Current Limitations
 
 - LocalStack does not implement the [selection mode](https://docs.aws.amazon.com/fis/latest/userguide/targets.html#target-selection-mode) mechanism available on AWS.


### PR DESCRIPTION
> [!NOTE]
> This change targets the LocalStack v4.0 release

This was deprecated in v3.6