### PR TITLE
Remove obsolete version top-level elements from compose examples

### DIFF
--- a/content/en/getting-started/installation.md
+++ b/content/en/getting-started/installation.md
@@ -295,38 +295,10 @@ Docker Compose v1.9.0 and above is supported.
 
 {{< tabpane lang="yml" >}}
 {{< tab header="Community" lang="yml" >}}
-services:
-  localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack
-    ports:
-      - "127.0.0.1:4566:4566"            # LocalStack Gateway
-      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
-    environment:
-      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
-      - DEBUG=${DEBUG:-0}
-    volumes:
-      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
+{{< github repo="localstack/localstack" file="docker-compose.yml" >}}
 {{< /tab >}}
 {{< tab header="Pro" lang="yml" >}}
-services:
-  localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack-pro  # required for Pro
-    ports:
-      - "127.0.0.1:4566:4566"            # LocalStack Gateway
-      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
-      - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (Pro)
-    environment:
-      # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro
-      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
-      - DEBUG=${DEBUG:-0}
-      - PERSISTENCE=${PERSISTENCE:-0}
-    volumes:
-      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
+{{< github repo="localstack/localstack" file="docker-compose-pro.yml" >}}
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/references/external-ports.md
+++ b/content/en/references/external-ports.md
@@ -47,8 +47,6 @@ $ GATEWAY_LISTEN=0.0.0.0:4666 EXTERNAL_SERVICE_PORTS_START=4610 EXTERNAL_SERVICE
 $ GATEWAY_LISTEN=0.0.0.0:4766 EXTERNAL_SERVICE_PORTS_START=4710 EXTERNAL_SERVICE_PORTS_END=4759 MAIN_CONTAINER_NAME=localstack-main-3 localstack start
 {{< /tab >}}
 {{< tab header="docker-compose" lang="yml" >}}
-version: "3.8"
-
 services:
   localstack-main-1:
     container_name: localstack-main-1

