### PR TITLE
EXTENSION_AUTO_LOAD doesn't seem to work

### DIFF
--- a/content/en/references/init-hooks.md
+++ b/content/en/references/init-hooks.md
@@ -199,7 +199,7 @@ services:
     environment:
 # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}
-      - EXTENSION_AUTO_LOAD=localstack-extension-terraform-init
+      - EXTENSION_AUTO_INSTALL=localstack-extension-terraform-init
     volumes:
 # you could also place your main.tf in `./ready.d` and set "./ready.d:/etc/localstack/init/ready.d"
       - "./main.tf:/etc/localstack/init/ready.d/main.tf"


### PR DESCRIPTION
I was following the guide on [terraform files as init hooks](https://docs.localstack.cloud/references/init-hooks/#terraform-files-as-init-hooks) with the docker-compose.yaml: 

```yaml
version: "3.8"

services:
  localstack:
    container_name: "localstack-main"
    image: localstack/localstack-pro  # required for Pro
    ports:
      - "127.0.0.1:4566:4566"            # LocalStack Gateway
    environment:
# Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}
      - EXTENSION_AUTO_LOAD=localstack-extension-terraform-init
    volumes:
# you could also place your main.tf in `./ready.d` and set "./ready.d:/etc/localstack/init/ready.d"
      - "./main.tf:/etc/localstack/init/ready.d/main.tf"
      - "./volume:/var/lib/localstack"
      - "/var/run/docker.sock:/var/run/docker.sock"
```

But in the container logs I was seeing:

```
localstack-main  | 2025-03-05T15:55:22.366  INFO --- [  MainThread] l.p.c.extensions.platform  : loaded 0 extensions
```

Then I saw on [Automating extensions installation](https://docs.localstack.cloud/user-guide/extensions/managing-extensions/#environment-variable) 

That there was an env var `EXTENSION_AUTO_INSTALL` which then installed and applied my tf config. 

Should this be changed? 

I noticed that in the description above the config on [Terraform Files as Init Hooks](https://docs.localstack.cloud/references/init-hooks/#terraform-files-as-init-hooks) it mentions `EXTENSION_AUTO_INSTALL` but then in the example config it has `EXTENSION_AUTO_LOAD` which presumably will only work if the extension has been installed previously? 