### PR TITLE
exclude MD059 from markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -27,3 +27,4 @@ config:
   MD018: false # No space after hash on atx style header
   MD022: false # Headers should be surrounded by blank lines
   MD037: false # Spaces inside emphasis markers
+  MD059: false # Link text should be descriptive


### PR DESCRIPTION
## Motivation
[Markdownlint version 0.38](https://github.com/DavidAnson/markdownlint/blob/224987d727ebada36752074d2466a061c9e03ff0/CHANGELOG.md#0380) introduced a new rule `MD059`.
This rule fails on several lines on the current `main`:
```
$ make lint
markdownlint-cli2 --fix
markdownlint-cli2 v0.18.0 (markdownlint v0.38.0)
Finding: content/**/*.md !node_modules !content/en/tutorials/cloud-pods-collaborative-debugging/* !content/en/user-guide/integrations/terraform/* !content/en/user-guide/aws/events/* !content/en/references/coverage/_index.md !content/en/getting-started/installation.md
Linting: 393 file(s)
Summary: 14 error(s)
content/en/references/configuration.md:174:107 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/aws/athena/index.md:117:83 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/aws/emr/index.md:27:164 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/codebuild/index.md:173:41 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/github-actions/index.md:101:41 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/github-actions/index.md:140:42 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/github-actions/index.md:171:49 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/gitlab-ci/index.md:137:55 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/gitlab-ci/index.md:160:55 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/gitlab-ci/index.md:175:41 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/ci/gitlab-ci/index.md:214:42 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/integrations/architect/index.md:20:111 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/integrations/sdks/dotnet/index.md:77:69 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
content/en/user-guide/integrations/sdks/java/index.md:158:2 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
```

This also causes the [Docs Parity Action](https://github.com/localstack/docs/blob/81e1842301f5947110319ac112ab3af6a03d5699/.github/workflows/docs-parity-updates.yml) to fail, f.e. [in this run](https://github.com/localstack/docs/actions/runs/14964246643/job/42031289934).

 This PR simply disables this action for now.

## Changes
- Disable markdownlint's MD058 ("Link text should be descriptive")