### PR TITLE
fix typo in chaos example

### DIFF
--- a/content/en/getting-started/quickstart/index.md
+++ b/content/en/getting-started/quickstart/index.md
@@ -95,7 +95,7 @@ pip install -r requirements-dev.txt
 {{< /tabpane >}}
 
 {{< callout "tip" >}}
-If you are encountering issues with the installation of the packages, such as Pillow, ensure you use the same version as the Python Lambdas (3.11.6) for Pillow to work. 
+If you are encountering issues with the installation of the packages, such as Pillow, ensure you use the same version as the Python Lambdas (3.11.6) for Pillow to work.
 If you're using <a href="https://github.com/pyenv/pyenv">pyenv</a>, install and activate Python 3.11 with the following commands:
 {{< command >}}
 $ pyenv install 3.11

--- a/content/en/user-guide/chaos-engineering/chaos-api/index.md
+++ b/content/en/user-guide/chaos-engineering/chaos-api/index.md
@@ -105,7 +105,7 @@ $ curl --location --request POST 'http://localhost.localstack.cloud:4566/_locals
         "region": "ap-south-1"
     },
     {
-        "service": "lambda",
+        "service": "lambda"
     }
 ]'
 {{< /command >}}


### PR DESCRIPTION
## Motivation
When playing with our cool Chaos API, me and @vittoriopolverino stumbled upon a small issue when copy-pasting one of the examples. The JSON was invalid because it contained a trailing `,` in the payload. This PR fixes that! 🚀 

## Changes
- Fix the invalid JSON in the Chaos API docs
- Fixes an unrelated linting error introduced with #1341 /cc @HarshCasper 