### PR TITLE
Update CODEOWNERS and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "alexrashed"
+      - "HarshCasper"
+      - "quetzalliwrites"
     labels:
       - "dependencies"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,16 +3,7 @@
 ######################
 
 # CODEOWNERS
-/CODEOWNERS @HarshCasper @alexrashed
-
-# CI
-/content/en/user-guide/ci/ @lakkeger
-
-# pulumi
-/content/en/user-guide/integrations/pulumi/ @lakkeger
-
-# terraform
-/content/en/user-guide/integrations/terraform/ @lakkeger
+/CODEOWNERS @HarshCasper @quetzalliwrites
 
 # network troubleshooting guide
 /content/en/references/network-troubleshooting @simonrw @joe4dev @dfangl


### PR DESCRIPTION
This PR removes myself from the CODEOWNERS file of this repo (not on services though), and removes some old outdated entries. It also updates the dependabot config to add @HarshCasper and @quetzalliwrites as reviewers instead.