### PR TITLE
Add s3 as ESM failure destination for Kinesis and DynamoDB stream sources

### DIFF
--- a/content/en/user-guide/aws/lambda/index.md
+++ b/content/en/user-guide/aws/lambda/index.md
@@ -204,7 +204,7 @@ Feature availability and coverage is categorized with the following system:
 | ParallelizationFactor          | Parallel batch processing by shard.             | ➖        | ➖    | 🟠       | 🟠        | ➖          | ➖            |
 | DestinationConfig.OnFailure    | SQS Failure Destination.                        | ➖        | ➖    | 🟢       | 🟢        | 🟠          | 🟠            |
 |                                | SNS Failure Destination.                        | ➖        | ➖    | 🟢       | 🟢        | 🟠          | 🟠            |
-|                                | S3 Failure Destination.                         | ➖        | ➖    | 🟠       | 🟠        | 🟠          | 🟠            |
+|                                | S3 Failure Destination.                         | ➖        | ➖    | 🟢       | 🟢        | 🟠          | 🟠            |
 | DestinationConfig.OnSuccess    | Success Destinations.                           | ➖        | ➖    | ➖       | ➖        | ➖          | ➖            |
 | MetricsConfig                  | CloudWatch metrics.                             | 🟠        | 🟠    | 🟠       | 🟠        | 🟠          | 🟠            |
 | ProvisionedPollerConfig        | Control throughput via min-max limits.          | ➖        | ➖    | ➖       | ➖        | 🟠          | 🟠            |


### PR DESCRIPTION
Implemented in https://github.com/localstack/localstack/pull/12087. This update to docs should be merged after ~~the next minor release~~ the next `latest` pro image is shipped.