### PR TITLE
remove warning against serverless v4

### DIFF
--- a/content/en/user-guide/integrations/serverless-framework/index.md
+++ b/content/en/user-guide/integrations/serverless-framework/index.md
@@ -17,14 +17,6 @@ In particular, the setup consists of the following two steps.
 1. Installing and configuring the [Serverless-LocalStack plugin](https://github.com/localstack/serverless-localstack).
 2. Adjusting AWS endpoints in Lambda functions.
 
-{{< callout "note" >}}
-Currently, the Serverless Framework integration with LocalStack via the `serverless-localstack` plugin only provides support up to Serverless Framework version 3.39.
-Serverless Framework V4 requires a subscription and a license to use.
-
-The `serverless-localstack` plugin has not been updated or tested against version 4 of the Serverless Framework, and breaking changes are expected if attempted.
-Currently there is no timeline on when an update will be released to enable compatibility with Serverless Framework V4.
-{{< /callout >}}
-
 ## Prerequisites
 
 This guide assumes that you have the following tools installed.


### PR DESCRIPTION
Since late October 2024 the serverless-plugin is confirmed to be compatible with Serverless v4. Wondering if there something else we could do more than just removing the warning.