### PR TITLE
Add note on debugging limitations for Lambda functions

### DIFF
--- a/content/en/user-guide/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/lambda-tools/debugging/index.md
@@ -25,7 +25,7 @@ More examples and tooling support for local Lambda debugging (including support 
 
 {{< callout tip >}}
 Due to the ports published by the Lambda container for the debugger, it is currently only possible to debug one Lambda function at a time.
-For complex debugging scenarios that require multiple ports, please consult the [Lambda Debug Mode (preview)]({{< relref "debugging#lambda-debug-mode-preview" >}}) section.
+For advanced debugging scenarios, such as those requiring multiple ports, refer to [Lambda Debug Mode (preview)]({{< relref "debugging#lambda-debug-mode-preview" >}}) section.
 {{< /callout >}}
 
 ## Debugging Python lambdas

--- a/content/en/user-guide/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/lambda-tools/debugging/index.md
@@ -23,6 +23,11 @@ More examples and tooling support for local Lambda debugging (including support 
 * [Lambda Debug Mode (preview)](#lambda-debug-mode-preview)
 * [Resources](#resources)
 
+{{< callout tip >}}
+Due to the ports published by the lambda container for the debugger, it is currently only possible to debug one Lambda function at a time.
+For complex debugging scenarios that require multiple ports, please consult the [Lambda Debug Mode (preview)]({{< relref "debugging#lambda-debug-mode-preview" >}}) section.
+{{< /callout >}}
+
 ## Debugging Python lambdas
 
 Lambda functions debugging used to be a difficult task.

--- a/content/en/user-guide/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/lambda-tools/debugging/index.md
@@ -24,7 +24,7 @@ More examples and tooling support for local Lambda debugging (including support 
 * [Resources](#resources)
 
 {{< callout tip >}}
-Due to the ports published by the lambda container for the debugger, it is currently only possible to debug one Lambda function at a time.
+Due to the ports published by the Lambda container for the debugger, it is currently only possible to debug one Lambda function at a time.
 For complex debugging scenarios that require multiple ports, please consult the [Lambda Debug Mode (preview)]({{< relref "debugging#lambda-debug-mode-preview" >}}) section.
 {{< /callout >}}
 


### PR DESCRIPTION
Attempt to improve the visibility on the remote debugging page.