### PR TITLE
Fix typo on activation issue

### DIFF
--- a/content/en/references/api-key.md
+++ b/content/en/references/api-key.md
@@ -111,7 +111,7 @@ If the key activation fails, LocalStack will quit with an error messages that ma
 ===============================================
 API key activation failed! 🔑❌
 
-The API key you provided in the `LOCALSTACK_API_KEY` environment variable '"foo..."(6)' could not beactivated against our licensing server. Server message: Unable to verify API key.
+The API key you provided in the `LOCALSTACK_API_KEY` environment variable '"foo..."(6)' could not be activated against our licensing server. Server message: Unable to verify API key.
 
 Due to this error, Localstack has quit. LocalStack pro features can only be used with a valid license.
 


### PR DESCRIPTION
Fix grammar typo in _Common activation issues_. Ticket [here](https://www.notion.so/localstack/docs-bug-typo-on-activation-issue-1edfc2a2343180108bc2f27edcd98bc5).
![image](https://github.com/user-attachments/assets/4b926d55-844e-4bc5-8c30-86e8445eebed)

