### PR TITLE
Fix quotation mark for OpenSearch password

### DIFF
--- a/content/en/user-guide/aws/opensearch/index.md
+++ b/content/en/user-guide/aws/opensearch/index.md
@@ -214,7 +214,7 @@ $ awslocal opensearch create-domain --cli-input-json file://./opensearch_domain.
 Once the domain setup is complete (`Processing: false`), the cluster can only be accessed with the given master user credentials, via HTTP basic authentication:
 
 {{< command >}}
-$ curl -u "admin:really-secure-passwordAa!1" http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/_cluster/health
+$ curl -u 'admin:really-secure-passwordAa!1' http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/_cluster/health
 {{< /command >}}
 
 The following output will be visible on your terminal:
@@ -265,7 +265,7 @@ docker run --rm -p 5601:5601 \
   --network ls \
   --dns 172.22.0.2 \
   -e "OPENSEARCH_HOSTS=http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566" \
-  -e "OPENSEARCH_USERNAME=admin" -e "OPENSEARCH_PASSWORD=really-secure-passwordAa!1" \
+  -e "OPENSEARCH_USERNAME=admin" -e 'OPENSEARCH_PASSWORD=really-secure-passwordAa!1' \
   opensearchproject/opensearch-dashboards:2.11.0
 {{< /command >}}
 


### PR DESCRIPTION
Hi😀

While trying to use OpenSearch Service via LocalStack and referring to the documentation, I encountered some errors.
https://docs.localstack.cloud/user-guide/aws/opensearch/

## Steps to Reproduce (Advanced Security Options section)

```sh
$ awslocal opensearch create-domain --cli-input-json file://./opensearch_domain.json --region us-east-1
$ curl -u "admin:really-secure-passwordAa!1" http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/_cluster/health
<?xml version='1.0' encoding='utf-8'?>
<Error><Code>InternalError</Code><Message>exception while calling s3 with unknown operation: MyHTTPSConnectionPool(host='127.0.0.1', port=53137): Max retries exceeded with url: /_cluster/health (Caused by NewConnectionError('&lt;urllib3.connection.HTTPSConnection object at 0xffff65b48110&gt;: Failed to establish a new connection: [Errno 111] Connection refused'))</Message><RequestId>88cee013-b17a-42c2-b130-4ae913123e26</RequestId></Error>%
```

## Steps to Reproduce (OpenSearch Dashboards section)

```sh
$ localstack start --network ls
$ awslocal opensearch create-domain --cli-input-json file://./opensearch_domain.json --region us-east-1
$ docker inspect localstack-main | \
 jq -r '.[0].NetworkSettings.Networks | to_entries | .[].value.IPAddress'
172.22.0.2
$ docker run --rm -p 5601:5601 \
  --network ls \
  --dns 172.22.0.2 \
  -e "OPENSEARCH_HOSTS=http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566" \
  -e "OPENSEARCH_USERNAME=admin" -e "OPENSEARCH_PASSWORD=really-secure-passwordAa!1" \
  opensearchproject/opensearch-dashboards:2.11.0
{"type":"log","@timestamp":"2024-12-14T12:49:53Z","tags":["error","opensearch","data"],"pid":1,"message":"[ResponseError]: Response Error"}
{"type":"log","@timestamp":"2024-12-14T12:49:55Z","tags":["error","opensearch","data"],"pid":1,"message":"[ResponseError]: Response Error"}
{"type":"log","@timestamp":"2024-12-14T12:49:58Z","tags":["error","opensearch","data"],"pid":1,"message":"[ResponseError]: Response Error"}
```

## Cause

The issue occurs because the characters `!1` in the password triggers **History Expansion** in some shell environments.

- https://www.oreilly.com/library/view/learning-the-bash/1565923472/ch02s06.html
- https://zsh.sourceforge.io/Doc/Release/Expansion.html

On macOS (using the default zsh shell), the following behavior occurs:

```sh
$ head -n 1 ${HISTFILE}
: 1734180039:0;ls

$ echo "admin:really-secure-passwordAa!1"
$ echo "admin:really-secure-passwordAals"
admin:really-secure-passwordAals
```

## After the Fix

I updated the document to use single quotes to disable history expansion😀

## Works Correctly (Advanced Security Options section)

```sh
$ curl -u 'admin:really-secure-passwordAa!1' http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/_cluster/health
{"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"discovered_cluster_manager":true,"active_primary_shards":4,"active_shards":4,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
```

## Works Correctly (OpenSearch Dashboards section)

```sh
$ docker run --rm -p 5601:5601 \
  --network ls \
  --dns 172.22.0.2 \
  -e "OPENSEARCH_HOSTS=http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566" \
  -e "OPENSEARCH_USERNAME=admin" -e 'OPENSEARCH_PASSWORD=really-secure-passwordAa!1' \
  opensearchproject/opensearch-dashboards:2.11.0
{"type":"log","@timestamp":"2024-12-14T12:50:36Z","tags":["info","http","server","OpenSearchDashboards"],"pid":1,"message":"http server running at http://0.0.0.0:5601"}
```

![image](https://github.com/user-attachments/assets/8cb65160-06ae-45ac-b70e-9c058acaed3a)

Thanks!