### PR TITLE
ELB: add alternative URL structure

### DIFF
--- a/content/en/user-guide/aws/elb/index.md
+++ b/content/en/user-guide/aws/elb/index.md
@@ -153,7 +153,7 @@ The following output will be retrieved:
 If a request cannot be made to a subdomain of `localhost.localstack.cloud`, an alternative URL structure is available, however it is not returned by AWS management API methods.
 To make a request against an ELB with id `<elb-id>`, use the URL:
 
-```
+```bash
 http(s)://localhost.localstack.cloud:4566/_aws/elb/<elb-id>/<elb-path>
 ```
 

--- a/content/en/user-guide/aws/elb/index.md
+++ b/content/en/user-guide/aws/elb/index.md
@@ -148,6 +148,15 @@ The following output will be retrieved:
 }
 ```
 
+#### Alternative URL structure
+
+If a request cannot be made to a subdomain of `localhost.localstack.cloud`, an alternative URL structure is available, however it is not returned by AWS management API methods.
+To make a request against an ELB with id `<elb-id>`, use the URL:
+
+```
+http(s)://localhost.localstack.cloud:4566/_aws/elb/<elb-id>/<elb-path>
+```
+
 ## Examples
 
 The following code snippets and sample applications provide practical examples of how to use ELB in LocalStack for various use cases:

--- a/content/en/user-guide/aws/elb/index.md
+++ b/content/en/user-guide/aws/elb/index.md
@@ -157,6 +157,18 @@ To make a request against an ELB with id `<elb-id>`, use the URL:
 http(s)://localhost.localstack.cloud:4566/_aws/elb/<elb-id>/<elb-path>
 ```
 
+Here's an example of how you would access the load balancer with a name of `example-lb` with the subdomain-based URL format:
+
+```bash
+http(s)://example-lb.elb.localhost.localstack.cloud:4566/test/path
+```
+
+With the alternative URL structure:
+
+```bash
+http(s)://localhost.localstack.cloud:4566/_aws/elb/example-lb/test/path
+```
+
 ## Examples
 
 The following code snippets and sample applications provide practical examples of how to use ELB in LocalStack for various use cases:


### PR DESCRIPTION
We are working on path-based routing for ELB. **Do not merge this PR until the feature is ready**

When that feature becomes available, this change adds a section in the ELB documentation showing the alternative _path based_ URL structure.

[[rendered](https://localstack-docs-preview-pr-1603.surge.sh/user-guide/aws/elb/#alternative-url-structure)]
