### PR TITLE
Managed Flink: Tagging support and CloudWatch Logs integration

### DIFF
--- a/content/en/user-guide/aws/kinesisanalyticsv2/index.md
+++ b/content/en/user-guide/aws/kinesisanalyticsv2/index.md
@@ -169,7 +169,6 @@ $ awslocal s3api list-objects --bucket sink-bucket
 - Only S3 zipfile code is supported
 - Values of 20,000 ms for `execution.checkpointing.interval` and 5,000 ms for `execution.checkpointing.min-pause` are used for checkpointing.
   They can not be overridden.
-- [Tagging](https://docs.aws.amazon.com/managed-flink/latest/java/how-tagging.html) is not supported
 - In-place [version upgrades](https://docs.aws.amazon.com/managed-flink/latest/java/how-in-place-version-upgrades.html) and [roll-backs](https://docs.aws.amazon.com/managed-flink/latest/java/how-system-rollbacks.html) are not supported
 - [Snapshot/savepoint management](https://docs.aws.amazon.com/managed-flink/latest/java/how-snapshots.html) is not implemented
 - CloudWatch and CloudTrail integration is not implemented

--- a/content/en/user-guide/aws/kinesisanalyticsv2/index.md
+++ b/content/en/user-guide/aws/kinesisanalyticsv2/index.md
@@ -155,7 +155,7 @@ $ awslocal s3api list-objects --bucket sink-bucket
 
 ## CloudWatch Logging
 
-LocalStack MSAF supports CloudWatch Logs integration to help monitor the Flink cluster for application events or configuration problems.
+LocalStack MSAF supports [CloudWatch Logs integration](https://docs.aws.amazon.com/managed-flink/latest/java/cloudwatch-logs.html) to help monitor the Flink cluster for application events or configuration problems.
 The logging option can be added at the time of creating the Flink application using the [CreateApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_CreateApplication.html) operation.
 Logging options can also be managed at a later point using the [AddApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_AddApplicationCloudWatchLoggingOption.html) and [DeleteApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_DeleteApplicationCloudWatchLoggingOption.html) operations.
 
@@ -204,7 +204,7 @@ $ awslocal logs get-log-events --log-group-name msaf-log-group --log-stream-name
 
 ## Resource Tagging
 
-You can manage resource tags using [TagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_TagResource.html), [UntagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_UntagResource.html) and [ListTagsForResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_ListTagsForResource.html).
+You can manage [resource tags](https://docs.aws.amazon.com/managed-flink/latest/java/how-tagging.html) using [TagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_TagResource.html), [UntagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_UntagResource.html) and [ListTagsForResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_ListTagsForResource.html).
 Tags can also be specified when creating the Flink application using the [CreateApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_CreateApplication.html) operation.
 
 {{< command >}}

--- a/content/en/user-guide/aws/kinesisanalyticsv2/index.md
+++ b/content/en/user-guide/aws/kinesisanalyticsv2/index.md
@@ -155,7 +155,7 @@ $ awslocal s3api list-objects --bucket sink-bucket
 
 ## CloudWatch Logging
 
-LocalStack supports CloudWatch Logs integration to help monitor the Flink cluster for application events or configuration problems.
+LocalStack MSAF supports CloudWatch Logs integration to help monitor the Flink cluster for application events or configuration problems.
 The logging option can be added at the time of creating the Flink application using the [CreateApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_CreateApplication.html) operation.
 Logging options can also be managed at a later point using the [AddApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_AddApplicationCloudWatchLoggingOption.html) and [DeleteApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_DeleteApplicationCloudWatchLoggingOption.html) operations.
 
@@ -201,6 +201,31 @@ To retrieve all events:
 $ awslocal logs get-log-events --log-group-name msaf-log-group --log-stream-name msaf-log-stream
 {{< /command >}}
 
+## Resource Tagging
+
+You can manage resource tags using [TagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_TagResource.html), [UntagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_UntagResource.html) and [ListTagsForResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_ListTagsForResource.html).
+Tags can also be specified when creating the Flink application using the [CreateApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_CreateApplication.html) operation.
+
+{{< command >}}
+$ awslocal kinesisanalyticsv2 tag-resource \
+    --resource-arn arn:aws:kinesisanalytics:us-east-1:000000000000:application/msaf-app \
+    --tags Key=country,Value=SE
+
+$ awslocal kinesisanalyticsv2 list-tags-for-resource \
+    --resource-arn arn:aws:kinesisanalytics:us-east-1:000000000000:application/msaf-app
+{
+    "Tags": [
+        {
+            "Key": "country",
+            "Value": "SE"
+        }
+    ]
+}
+
+$ awslocal kinesisanalyticsv2 untag-resource \
+    --resource-arn arn:aws:kinesisanalytics:us-east-1:000000000000:application/msaf-app \
+    --tag-keys country
+{{< /command >}}
 
 ## Supported Flink Versions
 
@@ -209,7 +234,7 @@ $ awslocal logs get-log-events --log-group-name msaf-log-group --log-stream-name
 | 1.20.0 | yes | yes |
 | 1.19.1 | yes | yes |
 | 1.18.1 | yes | yes |
-| 1.15.2 | yes | yes |
+| 1.15.2 | yes | no |
 | 1.13.1 | yes | no |
 
 ## Limitations

--- a/content/en/user-guide/aws/kinesisanalyticsv2/index.md
+++ b/content/en/user-guide/aws/kinesisanalyticsv2/index.md
@@ -160,7 +160,8 @@ The logging option can be added at the time of creating the Flink application us
 Logging options can also be managed at a later point using the [AddApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_AddApplicationCloudWatchLoggingOption.html) and [DeleteApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_DeleteApplicationCloudWatchLoggingOption.html) operations.
 
 There are following prerequisites for CloudWatch Logs integration:
-- You must create the application's log group and log stream. Flink will not create it for you.
+- You must create the application's log group and log stream.
+  Flink will not create it for you.
 - You must add the permissions your application needs to write to the log stream to the service execution role.
   Generally the following IAM actions are sufficient: `logs:DescribeLogGroups`, `logs:DescribeLogStreams` and `logs:PutLogEvents`
 

--- a/content/en/user-guide/aws/kinesisanalyticsv2/index.md
+++ b/content/en/user-guide/aws/kinesisanalyticsv2/index.md
@@ -202,6 +202,10 @@ To retrieve all events:
 $ awslocal logs get-log-events --log-group-name msaf-log-group --log-stream-name msaf-log-stream
 {{< /command >}}
 
+{{< callout >}}
+Logs events are reported to CloudWatch every 10 seconds.
+{{< /callout >}}
+
 ## Resource Tagging
 
 You can manage [resource tags](https://docs.aws.amazon.com/managed-flink/latest/java/how-tagging.html) using [TagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_TagResource.html), [UntagResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_UntagResource.html) and [ListTagsForResource](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_ListTagsForResource.html).


### PR DESCRIPTION
> [!NOTE]
> Reviewers please do not merge

This PR adds docs for CloudWatch Logs integration and resource tagging support in Managed Service for Apache Flink.