### PR TITLE
Add note on WSL2 path formatting for hot reloading in Rancher Desktop on Windows

### DIFF
--- a/content/en/user-guide/integrations/rancher-desktop/index.md
+++ b/content/en/user-guide/integrations/rancher-desktop/index.md
@@ -159,3 +159,20 @@ services:
 
 Finally, start the services using `docker compose up` or `nerdctl compose up`, depending on your configuration.
 This will launch your LocalStack instance configured to interact with Rancher Desktop.
+
+### 📝 Note on Hot Reloading Lambdas in Windows (WSL2)
+
+If you're using hot reloading for Lambda functions, make sure your Lambda handler paths are specified using **WSL2-compatible paths**.
+
+For example, instead of using a Windows-style path like:
+
+```bash
+C:\Users\myuser\projects\lambda\handler.py
+```
+
+Use the corresponding WSL-style path:
+```
+/mnt/c/Users/myuser/projects/lambda/handler.py
+```
+
+This ensures that LocalStack can properly mount and watch your Lambda code inside the container when running under WSL2.

--- a/content/en/user-guide/integrations/rancher-desktop/index.md
+++ b/content/en/user-guide/integrations/rancher-desktop/index.md
@@ -171,7 +171,7 @@ C:\Users\myuser\projects\lambda\handler.py
 ```
 
 Use the corresponding WSL-style path:
-```
+```bash
 /mnt/c/Users/myuser/projects/lambda/handler.py
 ```
 

--- a/content/en/user-guide/integrations/rancher-desktop/index.md
+++ b/content/en/user-guide/integrations/rancher-desktop/index.md
@@ -160,7 +160,7 @@ services:
 Finally, start the services using `docker compose up` or `nerdctl compose up`, depending on your configuration.
 This will launch your LocalStack instance configured to interact with Rancher Desktop.
 
-### 📝 Note on Hot Reloading Lambdas in Windows (WSL2)
+### Hot Reloading Lambdas in Windows (WSL2)
 
 If you're using hot reloading for Lambda functions, make sure your Lambda handler paths are specified using **WSL2-compatible paths**.
 

--- a/content/en/user-guide/integrations/rancher-desktop/index.md
+++ b/content/en/user-guide/integrations/rancher-desktop/index.md
@@ -171,6 +171,7 @@ C:\Users\myuser\projects\lambda\handler.py
 ```
 
 Use the corresponding WSL-style path:
+
 ```bash
 /mnt/c/Users/myuser/projects/lambda/handler.py
 ```

--- a/content/en/user-guide/integrations/rancher-desktop/index.md
+++ b/content/en/user-guide/integrations/rancher-desktop/index.md
@@ -159,21 +159,3 @@ services:
 
 Finally, start the services using `docker compose up` or `nerdctl compose up`, depending on your configuration.
 This will launch your LocalStack instance configured to interact with Rancher Desktop.
-
-### Hot Reloading Lambdas in Windows (WSL2)
-
-If you're using hot reloading for Lambda functions, make sure your Lambda handler paths are specified using **WSL2-compatible paths**.
-
-For example, instead of using a Windows-style path like:
-
-```bash
-C:\Users\myuser\projects\lambda\handler.py
-```
-
-Use the corresponding WSL-style path:
-
-```bash
-/mnt/c/Users/myuser/projects/lambda/handler.py
-```
-
-This ensures that LocalStack can properly mount and watch your Lambda code inside the container when running under WSL2.

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -41,7 +41,7 @@ If using Docker Desktop on macOS, you might need to allow [file sharing](https:/
 MacOS may prompt you to grant Docker access to your target folders.
 
 **WSL2-compatible paths required with Rancher Desktop on Windows:**
-Make sure your Lambda handler paths are specified using **WSL2-compatible paths**. For example, instead of using a Windows-style path like:
+Make sure your Lambda handler paths are specified using WSL2-compatible paths. For example, instead of using a Windows-style path like:
 ```bash
 C:\Users\myuser\projects\lambda\handler.py
 ```

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -42,13 +42,17 @@ MacOS may prompt you to grant Docker access to your target folders.
 
 **WSL2-compatible paths required with Rancher Desktop on Windows:**
 Make sure your Lambda handler paths are specified using WSL2-compatible paths. For example, instead of using a Windows-style path such as:
+
 ```bash
 C:\Users\myuser\projects\lambda\handler.py
 ```
+
 Use the corresponding WSL-style path:
+
 ```bash
 /mnt/c/Users/myuser/projects/lambda/handler.py
 ```
+
 This ensures that LocalStack can properly mount and watch your Lambda code inside the container when running under WSL2.
 
 **Layer limit with hot reloading for layers:**

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -40,6 +40,17 @@ Therefore, filesystem changes persist between code changes for invocations dispa
 If using Docker Desktop on macOS, you might need to allow [file sharing](https://docs.docker.com/desktop/settings/mac/#file-sharing) for your target folders.
 MacOS may prompt you to grant Docker access to your target folders.
 
+**WSL2-compatible paths required with Rancher Desktop on Windows:**
+Make sure your Lambda handler paths are specified using **WSL2-compatible paths**. For example, instead of using a Windows-style path like:
+```bash
+C:\Users\myuser\projects\lambda\handler.py
+```
+Use the corresponding WSL-style path:
+```bash
+/mnt/c/Users/myuser/projects/lambda/handler.py
+```
+This ensures that LocalStack can properly mount and watch your Lambda code inside the container when running under WSL2.
+
 **Layer limit with hot reloading for layers:**
 When hot reloading is active for a Lambda layer (Pro), the function can use at most one layer.
 

--- a/content/en/user-guide/lambda-tools/hot-reloading/index.md
+++ b/content/en/user-guide/lambda-tools/hot-reloading/index.md
@@ -41,7 +41,7 @@ If using Docker Desktop on macOS, you might need to allow [file sharing](https:/
 MacOS may prompt you to grant Docker access to your target folders.
 
 **WSL2-compatible paths required with Rancher Desktop on Windows:**
-Make sure your Lambda handler paths are specified using WSL2-compatible paths. For example, instead of using a Windows-style path like:
+Make sure your Lambda handler paths are specified using WSL2-compatible paths. For example, instead of using a Windows-style path such as:
 ```bash
 C:\Users\myuser\projects\lambda\handler.py
 ```


### PR DESCRIPTION
This PR adds a clarification to the Rancher Desktop documentation for Windows users running LocalStack via WSL2.

Specifically, it documents that when using hot reloading for Lambda functions, paths to Lambda handlers must be specified using WSL2-compatible paths `/mnt/c/` rather than Windows-style paths `C:\`

Without this, volume mounting of the lambda code into the lambda container would fail with a unintelligible error.

Changes:

Added a note under the Windows section of the Rancher Desktop guide.

Included a code snippet showing the correct WSL2 path format.

Motivation:

Hot reloading is a key developer feature in LocalStack, and ensuring it works reliably in WSL2-based workflows improves developer experience and reduces setup friction.