### PR TITLE
update docs to reference to actions/upload-artifact@v4

### DIFF
--- a/content/en/tutorials/ephemeral-application-previews/index.md
+++ b/content/en/tutorials/ephemeral-application-previews/index.md
@@ -190,7 +190,7 @@ After downloading, you can visualize logs and environment variables using a tool
 
 - name: Upload the Diagnostic Report
   if: failure()
-  uses: actions/upload-artifact@v3
+  uses: actions/upload-artifact@v4
   with:
     name: diagnose.json.gz
     path: ./diagnose.json.gz


### PR DESCRIPTION
## Motivation
GitHub is currently phasing out support for `actions/upload-artifact` versions other than the latest major release v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
This PR updates the references to use the new version of the action.

## Changes
Update the docs to reference the latest version of `actions/upload-artifact`.