### PR TITLE
Increase visibilty of codebuild privileged mode requirement

### DIFF
--- a/content/en/user-guide/ci/codebuild/index.md
+++ b/content/en/user-guide/ci/codebuild/index.md
@@ -12,6 +12,11 @@ description: Use LocalStack in CodeBuild
 CodeBuild allows you to define your build project, set the source code location, and handles the building and testing, while supporting various programming languages, build tools, and runtime environments.
 LocalStack supports CodeBuild out of the box and can be easily integrated into your pipeline to run your tests against a cloud emulator.
 
+{{< alert title="Requirement" >}}
+LocalStack depends on the Docker socket to emulate your infrastructure.
+To enable it, update your project by ticking **Environment > Additional Configuration > Privileged > Enable this flag if you want to build Docker Images or want your builds to get elevated privileges**.
+{{< / alert >}}
+
 ## Snippets
 
 CodeBuild has the capability to use LocalStack's GitHub Action.


### PR DESCRIPTION
# Motivation

A user was trying to use LocalStack on CodeBuild, however they kept getting "connection refused" when trying to connect. The solution to their problem was to run their job in "privileged" mode.

Our guide includes a "Current limitations" section at the _bottom_ of the page, however it is not clear that this is a _requirement_.

# Changes

* Make the _requirement_ more prominent by adding a callout at the top of the page, and labelling it "Requirement"
