### PR TITLE
Hide CodeBuild, CodeDeploy, CodePipeline & CodeConnections coverage pages

### DIFF
--- a/content/en/references/coverage/coverage_codebuild/index.md
+++ b/content/en/references/coverage/coverage_codebuild/index.md
@@ -4,6 +4,7 @@ linkTitle: "codebuild"
 description: >
   Implementation details for API codebuild
 hide_readingtime: true
+draft: true
 ---
 
 ## Coverage Overview

--- a/content/en/references/coverage/coverage_codedeploy/index.md
+++ b/content/en/references/coverage/coverage_codedeploy/index.md
@@ -4,6 +4,7 @@ linkTitle: "codedeploy"
 description: >
   Implementation details for API codedeploy
 hide_readingtime: true
+draft: true
 ---
 
 ## Coverage Overview

--- a/content/en/references/coverage/coverage_codepipeline/index.md
+++ b/content/en/references/coverage/coverage_codepipeline/index.md
@@ -4,6 +4,7 @@ linkTitle: "codepipeline"
 description: >
   Implementation details for API codepipeline
 hide_readingtime: true
+draft: true
 ---
 
 ## Coverage Overview

--- a/content/en/references/coverage/coverage_codestar-connections/index.md
+++ b/content/en/references/coverage/coverage_codestar-connections/index.md
@@ -4,6 +4,7 @@ linkTitle: "codestar-connections"
 description: >
   Implementation details for API codestar-connections
 hide_readingtime: true
+draft: true
 ---
 
 ## Coverage Overview


### PR DESCRIPTION
This PR hides CodeX services because are not available at this time.

They were initially hidden in #1683 but restored in #1695.

cc: @HarshCasper please be mindful with future automated PRs.