### PR TITLE
Fix typo in Initialization Hooks documentation

### DIFF
--- a/content/en/references/init-hooks.md
+++ b/content/en/references/init-hooks.md
@@ -95,7 +95,7 @@ curl -s localhost:4566/_localstack/init/ready | jq .
     {
       "stage": "READY",
       "name": "pre_seed.py",
-      "state": "OK"
+      "state": "SUCCESSFUL"
     }
   ]
 }


### PR DESCRIPTION
`"state": "OK"` is not one of the documented states.

https://docs.localstack.cloud/references/init-hooks/#querying-stages
> A script can be in one of four states: UNKNOWN, RUNNING, SUCCESSFUL, ERROR. Scripts are by default in the UNKNOWN state once they have been discovered. The remaining states should be self-explanatory.

Fix the example response to be `"SUCCESSFUL"` which is what is actually returned.