### PR TITLE
Added small clarification on profiles

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -493,6 +493,7 @@ These configurations have already been removed and **won't have any effect** on 
 ## Profiles
 
 LocalStack supports configuration profiles which are stored in the `~/.localstack` config directory.
+If the directory does not exist, create it manually.
 A configuration profile is a set of environment variables stored in an `.env` file in the LocalStack config directory.
 
 Here is an example of what configuration profiles might look like:


### PR DESCRIPTION
Added small clarification on configuration of profiles.
In my onboarding experience, the ./localstack/ directory was not created when I was trying profiles out and I spent some minutes getting lost on whether this directory was supposed to get automatically created or not. Which should be if you install localstack via cli. 