### PR TITLE
docs: added docs changes and docs bug issue templates

### DIFF
--- a/.github/issue_templates/docs-bug.yaml
+++ b/.github/issue_templates/docs-bug.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Describe the bug you found in LocalStack Docs.
       description: Is there a bug in one of our code snippets? Did we explain a concept incorrectly? Please share a clear and concise description of what the bug or mistake is.
-      placeholder: "I would like to file an LocalStack Docs Bug 🐞 report about..."
+      placeholder: "I would like to file a LocalStack Docs Bug 🐞 report about..."
     validations:
       required: true
   - type: textarea

--- a/.github/issue_templates/docs-bug.yaml
+++ b/.github/issue_templates/docs-bug.yaml
@@ -1,0 +1,35 @@
+name: Docs Bug 🐞 report
+description: Report mistakes and/or bugs in LocalStack Docs.
+title: "[Docs Bug 🐞 report]: "
+labels: "🐞 docs bug"
+assignees: quetzalliwrites, HarshCasper
+  - 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting mistakes and/or bugs in LocalStack Docs. We appreciate your contribution! 🙂
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug you found in LocalStack Docs.
+      description: Is there a bug in one of our code snippets? Did we explain a concept incorrectly? Please share a clear and concise description of what the bug or mistake is.
+      placeholder: "I would like to file an LocalStack Docs Bug 🐞 report about..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce-bug
+    attributes:
+      label: Attach any resources that can help us understand the issue.
+      description: Send us screenshots, direct quotes of the text that has issues, a link to the GitHub repository with project that has issues, etc. Help us reproduce this Docs issue.
+      placeholder: "Please find attached a screenshot of the text with issues..."
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/localstack/docs?tab=coc-ov-file#readme)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/issue_templates/docs.yaml
+++ b/.github/issue_templates/docs.yaml
@@ -1,0 +1,28 @@
+name: 📑 Docs
+description: Propose changes and improvements to LocalStack Docs.
+labels: "📑 docs"
+title: "[📑 Docs]: "
+assignees: quetzalliwrites, HarshCasper
+  - 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing to LocalStack Docs! We appreciate your feedback, ideas, and contributions. 
+  
+  - type: textarea
+    id: reason-context
+    attributes:
+      label: What docs changes are you proposing?
+      description: Why do the docs need this improvement? What is the motivation for this change?
+      placeholder: "I would like to contribute to LocalStack Docs 📑 by..."
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/localstack/docs?tab=coc-ov-file#readme)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
Docs-specific YAML issue templates capture more detailed and actionable feedback when users report issues in our documentation:

- Clear problem descriptions
- Screenshots & reproduction steps
- Consistency in reporting