### PR TITLE
CI: fix docs parity updates

### DIFF
--- a/.github/bot_templates/PARITY_COVERAGE_DOCS_PR.md
+++ b/.github/bot_templates/PARITY_COVERAGE_DOCS_PR.md
@@ -1,6 +1,6 @@
 # 📖 Parity Metrics Docs Update Report 📖
 This PR has been automatically generated to update the AWS parity coverage docs.
-It aggregates the latest parity coverage test results from our [test pipeline on CircleCI](https://app.circleci.com/pipelines/github/localstack/localstack/) as well as from our Pro integration tests.
+It aggregates the latest parity coverage test results from our [test pipeline on GitHub](https://github.com/localstack/localstack/actions/workflows/aws-main.yml?query=branch%3Amaster) as well as from our Pro integration tests.
 
 ## 👷🏽 Handle this PR
 The following options describe how to interact with this PR / the auto-update:

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -87,8 +87,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack
-          ARTIFACT_ID: test-results-integration-*
+          ARTIFACT_ID: parity-metric-raw-amd*
           WORKFLOW: "AWS / Build, Test, Push"
+          PREFIX_ARTIFACT: community-integration-test
 
       - name: Download coverage (capture-notimplemented) data from Community pipeline (GitHub)
         working-directory: docs

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -84,10 +84,13 @@ jobs:
 
       - name: Download metrics data from latest Community test run (CircleCI)
         working-directory: docs
+        run: /tmp/get_latest_github_metrics.sh ./target master
         env:
-          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
-        run: /tmp/get_latest_circleci_metrics.sh ./target
-
+          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
+          REPOSITORY_NAME: localstack
+          ARTIFACT_ID: capture-notimplemented
+          WORKFLOW: "AWS / Build, Test, Push"
+          RESOURCE_FOLDER: "metrics-implementation-details/community"
 
       - name: Create Parity Coverage Docs
         working-directory: docs

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Download scripts from meta repository
         run: |
           curl -o /tmp/get_latest_github_metrics.sh -L https://raw.githubusercontent.com/localstack/meta/main/scripts/get_latest_github_metrics.sh -H 'Accept: application/vnd.github.v3.raw'
-          curl -o /tmp/get_latest_circleci_metrics.sh -L https://raw.githubusercontent.com/localstack/meta/main/scripts/get_latest_circleci_metrics.sh -H 'Accept: application/vnd.github.v3.raw'
-          chmod +x /tmp/get_latest_github_metrics.sh /tmp/get_latest_circleci_metrics.sh 
+          chmod +x /tmp/get_latest_github_metrics.sh
 
       - name: Download metrics data from Moto Integration test pipeline (GitHub)
         working-directory: docs
@@ -82,7 +81,7 @@ jobs:
           WORKFLOW: "AWS / Build, Test, Push" 
           RESOURCE_FOLDER: "metrics-implementation-details"
 
-      - name: Download metrics data from latest Community test run (CircleCI)
+      - name: Download metrics data from latest Community test run (GitHub)
         working-directory: docs
         run: /tmp/get_latest_github_metrics.sh ./target master
         env:

--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -81,7 +81,16 @@ jobs:
           WORKFLOW: "AWS / Build, Test, Push" 
           RESOURCE_FOLDER: "metrics-implementation-details"
 
-      - name: Download metrics data from latest Community test run (GitHub)
+      - name: Download metrics data from Community pipeline (GitHub)
+        working-directory: docs
+        run: /tmp/get_latest_github_metrics.sh ./target master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
+          REPOSITORY_NAME: localstack
+          ARTIFACT_ID: test-results-integration-*
+          WORKFLOW: "AWS / Build, Test, Push"
+
+      - name: Download coverage (capture-notimplemented) data from Community pipeline (GitHub)
         working-directory: docs
         run: /tmp/get_latest_github_metrics.sh ./target master
         env:


### PR DESCRIPTION
This PR updates the parity docs generation workflow to consume artifacts from GitHub following the migration from CircleCI to GitHub Actions.

**Testing**

Tested in a forked repository and locally yesterday morning; will run tests in this PR as well