--- a/content/en/references/init-hooks.md
+++ b/content/en/references/init-hooks.md
@@ -136,8 +136,6 @@ Start Localstack:
 
 {{< tabpane >}}
 {{< tab header="docker-compose.yml" lang="yml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
@@ -188,8 +186,6 @@ Start LocalStack Pro with mounted `main.tf`:
 
 {{< tabpane >}}
 {{< tab header="docker-compose.yml" lang="yml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "localstack-main"

--- a/content/en/references/network-troubleshooting/endpoint-url/_index.md
+++ b/content/en/references/network-troubleshooting/endpoint-url/_index.md
@@ -117,8 +117,6 @@ docker inspect localstack-main | \
 docker run --rm -it --dns 172.27.0.2 --network ls <arguments> <image name>
 {{< / tab >}}
 {{< tab header="docker-compose.yml" lang="yaml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/references/podman.md
+++ b/content/en/references/podman.md
@@ -103,7 +103,6 @@ For the Docker Compose setup, use the following configuration.
 When running in rootless mode, ensure to comment out the HTTPS gateway port, as it is unable to bind to privileged ports below 1024.
 
 ```yaml
-version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/tutorials/java-notification-app/index.md
+++ b/content/en/tutorials/java-notification-app/index.md
@@ -531,8 +531,6 @@ Now that the initial coding is done, we can give it a try.
 Let's start LocalStack using a custom `docker-compose` setup, which includes MailHog to capture the emails sent by SES:
 
 ```yaml
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/tutorials/using-terraform-with-testcontainers-and-localstack/index.md
+++ b/content/en/tutorials/using-terraform-with-testcontainers-and-localstack/index.md
@@ -109,8 +109,6 @@ In the root folder, you'll find the essential configs in the `docker-compose.yml
 <summary><b>Expand file</b></summary>
 {{< highlight yaml >}}
 
-version: "3.8"
-
 services:
     localstack:
         container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/user-guide/aws/ecs/index.md
+++ b/content/en/user-guide/aws/ecs/index.md
@@ -322,7 +322,6 @@ Your file paths might differ, so check Docker's documentation on [Environment Va
 Here is a Docker Compose example:
 
 ```yaml
-version: '3.8'
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/user-guide/aws/es/index.md
+++ b/content/en/user-guide/aws/es/index.md
@@ -207,8 +207,6 @@ Note that only a single backend can be configured, meaning that you will get a s
 The following shows a sample docker-compose file that contains a single-noded elasticsearch cluster and a basic localstack setp.
 
 ```yaml
-version: "3.9"
-
 services:
   elasticsearch:
     container_name: elasticsearch

--- a/content/en/user-guide/aws/opensearch/index.md
+++ b/content/en/user-guide/aws/opensearch/index.md
@@ -286,8 +286,6 @@ It's important to bear in mind that only a single backend configuration is possi
 Here is a sample `docker-compose.yaml` file that contains a single-node OpenSearch cluster and a basic LocalStack setup.
 
 ```yaml
-version: "3.9"
-
 services:
   opensearch:
     container_name: opensearch

--- a/content/en/user-guide/aws/s3/index.md
+++ b/content/en/user-guide/aws/s3/index.md
@@ -256,8 +256,6 @@ The S3 Docker image only supports the S3 APIs and does not include other service
 IMAGE_NAME=localstack/localstack:s3-latest localstack start
 {{< /tab >}}
 {{< tab header="Docker Compose" lang="yml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/user-guide/extensions/managing-extensions/index.md
+++ b/content/en/user-guide/extensions/managing-extensions/index.md
@@ -108,8 +108,6 @@ If you want to use the `file://` directive, the distribution file needs to be mo
 In a docker-compose file, this would look something like:
 
 ```yaml
-version: "3.8"
-
 services:
   localstack:
     container_name: "localstack-main"
@@ -154,8 +152,6 @@ An example project could look something like this:
 * `docker-compose.yaml`
 
     ```yaml
-    version: "3.8"
-
     services:
       localstack:
         ...

--- a/content/en/user-guide/integrations/devcontainers/index.md
+++ b/content/en/user-guide/integrations/devcontainers/index.md
@@ -384,8 +384,6 @@ To get started with LocalStack and DevContainers in VS Code, follow these steps:
 {{< /tab >}}
 
 {{< tab header="docker-compose.yml" lang="yaml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "localstack-main"

--- a/content/en/user-guide/integrations/kafka/docker-compose.yml
+++ b/content/en/user-guide/integrations/kafka/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:6.0.2

--- a/content/en/user-guide/integrations/rancher-desktop/index.md
+++ b/content/en/user-guide/integrations/rancher-desktop/index.md
@@ -121,7 +121,6 @@ Modify your Docker Compose configuration to work with Rancher Desktop:
 
 {{< tabpane lang="yml" >}}
 {{< tab header="Community" lang="yml" >}}
-version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
@@ -138,7 +137,6 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 {{< /tab >}}
 {{< tab header="Pro" lang="yml" >}}
-version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/user-guide/lambda-tools/debugging/index.md
+++ b/content/en/user-guide/lambda-tools/debugging/index.md
@@ -466,8 +466,6 @@ LOCALSTACK_LAMBDA_DEBUG_MODE_CONFIG_PATH=/tmp/debug_config.yaml \
 localstack start --volume /path/to/debug-config.yaml:/tmp/lambda_debug_mode_config.yaml
 {{< /tab >}}
 {{< tab header="Docker Compose" lang="yaml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -639,8 +639,6 @@ For bash, please use single quotes `'` instead of double quotes `"` to make sure
 In order to make use of the environment variable placeholders, you can inject them into the LocalStack container, for example using the following `docker-compose.yml` file.
 
 ```yaml
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/content/en/user-guide/state-management/cloud-pods/index.md
+++ b/content/en/user-guide/state-management/cloud-pods/index.md
@@ -291,8 +291,6 @@ When autoloading multiple Cloud Pods, later pods might overwrite the state of ea
 AUTO_LOAD_POD=foo-pod localstack start
 {{< /tab >}}
 {{< tab header="Docker Compose" lang="yaml" >}}
-version: "3.8"
-
 services:
   localstack:
     container_name: "localstack-main"
@@ -346,8 +344,6 @@ LocalStack, upon mounting `init-pods.d` to the appropriate location, will sequen
 The docker compose file for correctly mounting `init-pods.d` will look like:
 
 ```yaml
-version: "3.8"
-
 services:
   localstack:
     container_name: "localstack-main"
@@ -493,8 +489,6 @@ To properly configure the remote, you need to provide the needed environment var
 For instance, a S3 remote needs a `AWS_ACCESS_KEY` and a `AWS_SECRET_ACCESS_KEY`, as follows:
 
 ```yaml
-version: "3.8"
-
 services:
   localstack:
     container_name: "localstack-main"

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -23,4 +23,8 @@
 {{ $linesToShow := last (sub $end $startIndex) (first $end $lines) }}
 
 {{ $content := delimit $linesToShow "\n" }}
+{{ if $lang }}
 {{ highlight $content $lang $options }}
+{{ else }}
+{{ $content | safeHTML }}
+{{ end }}


### PR DESCRIPTION
## Motivation
Reason for removing the version attributes see localstack/localstack#12354.

Also, hugo now takes the default docker compose files directly from the localstack/localstack repository using the github shortcode.

For this to work, I needed to enable the github shortcode to include the file as-is, without any highlighting, as the highlights are already done in the tab.
Happy to discuss this, if there is a better solution.

## Changes
* Remove `version` top level attributes from all docker compose examples.
* Get fresh versions of the docker compose examples directly from the LS repository.
