### PR TITLE
Fix references to Kinesis Data Analytics v2

### DIFF
--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -258,7 +258,7 @@ Please consult the [migration guide]({{< ref "user-guide/aws/lambda#migrating-to
 | - | - | - |
 | `REDIS_CONTAINER_MODE` | `1`\|`0` (default) | Start MemoryDB cluster nodes in separate containers instead of in the LocalStack container |
 
-# MSAF
+# MSF
 
 | Variable | Example Values | Description |
 | - | - | - |

--- a/content/en/references/configuration.md
+++ b/content/en/references/configuration.md
@@ -258,7 +258,7 @@ Please consult the [migration guide]({{< ref "user-guide/aws/lambda#migrating-to
 | - | - | - |
 | `REDIS_CONTAINER_MODE` | `1`\|`0` (default) | Start MemoryDB cluster nodes in separate containers instead of in the LocalStack container |
 
-# MSF
+### MSF
 
 | Variable | Example Values | Description |
 | - | - | - |

--- a/content/en/references/coverage/coverage_kinesisanalyticsv2/index.md
+++ b/content/en/references/coverage/coverage_kinesisanalyticsv2/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Amazon Managed Service for Apache Flink"
+title: "Managed Service for Apache Flink"
 linkTitle: "kinesisanalyticsv2"
 description: >
   Implementation details for MSF (formerly kinesisanalyticsv2)

--- a/content/en/references/coverage/coverage_kinesisanalyticsv2/index.md
+++ b/content/en/references/coverage/coverage_kinesisanalyticsv2/index.md
@@ -1,10 +1,14 @@
 ---
-title: "Kinesis Data Analytics API v2"
+title: "Amazon Managed Service for Apache Flink"
 linkTitle: "kinesisanalyticsv2"
 description: >
-  Implementation details for API kinesisanalyticsv2
+  Implementation details for MSF (formerly kinesisanalyticsv2)
 hide_readingtime: true
 ---
+
+{{< callout >}}
+Amazon Managed Service for Apache Flink (MSF) was previously known as Amazon Kinesis Data Analytics for Apache Flink.
+{{< /callout >}}
 
 ## Coverage Overview
 {{< localstack_coverage_table service="kinesisanalyticsv2" >}}

--- a/content/en/user-guide/aws/kinesisanalyticsv2/index.md
+++ b/content/en/user-guide/aws/kinesisanalyticsv2/index.md
@@ -13,12 +13,12 @@ This service was formerly known as 'Kinesis Data Analytics for Apache Flink'.
 ## Introduction
 
 [Apache Flink](https://flink.apache.org/) is a framework for building applications that process and analyze streaming data.
-[Managed Service for Apache Flink (MSAF)](https://docs.aws.amazon.com/managed-flink/latest/java/what-is.html) is an AWS service that provides the underlying infrastructure and a hosted Apache Flink cluster that can run Apache Flink applications.
+[Managed Service for Apache Flink (MSF)](https://docs.aws.amazon.com/managed-flink/latest/java/what-is.html) is an AWS service that provides the underlying infrastructure and a hosted Apache Flink cluster that can run Apache Flink applications.
 
 LocalStack lets you to run Flink applications locally and implements several [AWS-compatible API operations](https://docs.localstack.cloud/references/coverage/coverage_kinesisanalyticsv2/).
 
 {{< callout "note" >}}
-The emulated MSAF provider was introduced and made the default in LocalStack v4.1.
+The emulated MSF provider was introduced and made the default in LocalStack v4.1.
 
 If you wish to use the older mock provider, you can set `PROVIDER_OVERRIDE_KINESISANALYTICSV2=legacy`.
 {{< /callout >}}
@@ -50,7 +50,7 @@ The Flink application jar file will be placed in the `./target/flink-kds-s3.jar`
 
 ### Upload Application Code
 
-MSAF requires that all application code resides in S3.
+MSF requires that all application code resides in S3.
 
 Create an S3 bucket and upload the compiled Flink application jar.
 
@@ -71,10 +71,10 @@ $ awslocal s3api create-bucket --bucket sink-bucket
 
 ### Permissions
 
-MSAF requires a service execution role which allows it to connect to other services.
+MSF requires a service execution role which allows it to connect to other services.
 Without the proper permissions policy and role, this example application will not be able to connect to S3 sink bucket to output the result.
 
-Create an IAM role for the running MSAF application to assume.
+Create an IAM role for the running MSF application to assume.
 
 ```json
 # role.json
@@ -114,7 +114,7 @@ Next create add a permissions policy to this role that permits read and write ac
 $ awslocal iam put-role-policy --role-name msaf-role --policy-name msaf-policy --policy-document file://policy.json
 {{< /command >}}
 
-Now, when the running MSAF application assumes this role, it will have the necessary permissions to write to the S3 sink.
+Now, when the running MSF application assumes this role, it will have the necessary permissions to write to the S3 sink.
 
 ### Deploy Application
 
@@ -155,7 +155,7 @@ $ awslocal s3api list-objects --bucket sink-bucket
 
 ## CloudWatch Logging
 
-LocalStack MSAF supports [CloudWatch Logs integration](https://docs.aws.amazon.com/managed-flink/latest/java/cloudwatch-logs.html) to help monitor the Flink cluster for application events or configuration problems.
+LocalStack MSF supports [CloudWatch Logs integration](https://docs.aws.amazon.com/managed-flink/latest/java/cloudwatch-logs.html) to help monitor the Flink cluster for application events or configuration problems.
 The logging option can be added at the time of creating the Flink application using the [CreateApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_CreateApplication.html) operation.
 Logging options can also be managed at a later point using the [AddApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_AddApplicationCloudWatchLoggingOption.html) and [DeleteApplicationCloudWatchLoggingOption](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_DeleteApplicationCloudWatchLoggingOption.html) operations.
 

--- a/data/coverage/service_display_name.json
+++ b/data/coverage/service_display_name.json
@@ -266,7 +266,7 @@
     },
     "kinesisanalyticsv2": {
       "long_name": "Amazon Managed Service for Apache Flink",
-      "short_name": "",
+      "short_name": "MSF",
       "api": "https://docs.aws.amazon.com/managed-flink/latest/apiv2/Welcome.html"
     },
     "kms": {

--- a/data/coverage/service_display_name.json
+++ b/data/coverage/service_display_name.json
@@ -265,9 +265,9 @@
       "api": "https://docs.aws.amazon.com/kinesisanalytics/latest/dev/API_Reference.html"
     },
     "kinesisanalyticsv2": {
-      "long_name": "Kinesis Data Analytics API v2",
+      "long_name": "Amazon Managed Service for Apache Flink",
       "short_name": "",
-      "api": "https://docs.aws.amazon.com/kinesisanalytics/latest/apiv2/Welcome.html"
+      "api": "https://docs.aws.amazon.com/managed-flink/latest/apiv2/Welcome.html"
     },
     "kms": {
       "long_name": "Key Management Service",

--- a/data/coverage/service_display_name.json
+++ b/data/coverage/service_display_name.json
@@ -265,7 +265,7 @@
       "api": "https://docs.aws.amazon.com/kinesisanalytics/latest/dev/API_Reference.html"
     },
     "kinesisanalyticsv2": {
-      "long_name": "Amazon Managed Service for Apache Flink",
+      "long_name": "Managed Service for Apache Flink",
       "short_name": "MSF",
       "api": "https://docs.aws.amazon.com/managed-flink/latest/apiv2/Welcome.html"
     },

--- a/data/persistence/coverage.json
+++ b/data/persistence/coverage.json
@@ -1457,7 +1457,7 @@
   },
   "kinesisanalyticsv2": {
     "service": "kinesisanalyticsv2",
-    "full_name": "Kinesis Data Analytics API v2",
+    "full_name": "Amazon Managed Service for Apache Flink",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""

--- a/data/persistence/coverage.json
+++ b/data/persistence/coverage.json
@@ -1457,7 +1457,7 @@
   },
   "kinesisanalyticsv2": {
     "service": "kinesisanalyticsv2",
-    "full_name": "Amazon Managed Service for Apache Flink",
+    "full_name": "Managed Service for Apache Flink",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""


### PR DESCRIPTION
There were still references to this services as Kinesis Data Analytics v2 in the service coverage guide when the proper name is Amazon Managed Service for Apache Flink.  In addition, according to the product team at AWS the correct acronym is MSF and not MSAF.