### PR TITLE
update changelog for v4

### DIFF
--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -204,7 +204,7 @@ $ localstack start # start localstack in background with -d flag
   / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
  /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|
  
- 💻 LocalStack CLI 4.0.0
+ 💻 LocalStack CLI {{< localstack-latest-version >}}
  👤 Profile: default
 
 [12:47:13] starting LocalStack in Docker mode 🐳                       localstack.py:494

--- a/content/en/references/changelog.md
+++ b/content/en/references/changelog.md
@@ -33,6 +33,7 @@ which can be released as patch version because we are committed to make LocalSta
 
 | Version  | Release Date       | Release Notes                                                                                      |
 |----------|--------------------|----------------------------------------------------------------------------------------------------|
+| `v4.0.0` | November 21, 2024  | [v4.0.0](https://blog.localstack.cloud/announcing-localstack-40-general-availability/)             |
 | `v3.8.0` | October 3, 2024    | [v3.8.0](https://blog.localstack.cloud/localstack-release-v-3-8-0/)                                |
 | `v3.7.0` | August 29, 2024    | [v3.7.0](https://blog.localstack.cloud/2024-08-29-localstack-release-v-3-7-0/)                     |
 | `v3.6.0` | July 25, 2024      | [v3.6.0](https://discuss.localstack.cloud/t/localstack-release-v3-6-0/997)                         |


### PR DESCRIPTION
## Motivation
We released LocalStack v4 yesterday 🥳
This PR adds the v4 entry to the changelog in our docs.

## Changes
- Adds the changelog entry for v4.
- Sneak in a small change: Make the version in the sample output on the installation page parameterized such that it is automatically updated with the LocalStack version in the config.