### PR TITLE
Deprecate event rule engine config

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -376,7 +376,7 @@ To learn more about these configuration options, see [Cloud Pods]({{< ref "user-
 
 | Variable | Example Values | Description |
 | - | - | - |
-| `EVENT_RULE_ENGINE` | `python` (default) \| `java` (preview) | Engine for [event pattern matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping. Set it `java` to use the AWS [event-ruler](https://github.com/aws/event-ruler) offering better parity. |
+| `EVENT_RULE_ENGINE` | `python` (default) \| `java` (deprecated) | Engine for [event pattern matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping. Out latest `python` implementation introduced with [4.0.3](https://github.com/localstack/localstack/pull/11960) makes the `java` engine (previously in preview) using AWS [event-ruler](https://github.com/aws/event-ruler) obsolete. |
 | `SKIP_SSL_CERT_DOWNLOAD` | | Whether to skip downloading the SSL certificate for localhost.localstack.cloud |
 | `CUSTOM_SSL_CERT_PATH` | `/var/lib/localstack/custom/server.test.pem` | Defines the absolute path to a custom SSL certificate for localhost.localstack.cloud |
 | `IGNORE_ES_DOWNLOAD_ERRORS` | | Whether to ignore errors (e.g., network/SSL) when downloading Elasticsearch plugins |

--- a/content/en/user-guide/aws/events/index.md
+++ b/content/en/user-guide/aws/events/index.md
@@ -133,11 +133,6 @@ $ localstack logs
 
 ## Supported target types
 
-{{< callout >}}
-LocalStack supports a new event rule engine for [EventBridge event patterns](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html).
-You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (preview) to use the AWS [event-ruler](https://github.com/aws/event-ruler), which offers better parity with AWS.
-{{< /callout >}}
-
 At this time LocalStack supports the following [target types](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html#eb-console-targets) for EventBridge rules:
 
 - Lambda function

--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -162,11 +162,6 @@ The product of 10 and 10 is 100%
 
 ## Lambda Event Source Mappings
 
-{{< callout >}}
-Since [3.4.0](https://discuss.localstack.cloud/t/localstack-release-v3-4-0/871#new-experimental-event-rule-engine-2), LocalStack supports a new event rule engine for [Lambda event filtering](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html).
-You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (preview) to use the AWS [event-ruler](https://github.com/aws/event-ruler), which offers better parity.
-{{< /callout >}}
-
 [Lambda event source mappings](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html) allows you to connect Lambda functions to other AWS services.
 The following event sources are supported in LocalStack:
 

--- a/content/en/user-guide/aws/pipes/index.md
+++ b/content/en/user-guide/aws/pipes/index.md
@@ -24,11 +24,6 @@ The implementation of EventBridge Pipes is currently in **preview** stage and un
 If you would like support for more APIs or report bugs, please make an issue on [GitHub](https://github.com/localstack/localstack/issues/new/choose).
 {{< /callout >}}
 
-{{< callout "tip" >}}
-LocalStack now supports a new event rule engine for [EventBridge event patterns](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html).
-You can [configure]({{< ref "configuration" >}}) `EVENT_RULE_ENGINE=java` (preview) to use the AWS [event-ruler](https://github.com/aws/event-ruler), which offers better parity.
-{{< /callout >}}
-
 ## Getting started
 
 This guide is designed for users new to EventBridge Pipes and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.


### PR DESCRIPTION
`EVENT_RULE_ENGINE` deprecated in https://github.com/localstack/localstack/pull/11964

New Python implementation: https://github.com/localstack/localstack/pull/11960