### PR TITLE
Changing ip from ec2 doc's sample

### DIFF
--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -172,7 +172,7 @@ Run the following command to test the Python Web Server:
 
 {{< command >}}
 $ curl 172.17.0.4:8000
-# or
+# Or, you can run:
 $ curl 127.0.0.1:29043
 {{< /command >}}
 

--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -171,7 +171,9 @@ You can now use the IP address to test the Python Web Server.
 Run the following command to test the Python Web Server:
 
 {{< command >}}
-$ curl 127.0.0.1:8000
+$ curl 172.17.0.4:8000
+# or
+$ curl 127.0.0.1:29043
 {{< /command >}}
 
 You should see the following output:

--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -171,7 +171,7 @@ You can now use the IP address to test the Python Web Server.
 Run the following command to test the Python Web Server:
 
 {{< command >}}
-$ curl 172.17.0.4:8000
+$ curl 127.0.0.1:8000
 {{< /command >}}
 
 You should see the following output:


### PR DESCRIPTION
With the current IP(172.17.0.X), the sample doesn't work. However, if we changed it to 127.0.01 it works as expected.