### PR TITLE
ServiceDiscovery: changed commands for ECS sample app

### DIFF
--- a/content/en/user-guide/aws/servicediscovery/index.md
+++ b/content/en/user-guide/aws/servicediscovery/index.md
@@ -103,7 +103,9 @@ Create a file named `fargate-task.json` and add the following content:
                     "-c"
                 ],
                 "command": [
-                    "/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground\""
+                    "/bin/sh",
+                    "-c",
+                    "echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground"
                 ]
             }
         ],


### PR DESCRIPTION
The Fargate task definition was incorrect, and this change is necessary to correct the task definition JSON.

https://localstack-docs-preview-pr-1673.surge.sh/user-guide/aws/servicediscovery/
