### PR TITLE
docs: update Troubleshooting Guidelines section

### DIFF
--- a/content/en/getting-started/help-and-support/index.md
+++ b/content/en/getting-started/help-and-support/index.md
@@ -218,7 +218,7 @@ To use LocalStack's diagnostics endpoint:
 - Start LocalStack
 - Run the affected task(s)
 - Call the diagnostic endpoint `curl -s localhost:4566/_localstack/diagnose > diagnose.json && zip diagnose.zip diagnose.json && rm diagnose.json` (Endpoint URL depends on your configuration)
-- Send the output file to us
+- Once you have the `diagnose.zip` file, please send it to our support team via our email support@localstack.cloud, or via your existing support ticket.
 
 <span style="color: darkred;">**Ensure that you avoid sending the diagnostic output to public channels or forums, as it may contain sensitive information.**</span>
 {{< /callout >}}


### PR DESCRIPTION
Our support team decided to change the command so that it outputs a ZIP file, which is better than a .gz file because it can be sent both on HubSpot and on Slack. 