### PR TITLE
Docs for S3 auto load feature

### DIFF
--- a/content/en/getting-started/quickstart/index.md
+++ b/content/en/getting-started/quickstart/index.md
@@ -95,7 +95,7 @@ pip install -r requirements-dev.txt
 {{< /tabpane >}}
 
 {{< callout "tip" >}}
-If you are encountering issues with the installation of the packages, such as Pillow, ensure you use the same version as the Python Lambdas (3.11.6) for Pillow to work. 
+If you are encountering issues with the installation of the packages, such as Pillow, ensure you use the same version as the Python Lambdas (3.11.6) for Pillow to work.
 If you're using <a href="https://github.com/pyenv/pyenv">pyenv</a>, install and activate Python 3.11 with the following commands:
 {{< command >}}
 $ pyenv install 3.11

--- a/content/en/user-guide/state-management/cloud-pods/index.md
+++ b/content/en/user-guide/state-management/cloud-pods/index.md
@@ -398,10 +398,6 @@ Commands:
 The S3 remote enables you to store Cloud Pod assets in an existing S3 bucket within an actual AWS account.
 The initial step is to export the necessary AWS credentials within the terminal session.
 
-{{< callout >}}
-The Cloud Pods S3 remote is currently _only_ available when [installing the `localstack` CLI via `pip`](https://docs.localstack.cloud/getting-started/installation/#localstack-cli), and not for the binary CLI distribution.
-{{< /callout >}}
-
 ```bash
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
@@ -481,6 +477,46 @@ Likewise, you can execute the reverse operation to load a Cloud Pod from `oras-r
 {{< command >}}
 $ localstack pod load my-pod oras-remote
 {{< / command >}}
+
+### Auto Load with remotes
+
+LocalStack also supports the auto load of a Cloud Pod from registered remotes.
+The configuration is similar to what we just described.
+In particular you could simply add the remote name to the text files inside the `init-pods.d`, as follows:
+
+```text
+foo-pod,bar-remote
+```
+
+With such a configuration, the `foo-pod` Cloud Pod will be loaded from the `bar-remote` remote.
+To properly configure the remote, you need to provide the needed environment variables when starting the LocalStack container.
+For instance, a S3 remote needs a `AWS_ACCESS_KEY` and a `AWS_SECRET_ACCESS_KEY`, as follows:
+
+```yaml
+version: "3.8"
+
+services:
+  localstack:
+    container_name: "localstack-main"
+    image: localstack/localstack-pro
+    ports:
+      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4510-4559:4510-4559"
+    environment:
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}
+      - DEBUG=1
+      - AWS_ACCESS_KEY_ID:...
+      - AWS_SECRET_ACCESS_KEY:...
+    volumes:
+      - "./volume:/var/lib/localstack"
+      - "./init-pods.d:/etc/localstack/init-pods.d"
+```
+
+{{< callout >}}
+The Auto Load from remote feature does not automatically configure the remote.
+This needs to be done with the `localstack pod remote add ...` command.
+This commands creates a configuration file for the remote in the [LocalStack volume directory](https://docs.localstack.cloud/references/filesystem/#localstack-volume).
+{{< /callout >}}
 
 ## End-to-End Encryption (Enterprise)
 


### PR DESCRIPTION
We have been asked to work on pod auto-load for s3 remotes.
We implemented this feature in [#4041](https://github.com/localstack/localstack-ext/pull/4041).

Similar to the "normal" auto-load, the user needs to mount a `init-pods.d` folder into LS.

```bash
.
├── docker-compose.yml
└── init-pods.d
    └── pod-list.txt
```

The folder contains a txt file. Now you are able to specify a remote name by just adding it after the name of the pod.
For instance:
```text
foo-pod 
bar-pod,my-remote
```
`foo-pod` will be loaded from our platform, while `bar-pod` will be downloaded from `my-remote`.
The users need to provide to LS with all the necessary environment variables

**NB**: this approach assumes that the remotes has been already configured with the `localstack pod remote add ...` command. 