### PR TITLE
Remove callout about legacy CFn template deployer

### DIFF
--- a/content/en/user-guide/aws/cloudformation/index.md
+++ b/content/en/user-guide/aws/cloudformation/index.md
@@ -6,13 +6,6 @@ persistence: supported with limitations
 
 ---
 
-{{< callout >}}
-With LocalStack 3.5 we've improved how the internal engine orders resources for deployment and deletion of stacks.
-Specifically it now more accurately calculates dependencies between resources and doesn't try to deploy/delete resources which don't have their dependencies available yet.
-Should you encounter any issues, please report them on [GitHub](https://github.com/localstack/localstack/issues/new/choose).
-You can temporarily revert to the old behavior with `CFN_LEGACY_TEMPLATE_DEPLOYER=1`, but be aware that this is only a temporary option.
-{{< /callout >}}
-
 ## Introduction
 
 CloudFormation is a service provided by Amazon Web Services (AWS) that allows you to define and provision infrastructure as code.


### PR DESCRIPTION
We removed the legacy fallback of the template deployer with LocalStack version 3.6 so we should not mention this option in the docs.
