### PR TITLE
Clarify RDS postgres database name restriction

### DIFF
--- a/content/en/user-guide/aws/rds/index.md
+++ b/content/en/user-guide/aws/rds/index.md
@@ -232,7 +232,7 @@ The following details concern default usernames, passwords, and database names f
 - When setting up a new RDS instance, you have the flexibility to utilize any `master-username`, with the exception of **postgres**.
   The system will automatically generate the user.
 - It's important to remember that the username **postgres** has special significance, preventing the creation of a new RDS instance under this particular name.
-- For clarity, please avoid using the `db-name` **postgres**, as it is already allocated for use by LocalStack.
+- Using the `db-name` **postgres** might lead to issues for older versions of LocalStack, please try to avoid using it.
 
 ## IAM Authentication Support
 


### PR DESCRIPTION
## Motivation
Before recent changes, using `postgres` as database name for an RDS postgres database lead to unexpected errors.

Now, it should work, but we would still like to encourage users to use a different database name.

## Changes
* Clarify comment about `postgres` database name
