### PR TITLE
Add troubleshooting section to Bedrock and adapt default model

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -95,7 +95,7 @@ This section covers configuration options that are specific to certain AWS servi
 | Variable | Example Values | Description |
 | - | - | - |
 | `BEDROCK_PREWARM` | `0` (default) \| `1` | Pre-warm the Bedrock engine directly on LocalStack startup instead of on demand. |
-| `DEFAULT_BEDROCK_MODEL` | `mistral` (default) | The model to use to handle text model invocations in Bedrock. Any text-based model available for Ollama is usable. |
+| `DEFAULT_BEDROCK_MODEL` | `smollm2` (default) | The model to use to handle text model invocations in Bedrock. Any text-based model available for Ollama is usable. |
 
 ### BigData (EMR, Athena, Glue)
 

--- a/content/en/user-guide/aws/bedrock/index.md
+++ b/content/en/user-guide/aws/bedrock/index.md
@@ -127,6 +127,16 @@ $ awslocal bedrock create-model-invocation-job \
 
 The results will be at the S3 URL `s3://out-bucket/12345678/batch_input.jsonl.out`
 
+## Troubleshooting
+
+Users of Docker Desktop on macOS might run into the issue of Bedrock becoming unresponsive after some usage.
+A common reason for that is insufficient storage or memory space in the Docker Desktop VM.
+To resolve this issue you can increase those amounts directly in Docker Desktop or clean up unused artifacts with the Docker CLI like this
+
+{{< command >}}
+$ docker system prune
+{{< / command >}}
+
 ## Limitations
 
 * At this point, we have only tested text-based models in LocalStack.


### PR DESCRIPTION
In line with upcoming stability improvements for Bedrock, this PR changes the default model in the docs to `smollm2`.

Additionally, a troubleshooting section is added describing the issue of insufficient storage or memory space in Docker Desktop. 