### PR TITLE
CFn: document NoEcho behaviour

### DIFF
--- a/content/en/user-guide/aws/cloudformation/index.md
+++ b/content/en/user-guide/aws/cloudformation/index.md
@@ -152,7 +152,7 @@ Prefer stack re-creation over stack update at this time.
 
 {{< callout >}}
 Currently, support for `NoEcho` parameters is limited.
-Parameters will be masked only in the CLI: `describe-stacks` and `describe-change-set` or respective API responses in `Parameters` section.
+Parameters will be masked only in the `Parameters` section of responses to `DescribeStacks` and `DescribeChangeSets` requests.
 This might expose sensitive information.
 Please exercise caution when using parameters with `NoEcho`.
 {{< /callout >}}

--- a/content/en/user-guide/aws/cloudformation/index.md
+++ b/content/en/user-guide/aws/cloudformation/index.md
@@ -150,6 +150,13 @@ Currently, support for `UPDATE` operations on resources is limited.
 Prefer stack re-creation over stack update at this time.
 {{< /callout >}}
 
+{{< callout >}}
+Currently, support for `NoEcho` parameters is limited.
+Parameters will be masked only in the CLI: `describe-stacks` and `describe-change-set` or respective API responses in `Parameters` section.
+This might expose sensitive information.
+Please exercise caution when using parameters with `NoEcho`.
+{{< /callout >}}
+
 ### Intrinsic Functions
 
 | Intrinsic Function | Supported | Explanation                                                  |

--- a/content/en/user-guide/aws/ec2/index.md
+++ b/content/en/user-guide/aws/ec2/index.md
@@ -172,7 +172,7 @@ Run the following command to test the Python Web Server:
 
 {{< command >}}
 $ curl 172.17.0.4:8000
-# Or, you can run:
+# Or, you can run
 $ curl 127.0.0.1:29043
 {{< /command >}}
 


### PR DESCRIPTION
Duplicated from https://github.com/localstack/docs/pull/1579

We now have initial support for setting `NoEcho` in CFn parameters. This PR adds a callout reminding users not to use them for sensitive information, but otherwise they are availble.

Also: fix a linting error with the EC2 docs introduced in #1546 
